### PR TITLE
Fix assignment of `str`-typed value to `_device` attribute in `MemmapTensor`

### DIFF
--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -302,7 +302,7 @@ class MemmapTensor:
         dtype: torch.dtype,
         transfer_ownership: bool,
     ):
-        self._device = device
+        self._device = torch.device(device)
         self._shape = shape
         self._shape_indexed = None
         self.np_shape = tuple(self._shape)

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -124,9 +124,7 @@ class PersistentTensorDict(TensorDictBase):
 
     """
 
-    def __new__(cls, *args, **kwargs):
-        cls._td_dim_names = None
-        return super().__new__(cls, *args, **kwargs)
+    _td_dim_names = None
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

The `device` property of `MemmapTensor` is defined via the method
```python
@property
def device(self) -> torch.device:
    return self._device
```
which indicates that the `_device` attribute should only have the `torch.device` type, whereas the current implementation allows assigning a `str` value via the `_init_shape(self, device, ...)` method, which has a parameter `device` typed as `str | Device`.

This change fixes that by simply changing the assignment `self._device = device` in `_init_shape(self, device, ...)` to `self._device = torch.device(device)`. 

## Motivation and Context

When loading a memory mapped tensordict via `td = TensorDict.load_memmap(...)`, the `_device` attribute could be assigned a `str` value. 

This causes `td["some_key"].as_tensor()` to raise `AttributeError` when reading the attribute `self.device.type` at line 752 in `memmap.py`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] ~~I have updated the tests accordingly (*required for a bug fix or a new feature*).~~
- [ ] ~~I have updated the documentation accordingly.~~
