### PR TITLE
[BugFix] Remove functionalized check in _decorate_funs

### DIFF
--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -208,16 +208,15 @@ def _decorate_funs(
     if funs_to_decorate is None:
         funs_to_decorate = ["forward"]
 
-    if not model.__dict__.get("_functionalized", False):
-        for fun_to_decorate in funs_to_decorate:
-            try:
-                setattr(
-                    model,
-                    fun_to_decorate,
-                    types.MethodType(_make_decorator(model, fun_to_decorate), model),
-                )
-            except AttributeError:
-                continue
+    for fun_to_decorate in funs_to_decorate:
+        try:
+            setattr(
+                model,
+                fun_to_decorate,
+                types.MethodType(_make_decorator(model, fun_to_decorate), model),
+            )
+        except AttributeError:
+            continue
     model.__dict__["_functionalized"] = True
     model.__dict__["_is_stateless"] = make_stateless
 


### PR DESCRIPTION
## Description

Checking if a module is functionalized and doing nothing in that case can impair successive functionalizations like
```
make_functional(module, [func1])
make_functional(module, [func2])  # ignored bc already functional
```