### PR TITLE
[BugFix] `torch.where`: Expand mask on the right in lazy stack tds

### DIFF
--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -845,9 +845,11 @@ implements_for_memmap(torch.cat)(_cat)
 def _where(condition, input, other):
     device = input.device
     if device != torch.device("cpu"):
-        input = input.to("cpu").as_tensor().to(device)
+        input = input.to("cpu").as_tensor().to(device, non_blocking=True)
     else:
         input = input.as_tensor()
+    if condition.device != device or other.device != device:
+        raise ValueError(f"{condition.device}, {device}, {other.device}")
     return torch.where(condition=condition, input=input, other=other)
 
 

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -731,7 +731,8 @@ MemmapTensor of shape {self.shape}."""
                 out.device = device
             return out
 
-        self.device = device
+        out = self.clone()
+        out.device = device
         return self
 
     def unbind(self, dim: int) -> tuple[torch.Tensor, ...]:
@@ -845,7 +846,7 @@ implements_for_memmap(torch.cat)(_cat)
 def _where(condition, input, other):
     device = input.device
     if device != torch.device("cpu"):
-        input = input.to("cpu").as_tensor().to(device, non_blocking=True)
+        input = input.to("cpu").to(device, non_blocking=True)
     else:
         input = input.as_tensor()
     if condition.device != device or (isinstance(other, (MemmapTensor, torch.Tensor)) and other.device != device):

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -848,7 +848,7 @@ def _where(condition, input, other):
         input = input.to("cpu").as_tensor().to(device, non_blocking=True)
     else:
         input = input.as_tensor()
-    if condition.device != device or other.device != device:
+    if condition.device != device or (isinstance(other, (MemmapTensor, torch.Tensor)) and other.device != device):
         raise ValueError(f"{condition.device}, {device}, {other.device}")
     return torch.where(condition=condition, input=input, other=other)
 

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -843,7 +843,12 @@ implements_for_memmap(torch.cat)(_cat)
 
 
 def _where(condition, input, other):
-    return torch.where(condition=condition, input=input.as_tensor(), other=other)
+    device = input.device
+    if device != torch.device("cpu"):
+        input = input.to("cpu").as_tensor().to(device)
+    else:
+        input = input.as_tensor()
+    return torch.where(condition=condition, input=input, other=other)
 
 
 implements_for_memmap(torch.where)(_where)

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -732,8 +732,7 @@ MemmapTensor of shape {self.shape}."""
             return out
 
         out = self.clone()
-        out.device = device
-        return self
+        return out.to(device)
 
     def unbind(self, dim: int) -> tuple[torch.Tensor, ...]:
         """Unbinds a MemmapTensor along the desired dimension.

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -849,8 +849,6 @@ def _where(condition, input, other):
         input = input.to("cpu").to(device, non_blocking=True)
     else:
         input = input.as_tensor()
-    if condition.device != device or (isinstance(other, (MemmapTensor, torch.Tensor)) and other.device != device):
-        raise ValueError(f"{condition.device}, {device}, {other.device}")
     return torch.where(condition=condition, input=input, other=other)
 
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -7924,6 +7924,8 @@ class LazyStackedTensorDict(TensorDictBase):
     rename_key = _renamed_inplace_method(rename_key_)
 
     def where(self, condition, other, *, out=None, pad=None):
+        if condition.ndim < self.ndim:
+            condition = expand_right(condition, self.batch_size)
         condition = condition.unbind(self.stack_dim)
         if _is_tensor_collection(other.__class__) or (
             isinstance(other, Tensor)

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1764,7 +1764,10 @@ class TensorDictBase(MutableMapping):
     @cache  # noqa: B019
     def _add_batch_dim(self, *, in_dim, vmap_level):
         if self.is_memmap():
-            td = self.cpu()
+            if self.device.type != "cpu":
+                td = self.cpu()
+            else:
+                td = self.as_tensor()
         else:
             td = self
         out = TensorDict(

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1764,7 +1764,7 @@ class TensorDictBase(MutableMapping):
     @cache  # noqa: B019
     def _add_batch_dim(self, *, in_dim, vmap_level):
         if self.is_memmap():
-            td = self.cpu().as_tensor()
+            td = self.cpu()
         else:
             td = self
         out = TensorDict(

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1765,7 +1765,9 @@ class TensorDictBase(MutableMapping):
     def _add_batch_dim(self, *, in_dim, vmap_level):
         if self.is_memmap():
             if self.device.type != "cpu":
-                td = self.cpu()
+                raise RuntimeError(
+                    "MemmapTensor with non-cpu device are not supported in vmap ops."
+                )
             else:
                 td = self.as_tensor()
         else:

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -519,15 +519,15 @@ def dummy_memmap():
 @pytest.mark.parametrize("device", get_available_devices())
 class TestOps:
     def test_eq(self, device, dummy_memmap):
-        memmap = dummy_memmap.to(device)
-        assert (memmap == memmap.clone()).all()
-        assert (memmap.clone() == memmap).all()
+        dummy_memmap.device = device
+        assert (dummy_memmap == dummy_memmap.clone()).all()
+        assert (dummy_memmap.clone() == dummy_memmap).all()
         if device.type == "cpu":
-            assert (memmap == memmap.as_tensor()).all()
-            assert (memmap.as_tensor() == memmap).all()
+            assert (dummy_memmap == dummy_memmap.as_tensor()).all()
+            assert (dummy_memmap.as_tensor() == dummy_memmap).all()
         else:
-            assert (memmap == memmap._tensor).all()
-            assert (memmap._tensor == memmap).all()
+            assert (dummy_memmap == dummy_memmap._tensor).all()
+            assert (dummy_memmap._tensor == dummy_memmap).all()
 
     def test_fill_(self, device, dummy_memmap):
         memmap = dummy_memmap.to(device)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2889,6 +2889,13 @@ class TestTensorDicts(TestTensorDictsBase):
             ):
                 fun(td)
             return
+        if td_name == "memmap_td" and device.type != "cpu":
+            with pytest.raises(
+                RuntimeError,
+                match="MemmapTensor with non-cpu device are not supported in vmap ops",
+            ):
+                fun(td)
+            return
         fun(td)
 
         if td_name == "td_params":


### PR DESCRIPTION
Masks in `torch.where` for lazy stacks need to have as many dims as the tensordict to be unbound along the stack dim. This PR makes sure that it's the case.