### PR TITLE
Fix Python 3.7 CI pipelines

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -40,4 +40,4 @@ python -c "import functorch"
 pip3 install torchsnapshot-nightly
 
 printf "* Installing tensordict\n"
-python setup.py develop
+pip3 install -e .

--- a/.circleci/unittest/linux_stable/scripts/install.sh
+++ b/.circleci/unittest/linux_stable/scripts/install.sh
@@ -43,4 +43,4 @@ printf "* Installing tensordict\n"
 printf "g++ version: "
 gcc --version
 
-python setup.py develop
+pip3 install -e .


### PR DESCRIPTION
Previously these were failing due to an incompatible version of NumPy being requested for installation.

It was a little unclear at first why this should be the case here when essentially the same pipelines work just fine in TorchRL repo. It turns out that in TorchRL we install [SciPy](https://github.com/pytorch/rl/blob/main/.circleci/unittest/linux/scripts/environment.yml) and other dependencies which themselves have NumPy as a dependency. By contrast, in TensorDict there are far fewer dependencies in the environment and surprisingly none of them have NumPy as a dependency (including Torch!?). So NumPy installation was deferred until reaching `python setup.py develop` for TensorDict.

It seems that running `python setup.py develop` rather than `pip install xxx` has different dependency resolution behaviour and doesn't resolve a valid version of Python.

I have fixed this by installing TensorDict in CI with `pip install -e .` rather than `python setup.py develop`. Note that the `-e` flag is to mimic the behaviour of `develop`. 

An alternative fix might be to simply add NumPy to the dependencies? I think since they are installed via pip the dependency resolver should take care of things in that case also?