### PR TITLE
[Benchmarks] Perform multiple rounds in benchmarks

### DIFF
--- a/benchmarks/common/common_ops_test.py
+++ b/benchmarks/common/common_ops_test.py
@@ -25,31 +25,33 @@ def td(a, b):
 
 
 def test_common_ops(benchmark):
-    benchmark.pedantic(main, iterations=10000)
+    benchmark.pedantic(main, iterations=100, rounds=100)
 
 
 def test_creation(benchmark):
-    benchmark.pedantic(TensorDict, args=({}, [3, 4]), iterations=10000)
+    benchmark.pedantic(TensorDict, args=({}, [3, 4]), iterations=100, rounds=100)
 
 
 def test_creation_empty(benchmark, a, b):
-    benchmark.pedantic(TensorDict, args=({"a": a, "b": b}, [3, 4]), iterations=10000)
+    benchmark.pedantic(
+        TensorDict, args=({"a": a, "b": b}, [3, 4]), iterations=100, rounds=100
+    )
 
 
 def test_creation_nested_1(benchmark, a, b):
     benchmark.pedantic(
-        TensorDict, args=({"a": a, ("b", "b1"): b}, [3, 4]), iterations=10000
+        TensorDict, args=({"a": a, ("b", "b1"): b}, [3, 4]), iterations=100, rounds=100
     )
 
 
 def test_creation_nested_2(benchmark, a, b):
     benchmark.pedantic(
-        TensorDict, args=({"a": a, "b": {"b1": b}}, [3, 4]), iterations=10000
+        TensorDict, args=({"a": a, "b": {"b1": b}}, [3, 4]), iterations=100, rounds=100
     )
 
 
 def test_clone(benchmark, td):
-    benchmark.pedantic(td.clone, iterations=10000)
+    benchmark.pedantic(td.clone, iterations=100, rounds=100)
 
 
 def test_setitem(benchmark, td, c):
@@ -57,7 +59,7 @@ def test_setitem(benchmark, td, c):
         tdc = td.clone()
         tdc["c"] = c
 
-    benchmark.pedantic(exec_setitem, iterations=10000)
+    benchmark.pedantic(exec_setitem, iterations=100, rounds=100)
 
 
 def test_set(benchmark, td, c):
@@ -65,7 +67,7 @@ def test_set(benchmark, td, c):
         tdc = td.clone()
         tdc.set("c", c)
 
-    benchmark.pedantic(exec_set, iterations=10000)
+    benchmark.pedantic(exec_set, iterations=100, rounds=100)
 
 
 def test_set_shared(benchmark, td):
@@ -73,7 +75,7 @@ def test_set_shared(benchmark, td):
         tdc = td.clone()
         tdc.share_memory_()
 
-    benchmark.pedantic(exec_set_shared, iterations=10000)
+    benchmark.pedantic(exec_set_shared, iterations=100, rounds=100)
 
 
 def test_update(benchmark, a, b):
@@ -84,7 +86,7 @@ def test_update(benchmark, a, b):
         tdc = td.clone()
         tdc.update(td2)
 
-    benchmark.pedantic(exec_update, iterations=10000)
+    benchmark.pedantic(exec_update, iterations=100, rounds=100)
 
 
 def test_update_nested(benchmark, td):
@@ -94,7 +96,7 @@ def test_update_nested(benchmark, td):
         tdc = td.clone()
         tdc.update(td2)
 
-    benchmark.pedantic(exec_update_nested, iterations=10000)
+    benchmark.pedantic(exec_update_nested, iterations=100, rounds=100)
 
 
 def test_set_nested(benchmark, td, b):
@@ -102,7 +104,7 @@ def test_set_nested(benchmark, td, b):
         tdc = td.clone()
         tdc["b", "b1"] = b
 
-    benchmark.pedantic(exec_set_nested, iterations=10000)
+    benchmark.pedantic(exec_set_nested, iterations=100, rounds=100)
 
 
 def test_set_nested_new(benchmark, td, c):
@@ -110,7 +112,7 @@ def test_set_nested_new(benchmark, td, c):
         tdc = td.clone()
         tdc["c", "c", "c"] = c
 
-    benchmark.pedantic(exec_set_nested_new, iterations=10000)
+    benchmark.pedantic(exec_set_nested_new, iterations=100, rounds=100)
 
 
 def test_select(benchmark, td, c):
@@ -119,7 +121,7 @@ def test_select(benchmark, td, c):
         tdc["c", "c", "c"] = c
         tdc.select("a", "z", ("c", "c", "c"), strict=False)
 
-    benchmark.pedantic(exec_select, iterations=10000)
+    benchmark.pedantic(exec_select, iterations=100, rounds=100)
 
 
 def main():

--- a/benchmarks/common/memmap_benchmarks_test.py
+++ b/benchmarks/common/memmap_benchmarks_test.py
@@ -26,21 +26,25 @@ def memmap_tensor(request):
 @pytest.mark.parametrize("device", get_available_devices())
 def test_creation(benchmark, device):
     benchmark.pedantic(
-        MemmapTensor, args=(3, 4, 5), kwargs={"device": device}, iterations=10
+        MemmapTensor, args=(3, 4, 5), kwargs={"device": device}, rounds=10, iterations=1
     )
 
 
 def test_creation_from_tensor(benchmark, tensor):
-    benchmark.pedantic(MemmapTensor.from_tensor, args=(tensor,), iterations=10)
+    benchmark.pedantic(
+        MemmapTensor.from_tensor, args=(tensor,), rounds=10, iterations=1
+    )
 
 
 def test_add_one(benchmark, memmap_tensor):
-    benchmark.pedantic(lambda: memmap_tensor + 1, iterations=10_000)
+    benchmark.pedantic(lambda: memmap_tensor + 1, rounds=100, iterations=100)
 
 
 def test_contiguous(benchmark, memmap_tensor):
-    benchmark.pedantic(lambda: memmap_tensor.contiguous(), iterations=10_000)
+    benchmark.pedantic(lambda: memmap_tensor.contiguous(), rounds=100, iterations=100)
 
 
 def test_stack(benchmark, memmap_tensor):
-    benchmark.pedantic(torch.stack, args=([memmap_tensor] * 2, 0), iterations=10)
+    benchmark.pedantic(
+        torch.stack, args=([memmap_tensor] * 2, 0), rounds=10, iterations=1
+    )

--- a/benchmarks/common/pytree_benchmarks_test.py
+++ b/benchmarks/common/pytree_benchmarks_test.py
@@ -23,12 +23,13 @@ def test_reshape_pytree(benchmark, nested_dict):
     benchmark.pedantic(
         tree_map,
         args=(lambda x: x.reshape(12, *x.shape[2:]), nested_dict),
-        iterations=10000,
+        iterations=100,
+        rounds=100,
     )
 
 
 def test_reshape_td(benchmark, nested_td):
-    benchmark.pedantic(nested_td.reshape, args=(12,), iterations=10000)
+    benchmark.pedantic(nested_td.reshape, args=(12,), iterations=100, rounds=100)
 
 
 # view
@@ -36,40 +37,48 @@ def test_view_pytree(benchmark, nested_dict):
     benchmark.pedantic(
         tree_map,
         args=(lambda x: x.view(12, *x.shape[2:]), nested_dict),
-        iterations=10000,
+        iterations=100,
+        rounds=100,
     )
 
 
 def test_view_td(benchmark, nested_td):
-    benchmark.pedantic(nested_td.view, args=(12,), iterations=10000)
+    benchmark.pedantic(nested_td.view, args=(12,), iterations=100, rounds=100)
 
 
 # unbind
 def test_unbind_pytree(benchmark, nested_dict):
     benchmark.pedantic(
-        tree_map, args=(lambda x: x.unbind(0), nested_dict), iterations=10000
+        tree_map, args=(lambda x: x.unbind(0), nested_dict), iterations=100, rounds=100
     )
 
 
 def test_unbind_td(benchmark, nested_td):
-    benchmark.pedantic(nested_td.unbind, args=(0,), iterations=10000)
+    benchmark.pedantic(nested_td.unbind, args=(0,), iterations=100, rounds=100)
 
 
 # split
 def test_split_pytree(benchmark, nested_dict):
     benchmark.pedantic(
-        tree_map, args=(lambda x: x.split([1, 2], 0), nested_dict), iterations=10000
+        tree_map,
+        args=(lambda x: x.split([1, 2], 0), nested_dict),
+        iterations=100,
+        rounds=100,
     )
 
 
 def test_split_td(benchmark, nested_td):
-    benchmark.pedantic(nested_td.split, args=([1, 2], 0), iterations=10000)
+    benchmark.pedantic(nested_td.split, args=([1, 2], 0), iterations=100, rounds=100)
 
 
 # add
 def test_add_pytree(benchmark, nested_dict):
-    benchmark.pedantic(tree_map, args=(lambda x: x + 1, nested_dict), iterations=10000)
+    benchmark.pedantic(
+        tree_map, args=(lambda x: x + 1, nested_dict), iterations=100, rounds=100
+    )
 
 
 def test_add_td(benchmark, nested_td):
-    benchmark.pedantic(nested_td.apply, args=(lambda x: x + 1,), iterations=10000)
+    benchmark.pedantic(
+        nested_td.apply, args=(lambda x: x + 1,), iterations=100, rounds=100
+    )

--- a/benchmarks/nn/functional_benchmarks_test.py
+++ b/benchmarks/nn/functional_benchmarks_test.py
@@ -22,23 +22,27 @@ def net():
 # Creation
 def test_instantiation_functorch(benchmark, net):
     benchmark.pedantic(
-        functorch_make_functional, args=(deepcopy(net),), iterations=1000
+        functorch_make_functional, args=(deepcopy(net),), iterations=10, rounds=100
     )
 
 
 def test_instantiation_td(benchmark, net):
-    benchmark.pedantic(make_functional, args=(deepcopy(net),), iterations=1000)
+    benchmark.pedantic(
+        make_functional, args=(deepcopy(net),), iterations=10, rounds=100
+    )
 
 
 # Execution
 def test_exec_functorch(benchmark, net):
     x = torch.randn(2, 2)
     fmodule, params, buffers = functorch_make_functional(deepcopy(net))
-    benchmark.pedantic(fmodule, args=(params, buffers, x), iterations=10000)
+    benchmark.pedantic(fmodule, args=(params, buffers, x), iterations=100, rounds=100)
 
 
 def test_exec_td(benchmark, net):
     x = torch.randn(2, 2)
     fmodule = deepcopy(net)
     params = make_functional(fmodule)
-    benchmark.pedantic(fmodule, args=(x,), kwargs={"params": params}, iterations=10000)
+    benchmark.pedantic(
+        fmodule, args=(x,), kwargs={"params": params}, iterations=100, rounds=100
+    )


### PR DESCRIPTION
## Description

Currently most of our benchmarks are run once with multiple repeats. This means that the stats such as min, max, stddev of the runtime which get reported are not super useful.

This PR splits up the iterations into multiple rounds, resulting in more meaningful output.