### PR TITLE
[Feature] Using native torch.Tensor for memmap

### DIFF
--- a/tensordict/_memory_map.py
+++ b/tensordict/_memory_map.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tensordict/_memory_map.py
+++ b/tensordict/_memory_map.py
@@ -16,7 +16,10 @@ from torch.types import (
     _layout,
     _device,
 )
+from multiprocessing import util
+from multiprocessing.context import reduction
 
+import sys
 
 def empty_like(
     input: Tensor,
@@ -146,3 +149,9 @@ def reduce_handler(handler):
 def rebuild_handler(size, dupfd):
     detached = dupfd.detach()
     return FileHandler(size, detached)
+
+def from_tensor(tensor, *, filename=None, copy_existing=False):
+    if filename is not None and tensor.storage().filename is not None and not copy_existing:
+        raise ValueError(f"A filename was provided but the tensor already has a file associated ({tensor.storage().filename}). "
+                         f"To copy the tensor onto the new location, pass copy_existing=True.")
+    return empty_like(tensor, filename=filename).copy_(tensor)

--- a/tensordict/_memory_map.py
+++ b/tensordict/_memory_map.py
@@ -2,3 +2,97 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import Optional, Union
+
+import numpy as np
+import torch
+from torch import Tensor
+from torch import memory_format
+from torch.types import (
+    _bool,
+    _dtype,
+    _layout,
+    _device,
+)
+
+
+def empty_like(
+    input: Tensor,
+    *,
+    memory_format: Optional[memory_format] = None,
+    dtype: Optional[_dtype] = None,
+    layout: Optional[_layout] = None,
+    device: Optional[Union[_device, str, None]] = None,
+    pin_memory: Optional[_bool] = False,
+    requires_grad: Optional[_bool] = False,
+    filename: Optional[str] = None
+) -> Tensor:
+    shape = input.shape
+    if dtype is None:
+        dtype = input.dtype
+    if device is not None:
+        device = torch.device(device)
+        if device.type != "cpu":
+            raise ValueError
+    if filename is None:
+        if dtype.is_floating_point:
+            size = torch.finfo(dtype).bits // 8 * shape.numel()
+        elif dtype.is_complex:
+            raise ValueError(
+                "Complex-valued tensors are not supported by memory-mapped tensors."
+            )
+        elif dtype == torch.bool:
+            size = shape.numel()
+        else:
+            # assume integer
+            size = torch.iinfo(dtype).bits // 8 * shape.numel()
+        handler = FileHandler(size)
+        if layout is not None:
+            raise ValueError
+        if pin_memory:
+            raise ValueError
+        out = torch.frombuffer(
+            memoryview(handler.buffer), dtype=dtype,
+            # layout=layout,
+            device=device,
+            # pin_memory=pin_memory,
+            requires_grad=requires_grad
+            )
+        out = torch.reshape(out, shape)
+    else:
+        out = torch.from_file(
+            str(filename),
+            shared=True,
+            dtype=dtype,
+            size=shape.numel(),
+            layout=layout,
+            device=device, pin_memory=pin_memory, requires_grad=requires_grad
+        ).view(input.shape)
+    return out
+
+
+def zeros_like(
+    input: Tensor,
+    *,
+    memory_format: Optional[memory_format] = None,
+    dtype: Optional[_dtype] = None,
+    layout: Optional[_layout] = None,
+    device: Optional[Union[_device, str, None]] = None,
+    pin_memory: Optional[_bool] = False,
+    requires_grad: Optional[_bool] = False,
+    filename: Optional[str] = None
+):
+    return empty_like(input, memory_format=memory_format, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad, filename=filename).zero_()
+
+def ones_like(
+    input: Tensor,
+    *,
+    memory_format: Optional[memory_format] = None,
+    dtype: Optional[_dtype] = None,
+    layout: Optional[_layout] = None,
+    device: Optional[Union[_device, str, None]] = None,
+    pin_memory: Optional[_bool] = False,
+    requires_grad: Optional[_bool] = False,
+    filename: Optional[str] = None
+):
+    return empty_like(input, memory_format=memory_format, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad, filename=filename).fill_(1.0)

--- a/tensordict/_memory_map.py
+++ b/tensordict/_memory_map.py
@@ -2,6 +2,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import os
+import tempfile
 from typing import Optional, Union
 
 import numpy as np
@@ -96,3 +98,51 @@ def ones_like(
     filename: Optional[str] = None
 ):
     return empty_like(input, memory_format=memory_format, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad, filename=filename).fill_(1.0)
+
+
+class FileHandler:
+    if sys.platform == "linux":
+        _dir_candidates = ["/dev/shm"]
+    else:
+        _dir_candidates = []
+
+    def __init__(self, size, fd=-1, filename=None):
+        # borrowed from mp.heap
+        self.size = size
+        # if filename is None:
+        if fd == -1:
+            self.fd, name = tempfile.mkstemp(
+                prefix="pym-%d-" % os.getpid(), dir=self._choose_dir(size)
+            )
+            # self.filename = name
+            os.unlink(name)
+            util.Finalize(self, os.close, (self.fd,))
+            os.ftruncate(self.fd, size)
+        else:
+            self.fd = fd
+        # else:
+        #     self.filename = filename
+        self.buffer = mmap.mmap(self.fd, self.size)
+
+    def _choose_dir(self, size):
+        # Choose a non-storage backed directory if possible,
+        # to improve performance
+        for d in self._dir_candidates:
+            st = os.statvfs(d)
+            if st.f_bavail * st.f_frsize >= size:  # enough free space?
+                return d
+        tmpdir = util.get_temp_dir()
+        return tmpdir
+
+
+def reduce_handler(handler):
+    if handler.fd == -1:
+        raise ValueError(
+            "Handler is unpicklable because " "forking was enabled when it was created"
+        )
+    return rebuild_handler, (handler.size, reduction.DupFd(handler.fd))
+
+
+def rebuild_handler(size, dupfd):
+    detached = dupfd.detach()
+    return FileHandler(size, detached)

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -208,8 +208,15 @@ class MemmapTensor:
         prefix: str | None = None,
         filename: str | None = None,
         mode: str = "r+",
+        copy_existing: str = False,
     ) -> MemmapTensor:
         if isinstance(tensor, MemmapTensor):
+            if not copy_existing and isinstance(tensor, MemmapTensor):
+                raise RuntimeError(
+                    f"A filename was provided but the tensor already has a file associated ({tensor.filename}). "
+                    f"To copy the tensor onto the new location, pass copy_existing=True."
+                )
+
             if transfer_ownership:
                 raise RuntimeError(
                     "from_tensor(memmap_tensor, transfer_ownership=True) is not permitted, as this method will "

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -208,7 +208,7 @@ class MemmapTensor:
         prefix: str | None = None,
         filename: str | None = None,
         mode: str = "r+",
-        copy_existing: str = False,
+        copy_existing: str = True,
     ) -> MemmapTensor:
         if isinstance(tensor, MemmapTensor):
             if not copy_existing and isinstance(tensor, MemmapTensor):

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -522,7 +522,9 @@ class MemmapTensor:
     def numpy(self) -> np.ndarray:
         return self._tensor.numpy()
 
-    def copy_(self, other: torch.Tensor | MemmapTensor) -> MemmapTensor:
+    def copy_(
+        self, other: torch.Tensor | MemmapTensor, non_blocking: bool = False
+    ) -> MemmapTensor:
         if isinstance(other, MemmapTensor) and other.filename == self.filename:
             if not self.shape == other.shape:
                 raise ValueError(

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -629,7 +629,10 @@ class TensorDictParams(TensorDictBase, nn.Module):
         ...
 
     def memmap_(
-        self, prefix: str | None = None, copy_existing: bool = False
+        self,
+        prefix: str | None = None,
+        copy_existing: bool = False,
+        backend="MemmapTensor",
     ) -> TensorDictBase:
         raise RuntimeError("Cannot build a memmap TensorDict in-place.")
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1753,9 +1753,10 @@ class TensorDictBase(MutableMapping):
             if num_workers is None:
                 num_workers = mp.cpu_count()  # Get the number of CPU cores
             with mp.Pool(num_workers) as pool:
-                return self.map(
+                result = self.map(
                     fn, dim=dim, chunksize=chunksize, num_chunks=num_chunks, pool=pool
                 )
+            return result
         num_workers = pool._processes
         dim_orig = dim
         if dim < 0:
@@ -1765,9 +1766,9 @@ class TensorDictBase(MutableMapping):
 
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         chunksize = 1
-        out = pool.imap(fn, self_split, chunksize)
-        out = torch.cat(list(out), dim)
-        return out
+        result = pool.imap(fn, self_split, chunksize)
+        result = torch.cat(list(result), dim)
+        return result
 
     @cache  # noqa: B019
     def _add_batch_dim(self, *, in_dim, vmap_level):

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -2433,8 +2433,14 @@ class TensorDictBase(MutableMapping):
                 del target[key]
         return target
 
-    def copy_(self, tensordict: T) -> T:
-        """See :obj:`TensorDictBase.update_`."""
+    def copy_(self, tensordict: T, non_blocking: bool = False) -> T:
+        """See :obj:`TensorDictBase.update_`.
+
+        Args:
+            tensordict (TensorDictBase or compatible type): the value to copy.
+            non_blocking (bool, optional): currently ignored, present for compatibility
+                with torch.Tensor.
+        """
         return self.update_(tensordict)
 
     def copy_at_(self, tensordict: T, idx: IndexType) -> T:

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -3164,73 +3164,30 @@ class TensorDictBase(MutableMapping):
             A list of TensorDict with specified size in given dimension.
 
         """
-        batch_sizes = []
-        if self.batch_dims == 0:
-            raise RuntimeError("TensorDict with empty batch size is not splittable")
-        if not (-self.batch_dims <= dim < self.batch_dims):
-            raise IndexError(
-                f"Dimension out of range (expected to be in range of [-{self.batch_dims}, {self.batch_dims - 1}], but got {dim})"
-            )
+        # we must use slices to keep the storage of the tensors
+        batch_size = self.batch_size
         if dim < 0:
-            dim += self.batch_dims
+            dim = len(batch_size) + dim
         if isinstance(split_size, int):
-            rep, remainder = divmod(self.batch_size[dim], split_size)
-            rep_shape = torch.Size(
-                [
-                    split_size if idx == dim else size
-                    for (idx, size) in enumerate(self.batch_size)
-                ]
-            )
-            batch_sizes = [rep_shape for _ in range(rep)]
-            if remainder:
-                batch_sizes.append(
-                    torch.Size(
-                        [
-                            remainder if dim_idx == dim else dim_size
-                            for (dim_idx, dim_size) in enumerate(self.batch_size)
-                        ]
-                    )
-                )
-        elif isinstance(split_size, list) and all(
-            isinstance(element, int) for element in split_size
-        ):
-            if sum(split_size) != self.batch_size[dim]:
-                raise RuntimeError(
-                    f"Split method expects split_size to sum exactly to {self.batch_size[dim]} (tensor's size at dimension {dim}), but got split_size={split_size}"
-                )
-            for i in split_size:
-                batch_sizes.append(
-                    torch.Size(
-                        [
-                            i if dim_idx == dim else dim_size
-                            for (dim_idx, dim_size) in enumerate(self.batch_size)
-                        ]
-                    )
-                )
+            idx0 = 0
+            idx1 = split_size
+            split_sizes = [slice(idx0, idx1)]
+            while idx1 <= batch_size[dim]:
+                idx0 = idx1
+                idx1 += split_size
+                split_sizes.append(slice(idx0, idx1))
         else:
-            raise TypeError(
-                "split(): argument 'split_size' must be int or list of ints"
-            )
-        dictionaries = [{} for _ in range(len(batch_sizes))]
-        for key, item in self.items():
-            split_tensors = torch.split(item, split_size, dim)
-            for idx, split_tensor in enumerate(split_tensors):
-                dictionaries[idx][key] = split_tensor
-        names = None
-        if self._has_names():
-            names = copy(self.names)
-        return [
-            TensorDict(
-                dictionaries[i],
-                batch_sizes[i],
-                device=self.device,
-                names=names,
-                _run_checks=False,
-                _is_shared=self.is_shared(),
-                _is_memmap=self.is_memmap(),
-            )
-            for i in range(len(dictionaries))
-        ]
+            if len(split_size) == 0:
+                raise RuntimeError("Insufficient number of elements in split_size.")
+            idx0 = 0
+            idx1 = split_size[0]
+            split_sizes = [slice(idx0, idx1)]
+            for idx in split_size[1:]:
+                idx0 = idx1
+                idx1 += idx
+                split_sizes.append(slice(idx0, idx1))
+        index = (slice(None),) * dim
+        return tuple(self[index + (ss,)] for ss in split_sizes)
 
     def gather(self, dim: int, index: Tensor, out: T | None = None) -> T:
         """Gathers values along an axis specified by `dim`.
@@ -4692,11 +4649,13 @@ class TensorDict(TensorDictBase):
             from_tensor = MemmapTensor.from_tensor
         elif backend == "Tensor":
             from_tensor = from_tensor_memmap
-            if self.device.type != "cpu":
+            if self.device is not None and self.device.type != "cpu":
                 # TODO: provide a method to remove the device of a tensordict
-                raise RuntimeError("A tensordict on cuda cannot be memory-mapped. "
-                                   "Choose the MemmapBackend or remove the device from "
-                                   "the tensordict and its children.")
+                raise RuntimeError(
+                    "A tensordict on cuda cannot be memory-mapped. "
+                    "Choose the MemmapBackend or remove the device from "
+                    "the tensordict and its children."
+                )
         else:
             raise RuntimeError(f"Unrecognized backend {backend}.")
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4692,6 +4692,11 @@ class TensorDict(TensorDictBase):
             from_tensor = MemmapTensor.from_tensor
         elif backend == "Tensor":
             from_tensor = from_tensor_memmap
+            if self.device.type != "cpu":
+                # TODO: provide a method to remove the device of a tensordict
+                raise RuntimeError("A tensordict on cuda cannot be memory-mapped. "
+                                   "Choose the MemmapBackend or remove the device from "
+                                   "the tensordict and its children.")
         else:
             raise RuntimeError(f"Unrecognized backend {backend}.")
 

--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -4447,7 +4447,7 @@ class TensorDict(TensorDictBase):
                 if best_attempt and _is_tensor_collection(dest.__class__):
                     dest.update(value, inplace=True)
                 else:
-                    dest.copy_(value)
+                    dest.copy_(value, non_blocking=True)
             except KeyError as err:
                 raise err
             except Exception as err:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-from enum import Enum
 
 import math
 import time
@@ -16,6 +15,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import KeysView
 from copy import copy
+from enum import Enum
 from functools import wraps
 from importlib import import_module
 from typing import Any, Callable, List, Sequence, Tuple, TYPE_CHECKING, Union

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+from enum import Enum
+
 import math
 import time
 

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import math
 import tempfile
+import warnings
 
 import numpy as np
 import pytest
@@ -176,7 +177,9 @@ class TestTensorDictsBase:
         # When deprecating MemmapTensor, we'll also deprecate this behaviour.
         if device.type == "cpu":
             return self.td(device).memmap_(backend="Tensor")
-        return self.td(device).memmap_(backend="MemmapTensor")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return self.td(device).memmap_(backend="MemmapTensor")
 
     def memmap_td_file(self, device):
         if device.type == "cpu":

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -171,10 +171,17 @@ class TestTensorDictsBase:
         return td.get_sub_tensordict((slice(None), 1))
 
     def memmap_td(self, device):
-        return self.td(device).memmap_(backend="Tensor")
+        # MemmapTensor allows a 'cuda' device, which means that the data will
+        # be sent to cuda when accessed.
+        # When deprecating MemmapTensor, we'll also deprecate this behaviour.
+        if device.type == "cpu":
+            return self.td(device).memmap_(backend="Tensor")
+        return self.td(device).memmap_(backend="MemmapTensor")
 
     def memmap_td_file(self, device):
-        return self.td(device).memmap_(backend="Tensor", prefix=global_dir_prefix)
+        if device.type == "cpu":
+            return self.td(device).memmap_(backend="Tensor", prefix=global_dir_prefix)
+        return self.td(device).memmap_(backend="MemmapTensor", prefix=global_dir_prefix)
 
     def permute_td(self, device):
         return TensorDict(

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -6,6 +6,7 @@ import math
 import tempfile
 
 import numpy as np
+import pytest
 import torch
 
 from tensordict import PersistentTensorDict, tensorclass, TensorDict
@@ -15,6 +16,8 @@ from tensordict.tensordict import (
     is_tensor_collection,
     LazyStackedTensorDict,
 )
+
+global_dir_prefix = str(tempfile.TemporaryDirectory())
 
 
 def prod(sequence):
@@ -169,6 +172,9 @@ class TestTensorDictsBase:
 
     def memmap_td(self, device):
         return self.td(device).memmap_(backend="Tensor")
+
+    def memmap_td_file(self, device):
+        return self.td(device).memmap_(backend="Tensor", prefix=global_dir_prefix)
 
     def permute_td(self, device):
         return TensorDict(

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -175,6 +175,7 @@ class TestTensorDictsBase:
         # MemmapTensor allows a 'cuda' device, which means that the data will
         # be sent to cuda when accessed.
         # When deprecating MemmapTensor, we'll also deprecate this behaviour.
+        device = torch.device(device)
         if device.type == "cpu":
             return self.td(device).memmap_(backend="Tensor")
         with warnings.catch_warnings():
@@ -182,6 +183,7 @@ class TestTensorDictsBase:
             return self.td(device).memmap_(backend="MemmapTensor")
 
     def memmap_td_file(self, device):
+        device = torch.device(device)
         if device.type == "cpu":
             return self.td(device).memmap_(backend="Tensor", prefix=global_dir_prefix)
         return self.td(device).memmap_(backend="MemmapTensor", prefix=global_dir_prefix)

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -168,7 +168,7 @@ class TestTensorDictsBase:
         return td.get_sub_tensordict((slice(None), 1))
 
     def memmap_td(self, device):
-        return self.td(device).memmap_()
+        return self.td(device).memmap_(backend="Tensor")
 
     def permute_td(self, device):
         return TensorDict(

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -484,8 +484,8 @@ class iSendBase:
     @pytest.mark.flaky(reruns=5, reruns_delay=5)
     def test_isend(self, pseudo_rand, set_context):
         queue = mp.Queue(1)
-        main_worker = mp.Process(target=type(self).server, args=(queue, pseudo_rand))
-        secondary_worker = mp.Process(target=type(self).client, args=(pseudo_rand,))
+        main_worker = mp.Process(target=self.server, args=(queue, pseudo_rand))
+        secondary_worker = mp.Process(target=self.client, args=(pseudo_rand,))
 
         main_worker.start()
         secondary_worker.start()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2710,56 +2710,41 @@ class TestTensorDicts(TestTensorDictsBase):
             torch.testing.assert_close(td.get(("a", "b", "d")), tensor2)
 
     @pytest.mark.parametrize("performer", ["torch", "tensordict"])
-    def test_split(self, td_name, device, performer):
+    @pytest.mark.parametrize("dim", range(4))
+    def test_split(self, td_name, device, performer, dim):
         td = getattr(self, td_name)(device)
+        tensor = torch.zeros(()).expand(td.shape)
 
-        for dim in range(td.batch_dims):
-            rep, remainder = divmod(td.shape[dim], 2)
-            length = rep + remainder
+        rep, remainder = divmod(td.shape[dim], 2)
 
-            # split_sizes to be [2, 2, ..., 2, 1] or [2, 2, ..., 2]
-            split_sizes = [2] * rep + [1] * remainder
-            for test_split_size in (2, split_sizes):
-                if performer == "torch":
-                    tds = torch.split(td, test_split_size, dim)
-                elif performer == "tensordict":
-                    tds = td.split(test_split_size, dim)
-                assert len(tds) == length
+        # split_sizes to be [2, 2, ..., 2, 1] or [2, 2, ..., 2]
+        split_sizes = [2] * rep + [1] * remainder
+        for test_split_size in (2, split_sizes):
+            if performer == "torch":
+                tds = torch.split(td, test_split_size, dim)
+            elif performer == "tensordict":
+                tds = td.split(test_split_size, dim)
+            tensors = tensor.split(test_split_size, dim)
+            length = len(tensors)
+            assert len(tds) == length, (
+                test_split_size,
+                dim,
+                [td.shape for td in tds],
+                td.shape,
+                length,
+            )
 
-                for idx, split_td in enumerate(tds):
-                    expected_split_dim_size = 1 if idx == rep else 2
-                    expected_batch_size = [
-                        expected_split_dim_size if dim_idx == dim else dim_size
-                        for (dim_idx, dim_size) in enumerate(td.batch_size)
-                    ]
+            for _tensor, split_td in zip(tensors, tds):
+                assert _tensor.shape == split_td.shape
 
-                    # Test each split_td has the expected batch_size
-                    assert split_td.batch_size == torch.Size(expected_batch_size)
+                if td_name == "nested_td":
+                    assert isinstance(split_td["my_nested_td"], TensorDict)
+                    assert isinstance(split_td["my_nested_td", "inner"], torch.Tensor)
 
-                    if td_name == "nested_td":
-                        assert isinstance(split_td["my_nested_td"], TensorDict)
-                        assert isinstance(
-                            split_td["my_nested_td"]["inner"], torch.Tensor
-                        )
-
-                    # Test each tensor (or nested_td) in split_td has the expected shape
-                    for key, item in split_td.items():
-                        expected_shape = [
-                            expected_split_dim_size if dim_idx == dim else dim_size
-                            for (dim_idx, dim_size) in enumerate(td[key].shape)
-                        ]
-                        assert item.shape == torch.Size(expected_shape)
-
-                        if key == "my_nested_td":
-                            expected_inner_tensor_size = [
-                                expected_split_dim_size if dim_idx == dim else dim_size
-                                for (dim_idx, dim_size) in enumerate(
-                                    td[key]["inner"].shape
-                                )
-                            ]
-                            assert item["inner"].shape == torch.Size(
-                                expected_inner_tensor_size
-                            )
+                # Test each tensor (or nested_td) in split_td has the expected shape
+                for key, item in split_td.items(True, True):
+                    expected_shape = _tensor.shape + td[key].shape[len(_tensor.shape) :]
+                    assert item.shape == torch.Size(expected_shape)
 
     def test_pop(self, td_name, device):
         td = getattr(self, td_name)(device)
@@ -4333,7 +4318,9 @@ def test_flatten_unflatten_key_collision(inplace, separator):
 def test_split_with_invalid_arguments():
     td = TensorDict({"a": torch.zeros(2, 1)}, [])
     # Test empty batch size
-    with pytest.raises(RuntimeError, match="not splittable"):
+    with pytest.raises(
+        RuntimeError, match="The number of dimensions is insufficient for the split_dim"
+    ):
         td.split(1, 0)
 
     td = TensorDict({}, [3, 2])
@@ -4345,16 +4332,22 @@ def test_split_with_invalid_arguments():
         td.split(["1", 2], 0)
 
     # Test invalid split_size sum
-    with pytest.raises(RuntimeError, match="expects split_size to sum exactly"):
+    with pytest.raises(
+        RuntimeError, match="Insufficient number of elements in split_size"
+    ):
         td.split([], 0)
 
     with pytest.raises(RuntimeError, match="expects split_size to sum exactly"):
         td.split([1, 1], 0)
 
     # Test invalid dimension input
-    with pytest.raises(IndexError, match="Dimension out of range"):
+    with pytest.raises(
+        RuntimeError, match="The number of dimensions is insufficient for the split_dim"
+    ):
         td.split(1, 2)
-    with pytest.raises(IndexError, match="Dimension out of range"):
+    with pytest.raises(
+        RuntimeError, match="The number of dimensions is insufficient for the split_dim"
+    ):
         td.split(1, -3)
 
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -5252,7 +5252,7 @@ def test_memmap_as_tensor(device):
     td_memmap = td.clone().memmap_(backend="Tensor")
     assert (td == td_memmap).all()
 
-    assert (td == td_memmap.apply(lambda x: x.as_tensor())).all()
+    assert (td == td_memmap.as_tensor()).all()
     if device.type == "cuda":
         td = td.pin_memory()
         td_memmap = td.clone().memmap_(backend="Tensor")

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -5249,7 +5249,7 @@ def test_memmap_as_tensor(device):
     if device.type == "cuda":
         td = td.pin_memory()
         td_memmap = td.clone().memmap_(backend="Tensor")
-        td_memmap_pm = td_memmap.apply(lambda x: x.as_tensor()).pin_memory()
+        td_memmap_pm = td_memmap.as_tensor().pin_memory()
         assert (td.pin_memory().to(device) == td_memmap_pm.to(device)).all()
 
 


### PR DESCRIPTION
Introduces a new backend for memory-mapped tensors that doesn't rely on np