### PR TITLE
[Refactor] Refactor cache

### DIFF
--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -274,7 +274,6 @@ class PersistentTensorDict(TensorDictBase):
                 )
             return out
 
-    @cache  # noqa: B019
     def get(self, key, default=NO_DEFAULT):
         array = self._get_array(key, default)
         if array is default:
@@ -407,7 +406,6 @@ class PersistentTensorDict(TensorDictBase):
                 ) from err
         sub_td.update(value, inplace=True)
 
-    # @cache  # noqa: B019
     def keys(
         self, include_nested: bool = False, leaves_only: bool = False
     ) -> _PersistentTDKeysView:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3962,12 +3962,10 @@ class TestLazyStackedTensorDict:
         from tensordict.nn import TensorDictModule  # noqa
         from torch import vmap
 
-        print("first call to vmap")
         fun = vmap(lambda x: x)
         fun(td)
         td.zero_()
         # this value should be cached
-        print("second call to vmap")
         std = fun(td)
         for value in std.values(True, True):
             assert (value == 0).all()


### PR DESCRIPTION
Caching can be good but since it requires an assertion of the locked state of the tensordict, non-locked tensordicts are negatively affected by this.
In this PR, I propose a caching mechanism where the cached method only appears when the tensordict is locked. If it isn't the cache is not only ignored, it is skipped.
I do this by setting the decorated method when calling lock_ and resetting the previous method after that.

cc @tcbegley if you have time

EDIT
Putting on hold as it seems to be causing some memory leaks