### PR TITLE
[Feature] Seed workers in TensorDict.map

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3018,7 +3018,7 @@ class TensorDictBase(MutableMapping):
             for i in range(num_workers):
                 queue.put(i)
             with mp.Pool(
-                num_workers,
+                processes=num_workers,
                 initializer=_proc_init,
                 initargs=(seed, queue),
                 maxtasksperchild=max_tasks_per_child,

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3014,7 +3014,7 @@ class TensorDictBase(MutableMapping):
                 torch.empty((), dtype=torch.int64).random_(generator=generator).item()
             )
 
-            queue = mp.Queue(maxsize=num_workers)
+            queue = mp.Queue(maxsize=num_workers * 2)
             for i in range(num_workers * 2):
                 queue.put(i)
             with mp.Pool(

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2914,11 +2914,12 @@ class TensorDictBase(MutableMapping):
         self,
         fn: Callable,
         dim: int = 0,
-        num_workers: int = None,
-        chunksize: int = None,
-        num_chunks: int = None,
-        pool: mp.Pool = None,
-        seed: int = None,
+        num_workers: int | None = None,
+        chunksize: int | None = None,
+        num_chunks: int | None = None,
+        pool: mp.Pool | None = None,
+        seed: int | None = None,
+        maxtasksperchild: int | None = None,
     ):
         """Maps a function to splits of the tensordict across one dimension.
 
@@ -2975,6 +2976,9 @@ class TensorDictBase(MutableMapping):
                   know which worker will pick which job. However, we can make sure
                   that each worker has a different seed and that the pseudo-random
                   operations on each will be uncorrelated.
+            maxtasksperchild (int, optional): the maximum number of jobs picked
+                by every child process. Defaults to ``None``, i.e., no restriction
+                on the number of jobs.
 
         Examples:
             >>> import torch
@@ -3009,7 +3013,10 @@ class TensorDictBase(MutableMapping):
             for i in range(num_workers):
                 queue.put(i)
             with mp.Pool(
-                num_workers, initializer=_proc_init, initargs=(seed, queue)
+                num_workers,
+                initializer=_proc_init,
+                initargs=(seed, queue),
+                maxtasksperchild=maxtasksperchild,
             ) as pool:
                 return self.map(
                     fn, dim=dim, chunksize=chunksize, num_chunks=num_chunks, pool=pool

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3003,8 +3003,8 @@ class TensorDictBase(MutableMapping):
             at little cost.
 
         """
-        # from torch import multiprocessing as mp
-        import multiprocessing as mp
+        from torch import multiprocessing as mp
+        # import multiprocessing as mp
 
         if pool is None:
             if num_workers is None:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3037,10 +3037,10 @@ class TensorDictBase(MutableMapping):
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
         chunksize = 1
-        # out = []
+        out = []
         imap = pool.imap(fn, self_split, chunksize)
-        # while len(out) < len(self_split):
-        #     out.append(imap.next(timeout=50.0))
+        while len(out) < len(self_split):
+            out.append(imap.next(timeout=50.0))
         # out = pool.map(fn, self_split, chunksize)
         out = torch.cat(list(imap), dim)
         return out

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3014,8 +3014,8 @@ class TensorDictBase(MutableMapping):
                 torch.empty((), dtype=torch.int64).random_(generator=generator).item()
             )
 
-            queue = mp.Queue(maxsize=num_workers * 2)
-            for i in range(num_workers * 2):
+            queue = mp.Queue(maxsize=num_workers)
+            for i in range(num_workers):
                 queue.put(i)
             with mp.Pool(
                 processes=num_workers,
@@ -3036,14 +3036,12 @@ class TensorDictBase(MutableMapping):
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
         chunksize = 1
-        out = []
+        # out = []
         imap = pool.imap(fn, self_split, chunksize)
-        while len(out) < len(self_split):
-            print('out', out)
-            out.append(imap.next(timeout=50.0))
-            print(out[-1]['c'])
+        # while len(out) < len(self_split):
+        #     out.append(imap.next(timeout=50.0))
         # out = pool.map(fn, self_split, chunksize)
-        out = torch.cat(out, dim)
+        out = torch.cat(list(out), dim)
         return out
 
     # Functorch compatibility

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3036,8 +3036,9 @@ class TensorDictBase(MutableMapping):
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
         chunksize = 1
-        # out = pool.imap_unordered(fn, self_split, chunksize)
-        out = pool.map(fn, self_split, chunksize)
+        out = pool.imap_unordered(fn, self_split, chunksize)
+        # out = pool.map(fn, self_split, chunksize)
+        print('out', out)
         out = torch.cat(list(out), dim)
         return out
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3036,7 +3036,8 @@ class TensorDictBase(MutableMapping):
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
         # chunksize = 1
-        out = pool.imap(fn, self_split)#, chunksize)
+        # out = pool.imap_unordered(fn, self_split, chunksize)
+        out = pool.map(fn, self_split, chunksize)
         out = torch.cat(list(out), dim)
         return out
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3035,8 +3035,8 @@ class TensorDictBase(MutableMapping):
 
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
-        chunksize = 1
-        out = pool.imap(fn, self_split, chunksize)
+        # chunksize = 1
+        out = pool.imap(fn, self_split)#, chunksize)
         out = torch.cat(list(out), dim)
         return out
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3041,6 +3041,7 @@ class TensorDictBase(MutableMapping):
         while len(out) < len(self_split):
             print('out', out)
             out.append(imap.next(timeout=5.0))
+            print(out[-1]['c'])
         # out = pool.map(fn, self_split, chunksize)
         out = torch.cat(out, dim)
         return out

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3036,10 +3036,13 @@ class TensorDictBase(MutableMapping):
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
         chunksize = 1
-        out = pool.imap_unordered(fn, self_split, chunksize)
+        out = []
+        imap = pool.imap(fn, self_split, chunksize)
+        while len(out) < len(self_split):
+            print('out', out)
+            out.append(next(imap, timeout=5.0))
         # out = pool.map(fn, self_split, chunksize)
-        out = torch.cat(list(out), dim)
-        print('out', out)
+        out = torch.cat(out, dim)
         return out
 
     # Functorch compatibility

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3038,8 +3038,8 @@ class TensorDictBase(MutableMapping):
         chunksize = 1
         out = pool.imap_unordered(fn, self_split, chunksize)
         # out = pool.map(fn, self_split, chunksize)
-        print('out', out)
         out = torch.cat(list(out), dim)
+        print('out', out)
         return out
 
     # Functorch compatibility

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3015,7 +3015,7 @@ class TensorDictBase(MutableMapping):
             )
 
             queue = mp.Queue(maxsize=num_workers)
-            for i in range(num_workers):
+            for i in range(num_workers * 2):
                 queue.put(i)
             with mp.Pool(
                 processes=num_workers,

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3041,6 +3041,7 @@ class TensorDictBase(MutableMapping):
         imap = pool.imap(fn, self_split, chunksize)
         while len(out) < len(self_split):
             out.append(imap.next(timeout=50.0))
+            print(len(out))
         # out = pool.map(fn, self_split, chunksize)
         out = torch.cat(list(imap), dim)
         return out

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3004,6 +3004,7 @@ class TensorDictBase(MutableMapping):
 
         """
         from torch import multiprocessing as mp
+
         # import multiprocessing as mp
 
         if pool is None:
@@ -3035,7 +3036,7 @@ class TensorDictBase(MutableMapping):
             raise ValueError(f"Got incompatible dimension {dim_orig}")
 
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
-        print('number of tds', len(self_split))
+        print("number of tds", len(self_split))
         chunksize = 1
         out = []
         imap = pool.imap(fn, self_split, chunksize)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2957,6 +2957,8 @@ class TensorDictBase(MutableMapping):
                 of the pool will be seeded with the provided seed incremented
                 by a unique integer from ``0`` to ``num_workers``. If no seed
                 is provided, a random integer will be used as seed.
+                To work with unseeded workers, a pool should be created separately
+                and passed to :meth:`map` directly.
                 .. note::
                   Caution should be taken when providing a low-valued seed as
                   this can cause autocorrelation between experiments, example:
@@ -2964,6 +2966,15 @@ class TensorDictBase(MutableMapping):
                   range from 4 to 11. If the seed is 5, the workers seed will range
                   from 5 to 12. These two experiments will have an overlap of 7
                   seeds, which can have unexpected effects on the results.
+
+                .. note::
+                  The goal of seeding the workers is to have independent seed on
+                  each worker, and NOT to have reproducible results across calls
+                  of the `map` method. In other words, two experiments may and
+                  probably will return different results as it is impossible to
+                  know which worker will pick which job. However, we can make sure
+                  that each worker has a different seed and that the pseudo-random
+                  operations on each will be uncorrelated.
 
         Examples:
             >>> import torch

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3004,7 +3004,7 @@ class TensorDictBase(MutableMapping):
 
         """
         # from torch import multiprocessing as mp
-        from multiprocessing as mp
+        import multiprocessing as mp
 
         if pool is None:
             if num_workers is None:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3003,7 +3003,8 @@ class TensorDictBase(MutableMapping):
             at little cost.
 
         """
-        from torch import multiprocessing as mp
+        # from torch import multiprocessing as mp
+        from multiprocessing as mp
 
         if pool is None:
             if num_workers is None:
@@ -3041,7 +3042,7 @@ class TensorDictBase(MutableMapping):
         # while len(out) < len(self_split):
         #     out.append(imap.next(timeout=50.0))
         # out = pool.map(fn, self_split, chunksize)
-        out = torch.cat(list(out), dim)
+        out = torch.cat(list(imap), dim)
         return out
 
     # Functorch compatibility

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3002,8 +3002,6 @@ class TensorDictBase(MutableMapping):
         """
         from torch import multiprocessing as mp
 
-        # import multiprocessing as mp
-
         if pool is None:
             if num_workers is None:
                 num_workers = mp.cpu_count()  # Get the number of CPU cores
@@ -3033,14 +3031,8 @@ class TensorDictBase(MutableMapping):
             raise ValueError(f"Got incompatible dimension {dim_orig}")
 
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
-        print("number of tds", len(self_split))
         chunksize = 1
-        out = []
         imap = pool.imap(fn, self_split, chunksize)
-        while len(out) < len(self_split):
-            out.append(imap.next(timeout=50.0))
-            print(len(out))
-        # out = pool.map(fn, self_split, chunksize)
         out = torch.cat(list(imap), dim)
         return out
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2954,9 +2954,10 @@ class TensorDictBase(MutableMapping):
             pool (mp.Pool, optional): a multiprocess Pool instance to use
                 to execute the job. If none is provided, a pool will be created
                 within the ``map`` method.
-            seed (integer, optional): the initial seed of the pool. Each member
+            generator (torch.Generator, optional): a generator to use for seeding.
+                A base seed will be generated from it, and each worker
                 of the pool will be seeded with the provided seed incremented
-                by a unique integer from ``0`` to ``num_workers``. If no seed
+                by a unique integer from ``0`` to ``num_workers``. If no generator
                 is provided, a random integer will be used as seed.
                 To work with unseeded workers, a pool should be created separately
                 and passed to :meth:`map` directly.

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3034,6 +3034,7 @@ class TensorDictBase(MutableMapping):
             raise ValueError(f"Got incompatible dimension {dim_orig}")
 
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
+        print('number of tds', len(self_split))
         chunksize = 1
         out = pool.imap(fn, self_split, chunksize)
         out = torch.cat(list(out), dim)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3040,7 +3040,7 @@ class TensorDictBase(MutableMapping):
         imap = pool.imap(fn, self_split, chunksize)
         while len(out) < len(self_split):
             print('out', out)
-            out.append(imap.next(timeout=5.0))
+            out.append(imap.next(timeout=50.0))
             print(out[-1]['c'])
         # out = pool.map(fn, self_split, chunksize)
         out = torch.cat(out, dim)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3035,7 +3035,7 @@ class TensorDictBase(MutableMapping):
 
         self_split = _split_tensordict(self, chunksize, num_chunks, num_workers, dim)
         print('number of tds', len(self_split))
-        # chunksize = 1
+        chunksize = 1
         # out = pool.imap_unordered(fn, self_split, chunksize)
         out = pool.map(fn, self_split, chunksize)
         out = torch.cat(list(out), dim)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3040,7 +3040,7 @@ class TensorDictBase(MutableMapping):
         imap = pool.imap(fn, self_split, chunksize)
         while len(out) < len(self_split):
             print('out', out)
-            out.append(next(imap, timeout=5.0))
+            out.append(imap.next(timeout=5.0))
         # out = pool.map(fn, self_split, chunksize)
         out = torch.cat(out, dim)
         return out

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2943,13 +2943,13 @@ class TensorDictBase(MutableMapping):
                 of workers. For very large tensordicts, such large chunks
                 may not fit in memory for the operation to be done and
                 more chunks may be needed to make the operation practically
-                doable. This argument is exclusive with num_chunks.
+                doable. This argument is exclusive with ``num_chunks``.
             num_chunks (int, optional): the number of chunks to split the tensordict
                 into. If none is provided, the number of chunks will equate the number
                 of workers. For very large tensordicts, such large chunks
                 may not fit in memory for the operation to be done and
                 more chunks may be needed to make the operation practically
-                doable. This argument is exclusive with chunksize.
+                doable. This argument is exclusive with ``chunksize``.
             pool (mp.Pool, optional): a multiprocess Pool instance to use
                 to execute the job. If none is provided, a pool will be created
                 within the ``map`` method.

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -537,7 +537,7 @@ class MemoryMappedTensor(torch.Tensor):
                     "isn't supported at the moment."
                 ) from err
             raise
-        if out.data_ptr() == self.data_ptr():
+        if out.storage().data_ptr() == self.storage().data_ptr():
             out = MemoryMappedTensor(out)
             out._handler = self._handler
             out._filename = self._filename

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1725,7 +1725,9 @@ def _legacy_lazy(func):
 
 # Process initializer for map
 def _proc_init(base_seed, queue):
-    worker_id = queue.get()
+    print('init worker', os.getpid())
+    worker_id = queue.get(timeout=10)
+    print('worker id', worker_id)
     seed = base_seed + worker_id
     torch.manual_seed(seed)
     np_seed = _generate_state(base_seed, worker_id)

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1726,8 +1726,8 @@ def _legacy_lazy(func):
 # Process initializer for map
 def _proc_init(base_seed, queue):
     print('init worker', os.getpid())
-    if queue.empty():
-        exit()
+    # if queue.empty():
+    #     exit()
     worker_id = queue.get(timeout=10)
     print('worker id', worker_id)
     seed = base_seed + worker_id

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1728,5 +1728,5 @@ def _proc_init(base_seed, queue):
     worker_id = queue.get()
     seed = base_seed + worker_id
     torch.manual_seed(seed)
-    _generate_state(base_seed, worker_id)
-    print("seeded with", seed)
+    np_seed = _generate_state(base_seed, worker_id)
+    np.random.seed(np_seed)

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1725,13 +1725,13 @@ def _legacy_lazy(func):
 
 # Process initializer for map
 def _proc_init(base_seed, queue):
-    print('init worker', os.getpid())
+    print("init worker", os.getpid())
     if queue.empty():
         return
     worker_id = queue.get(timeout=10)
-    print('worker id', worker_id)
+    print("worker id", worker_id)
     seed = base_seed + worker_id
     torch.manual_seed(seed)
     np_seed = _generate_state(base_seed, worker_id)
     np.random.seed(np_seed)
-    print('done')
+    print("done")

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1726,9 +1726,7 @@ def _legacy_lazy(func):
 
 # Process initializer for map
 def _proc_init(base_seed, queue):
-    print("worker", os.getpid())
     worker_id = queue.get(timeout=10)
-    print(worker_id)
     seed = base_seed + worker_id
     torch.manual_seed(seed)
     np_seed = _generate_state(base_seed, worker_id)

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1726,6 +1726,8 @@ def _legacy_lazy(func):
 # Process initializer for map
 def _proc_init(base_seed, queue):
     print('init worker', os.getpid())
+    if queue.empty():
+        exit()
     worker_id = queue.get(timeout=10)
     print('worker id', worker_id)
     seed = base_seed + worker_id

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1732,3 +1732,4 @@ def _proc_init(base_seed, queue):
     torch.manual_seed(seed)
     np_seed = _generate_state(base_seed, worker_id)
     np.random.seed(np_seed)
+    print('done')

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import collections
 import dataclasses
 import inspect
-
 import math
 import os
 
@@ -50,6 +49,7 @@ from tensordict._tensordict import (  # noqa: F401
 from torch import Tensor
 from torch._C import _disabled_torch_function_impl
 from torch.nn.parameter import _ParameterMeta
+from torch.utils.data._utils.worker import _generate_state
 
 if TYPE_CHECKING:
     from tensordict.memmap_deprec import MemmapTensor as _MemmapTensor
@@ -1721,3 +1721,12 @@ def _legacy_lazy(func):
         )
     func.LEGACY = True
     return func
+
+
+# Process initializer for map
+def _proc_init(base_seed, queue):
+    worker_id = queue.get()
+    seed = base_seed + worker_id
+    torch.manual_seed(seed)
+    _generate_state(base_seed, worker_id)
+    print("seeded with", seed)

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1726,13 +1726,10 @@ def _legacy_lazy(func):
 
 # Process initializer for map
 def _proc_init(base_seed, queue):
-    print("init worker", os.getpid())
-    if queue.empty():
-        return
+    print("worker", os.getpid())
     worker_id = queue.get(timeout=10)
-    print("worker id", worker_id)
+    print(worker_id)
     seed = base_seed + worker_id
     torch.manual_seed(seed)
     np_seed = _generate_state(base_seed, worker_id)
     np.random.seed(np_seed)
-    print("done")

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1726,8 +1726,8 @@ def _legacy_lazy(func):
 # Process initializer for map
 def _proc_init(base_seed, queue):
     print('init worker', os.getpid())
-    # if queue.empty():
-    #     exit()
+    if queue.empty():
+        return
     worker_id = queue.get(timeout=10)
     print('worker id', worker_id)
     seed = base_seed + worker_id

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6557,9 +6557,9 @@ class TestMap:
     def get_rand_incr(cls, td):
         print('worker', os.getpid())
         # torch
-        td["r"] = td["r"] + torch.randint(0, 100, ())
+        td["r"] += torch.randint(0, 100, ()).item()
         # numpy
-        td["s"] = td["s"] + np.random.randint(0, 100, ())
+        td["s"] += np.random.randint(0, 100, ()).item()
         print(td['c'])
         return td
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6557,9 +6557,9 @@ class TestMap:
     @classmethod
     def get_rand_incr(cls, td):
         # torch
-        td["r"] += torch.randint(0, 100, ()).item()
+        td["r"] = td["r"] + torch.randint(0, 100, ()).item()
         # numpy
-        td["s"] += np.random.randint(0, 100, ()).item()
+        td["s"] = td["s"] + np.random.randint(0, 100, ()).item()
         return td
 
     def test_map_seed(self):
@@ -6572,7 +6572,7 @@ class TestMap:
                 "c": torch.arange(20),
             },
             batch_size=[20],
-        ).memmap_()
+        )
         generator = torch.Generator()
         # we use 4 workers with max 5 items each,
         # making sure that no worker does more than any other.

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6580,6 +6580,7 @@ class TestMap:
             chunksize=1,
             max_tasks_per_child=5,
         )
+        print('first')
         generator.manual_seed(0)
         td_out_1 = td.map(
             TestMap.get_rand_incr,
@@ -6588,6 +6589,7 @@ class TestMap:
             chunksize=1,
             max_tasks_per_child=5,
         )
+        print('second')
         # we cannot know which worker picks which job, but since they will all have
         # a seed from 0 to 4 and produce 1 number each, we can chekc that
         # those numbers are exactly what we were expecting.

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6574,7 +6574,7 @@ class TestMap:
         # making sure that no worker does more than any other.
         generator.manual_seed(0)
         td_out_0 = td.map(
-            self.get_rand_incr,
+            TestMap.get_rand_incr,
             num_workers=4,
             generator=generator,
             chunksize=1,
@@ -6582,7 +6582,7 @@ class TestMap:
         )
         generator.manual_seed(0)
         td_out_1 = td.map(
-            self.get_rand_incr,
+            TestMap.get_rand_incr,
             num_workers=4,
             generator=generator,
             chunksize=1,

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6571,7 +6571,7 @@ class TestMap:
                 "c": torch.arange(20),
             },
             batch_size=[20],
-        )
+        ).memmap_()
         generator = torch.Generator()
         # we use 4 workers with max 5 items each,
         # making sure that no worker does more than any other.

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6563,6 +6563,7 @@ class TestMap:
         return td
 
     def test_map_seed(self):
+        mp.set_start_method('spawn')
         td = TensorDict(
             {
                 "r": torch.zeros(20, dtype=torch.int),

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -33,7 +33,6 @@ except ImportError:
     _has_h5py = False
 
 import contextlib
-from sys import platform
 
 from _utils_internal import decompose, get_available_devices, prod, TestTensorDictsBase
 from functorch import dim as ftdim
@@ -6547,10 +6546,6 @@ class TestFCD(TestTensorDictsBase):
             assert y._tensor.shape[0] == param_batch
 
 
-@pytest.mark.skipif(
-    platform.startswith("linux"),
-    reason="mp.Pool with maxtasksperchild starts more processes than needed on linux.",
-)
 class TestMap:
     """Tests for TensorDict.map that are independent from tensordict's type."""
 
@@ -6563,6 +6558,10 @@ class TestMap:
         return td
 
     def test_map_seed(self):
+        pytest.skip(
+            reason="Using max_tasks_per_child is unstable and can cause multiple processes to start over even though all jobs are completed",
+        )
+
         if mp.get_start_method(allow_none=True) is None:
             mp.set_start_method("spawn")
         td = TensorDict(
@@ -6592,6 +6591,49 @@ class TestMap:
             generator=generator,
             chunksize=1,
             max_tasks_per_child=5,
+        )
+        print("got 2")
+        # we cannot know which worker picks which job, but since they will all have
+        # a seed from 0 to 4 and produce 1 number each, we can chekc that
+        # those numbers are exactly what we were expecting.
+        assert (td_out_0["r"].sort().values == td_out_1["r"].sort().values).all(), (
+            td_out_0["r"].sort().values,
+            td_out_1["r"].sort().values,
+        )
+        assert (td_out_0["s"].sort().values == td_out_1["s"].sort().values).all(), (
+            td_out_0["s"].sort().values,
+            td_out_1["s"].sort().values,
+        )
+
+    def test_map_seed_single(self):
+        # A cheap version of the previous test
+        if mp.get_start_method(allow_none=True) is None:
+            mp.set_start_method("spawn")
+        td = TensorDict(
+            {
+                "r": torch.zeros(20, dtype=torch.int),
+                "s": torch.zeros(20, dtype=torch.int),
+                "c": torch.arange(20),
+            },
+            batch_size=[20],
+        )
+        generator = torch.Generator()
+        # we use 4 workers with max 5 items each,
+        # making sure that no worker does more than any other.
+        generator.manual_seed(0)
+        td_out_0 = td.map(
+            TestMap.get_rand_incr,
+            num_workers=1,
+            generator=generator,
+            chunksize=1,
+        )
+        print("got 1")
+        generator.manual_seed(0)
+        td_out_1 = td.map(
+            TestMap.get_rand_incr,
+            num_workers=1,
+            generator=generator,
+            chunksize=1,
         )
         print("got 2")
         # we cannot know which worker picks which job, but since they will all have

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6568,6 +6568,7 @@ class TestMap:
             {
                 "r": torch.zeros(20, dtype=torch.int),
                 "s": torch.zeros(20, dtype=torch.int),
+                "c": torch.arange(20),
             },
             batch_size=[20],
         )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -8,6 +8,7 @@ import gc
 import json
 import os
 import re
+import time
 import uuid
 
 import numpy as np
@@ -6549,18 +6550,24 @@ class TestFCD(TestTensorDictsBase):
             assert y.dims == (d0,)
             assert y._tensor.shape[0] == param_batch
 
-
+COUNTER = 0
 class TestMap:
     """Tests for TensorDict.map that are independent from tensordict's type."""
 
     @classmethod
     def get_rand_incr(cls, td):
-        print('worker', os.getpid())
+        global COUNTER
+        if COUNTER == 5:
+            print('pausing')
+            time.sleep(1000)
+            return
+        COUNTER += 1
+        # print('worker', os.getpid())
         # torch
         td["r"] += torch.randint(0, 100, ()).item()
         # numpy
         td["s"] += np.random.randint(0, 100, ()).item()
-        print(td['c'])
+        # print(td['c'])
         return td
 
     def test_map_seed(self):
@@ -6582,7 +6589,7 @@ class TestMap:
             num_workers=4,
             generator=generator,
             chunksize=1,
-            max_tasks_per_child=6,
+            max_tasks_per_child=5,
         )
         print('first')
         generator.manual_seed(0)
@@ -6591,7 +6598,7 @@ class TestMap:
             num_workers=4,
             generator=generator,
             chunksize=1,
-            max_tasks_per_child=6,
+            max_tasks_per_child=5,
         )
         print('second')
         # we cannot know which worker picks which job, but since they will all have

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6560,6 +6560,7 @@ class TestMap:
         td["r"] = td["r"] + torch.randint(0, 100, ())
         # numpy
         td["s"] = td["s"] + np.random.randint(0, 100, ())
+        print(td['c'])
         return td
 
     def test_map_seed(self):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6582,7 +6582,7 @@ class TestMap:
             num_workers=4,
             generator=generator,
             chunksize=1,
-            max_tasks_per_child=5,
+            # max_tasks_per_child=5,
         )
         print('first')
         generator.manual_seed(0)
@@ -6591,7 +6591,7 @@ class TestMap:
             num_workers=4,
             generator=generator,
             chunksize=1,
-            max_tasks_per_child=5,
+            # max_tasks_per_child=5,
         )
         print('second')
         # we cannot know which worker picks which job, but since they will all have

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6582,7 +6582,7 @@ class TestMap:
             num_workers=4,
             generator=generator,
             chunksize=1,
-            # max_tasks_per_child=5,
+            max_tasks_per_child=6,
         )
         print('first')
         generator.manual_seed(0)
@@ -6591,7 +6591,7 @@ class TestMap:
             num_workers=4,
             generator=generator,
             chunksize=1,
-            # max_tasks_per_child=5,
+            max_tasks_per_child=6,
         )
         print('second')
         # we cannot know which worker picks which job, but since they will all have

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6550,7 +6550,10 @@ class TestFCD(TestTensorDictsBase):
             assert y.dims == (d0,)
             assert y._tensor.shape[0] == param_batch
 
+
 COUNTER = 0
+
+
 class TestMap:
     """Tests for TensorDict.map that are independent from tensordict's type."""
 
@@ -6558,7 +6561,7 @@ class TestMap:
     def get_rand_incr(cls, td):
         global COUNTER
         if COUNTER == 5:
-            print('pausing')
+            print("pausing")
             time.sleep(1000)
             return
         COUNTER += 1
@@ -6571,7 +6574,7 @@ class TestMap:
         return td
 
     def test_map_seed(self):
-        mp.set_start_method('spawn')
+        mp.set_start_method("spawn")
         td = TensorDict(
             {
                 "r": torch.zeros(20, dtype=torch.int),
@@ -6591,7 +6594,7 @@ class TestMap:
             chunksize=1,
             max_tasks_per_child=5,
         )
-        print('first')
+        print("first")
         generator.manual_seed(0)
         td_out_1 = td.map(
             TestMap.get_rand_incr,
@@ -6600,7 +6603,7 @@ class TestMap:
             chunksize=1,
             max_tasks_per_child=5,
         )
-        print('second')
+        print("second")
         # we cannot know which worker picks which job, but since they will all have
         # a seed from 0 to 4 and produce 1 number each, we can chekc that
         # those numbers are exactly what we were expecting.

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6572,8 +6572,12 @@ class TestMap:
         # we use 20 workers to make sure that each worker has one item to work with
         # Using less could cause undeterministic behaviour depending on the workers'
         # speed, since we cannot tell who will pick which job.
-        td_out_0 = td.map(self.get_rand_incr, num_workers=20, seed=0, chunksize=1)
-        td_out_1 = td.map(self.get_rand_incr, num_workers=20, seed=0, chunksize=1)
+        td_out_0 = td.map(
+            self.get_rand_incr, num_workers=20, seed=0, chunksize=1, maxtasksperchild=1
+        )
+        td_out_1 = td.map(
+            self.get_rand_incr, num_workers=20, seed=0, chunksize=1, maxtasksperchild=1
+        )
         # we cannot know which worker picks which job, but since they will all have
         # a seed from 0 to 4 and produce 1 number each, we can chekc that
         # those numbers are exactly what we were expecting.

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -6555,6 +6555,7 @@ class TestMap:
 
     @classmethod
     def get_rand_incr(cls, td):
+        print('worker', os.getpid())
         # torch
         td["r"] = td["r"] + torch.randint(0, 100, ())
         # numpy


### PR DESCRIPTION
## Description

Seeds the workers in TensorDict.map pool.
The base seed can be passed to the method.
If no seed is required, the unseeded pool can be passed to the method.

The seed is aimed at having a separate seed for each worker and NOT to have reproducible results. By nature, pool's workers will pick up job on the basis of their status, hence the process is non-deterministic by nature.

The tests only verify that with torch and numpy, each worker has a predictable behaviour if the number of jobs equates the number of workers.

cc @NicolasHug 