### PR TITLE
[BugFix] No fallback on `TensorDictModule.__getattr__` for private attributes

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
+from copy import deepcopy
 from textwrap import indent
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
@@ -1227,10 +1228,13 @@ class TensorDictModule(TensorDictModuleBase):
         try:
             return super().__getattr__(name)
         except AttributeError as err1:
-            try:
-                return getattr(super().__getattr__("module"), name)
-            except Exception as err2:
-                raise err2 from err1
+            if not name.startswith("_"):
+                # no fallback for private attributes
+                try:
+                    return getattr(super().__getattr__("module"), name)
+                except Exception as err2:
+                    raise err2 from err1
+            raise
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
-from copy import deepcopy
 from textwrap import indent
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -722,6 +722,19 @@ class TestTDModule:
         assert td_out.shape == torch.Size([10, 3])
         assert td_out.get("out").shape == torch.Size([10, 3, 4])
 
+    def test_deepcopy(self):
+        class DummyModule(nn.Linear):
+            some_attribute = "a"
+
+            def __deepcopy__(self, memodict={}):
+                return DummyModule(self.in_features, self.out_features)
+
+        tdmodule = TensorDictModule(DummyModule(1, 1), in_keys=["a"], out_keys=["b"])
+        with pytest.raises(AttributeError):
+            tdmodule.__deepcopy__
+        assert tdmodule.some_attribute == "a"
+        assert isinstance(copy.deepcopy(tdmodule), TensorDictModule)
+
     def test_dispatch(self):
         tdm = TensorDictModule(nn.Linear(1, 1), ["a"], ["b"])
         td = TensorDict({"a": torch.zeros(1, 1)}, 1)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -726,7 +726,7 @@ class TestTDModule:
         class DummyModule(nn.Linear):
             some_attribute = "a"
 
-            def __deepcopy__(self, memodict={}):
+            def __deepcopy__(self, memodict=None):
                 return DummyModule(self.in_features, self.out_features)
 
         tdmodule = TensorDictModule(DummyModule(1, 1), in_keys=["a"], out_keys=["b"])


### PR DESCRIPTION
## Description

Currently, `TensorDictModule.__getattr__` falls back on the module `__getattr__` if the attribute cannot be found. For `deepcopy`, this causes `__deepcopy__` to return the module within, not the TDModule container copy.
We solve this by excluding any private attribute from fallback.

Related issue:
https://github.com/pytorch/rl/issues/1576#issuecomment-1826899930