### PR TITLE
[Feature] Saving metadata of tensorclass

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1532,7 +1532,7 @@ class TensorDict(TensorDictBase):
         def load_metadata(filepath):
             with open(filepath) as json_metadata:
                 metadata = json.load(json_metadata)
-                if metadata['_type'] != cls.__name__:
+                if metadata["_type"] != cls.__name__:
                     # return early to load from another cls
                     return metadata
                 if metadata["device"] == "None":
@@ -1548,6 +1548,7 @@ class TensorDict(TensorDictBase):
         type_name = metadata["_type"]
         if type_name != cls.__name__:
             import tensordict
+
             for other_cls in tensordict.base._ACCEPTED_CLASSES:
                 if other_cls.__name__ == type_name:
                     return other_cls.load_memmap(prefix)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -800,7 +800,7 @@ class TensorDict(TensorDictBase):
                 {
                     "shape": list(data.shape),
                     "device": str(data.device),
-                    "_type": data.__class__.__name__,
+                    "_type": str(data.__class__),
                 }
             )
             with open(filepath, "w") as json_metadata:
@@ -1466,7 +1466,7 @@ class TensorDict(TensorDictBase):
                 {
                     "shape": list(data.shape),
                     "device": str(data.device),
-                    "_type": data.__class__.__name__,
+                    "_type": str(data.__class__),
                 }
             )
             with open(filepath, "w") as json_metadata:
@@ -1532,7 +1532,7 @@ class TensorDict(TensorDictBase):
         def load_metadata(filepath):
             with open(filepath) as json_metadata:
                 metadata = json.load(json_metadata)
-                if metadata["_type"] != cls.__name__:
+                if metadata["_type"] != str(cls):
                     # return early to load from another cls
                     return metadata
                 if metadata["device"] == "None":
@@ -1546,11 +1546,11 @@ class TensorDict(TensorDictBase):
 
         metadata = load_metadata(prefix / "meta.json")
         type_name = metadata["_type"]
-        if type_name != cls.__name__:
+        if type_name != str(cls):
             import tensordict
 
             for other_cls in tensordict.base._ACCEPTED_CLASSES:
-                if other_cls.__name__ == type_name:
+                if str(other_cls) == type_name:
                     return other_cls.load_memmap(prefix)
             else:
                 raise RuntimeError(

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -800,6 +800,7 @@ class TensorDict(TensorDictBase):
                 {
                     "shape": list(data.shape),
                     "device": str(data.device),
+                    "_type": data.__class__.__name__,
                 }
             )
             with open(filepath, "w") as json_metadata:
@@ -1465,6 +1466,7 @@ class TensorDict(TensorDictBase):
                 {
                     "shape": list(data.shape),
                     "device": str(data.device),
+                    "_type": data.__class__.__name__,
                 }
             )
             with open(filepath, "w") as json_metadata:
@@ -1540,6 +1542,9 @@ class TensorDict(TensorDictBase):
             return metadata
 
         metadata = load_metadata(prefix / "meta.json")
+        type_name = metadata["_type"]
+        if type_name != cls.__name__:
+            raise RuntimeError
         out = cls({}, batch_size=metadata.pop("shape"), device=metadata.pop("device"))
 
         for key, entry_metadata in metadata.items():

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -134,16 +134,15 @@ class MemoryMappedTensor(torch.Tensor):
         """
         if isinstance(input, MemoryMappedTensor):
             if (
-                filename is None
-                or Path(filename).absolute() == Path(input._filename).absolute()
+                (filename is None and input._filename is None)
+                or (input._filename is not None and filename is not None and Path(filename).absolute() == Path(input.filename).absolute())
             ):
                 # either location was not specified, or memmap is already in the
                 # correct location, so just return the MemmapTensor unmodified
                 return input
             elif (
                 not copy_existing
-                and filename is not None
-                and Path(filename).absolute() != Path(input._filename).absolute()
+                and (input._filename is not None and filename is not None and Path(filename).absolute() != Path(input.filename).absolute())
             ):
                 raise RuntimeError(
                     f"A filename was provided but the tensor already has a file associated "

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -133,16 +133,18 @@ class MemoryMappedTensor(torch.Tensor):
 
         """
         if isinstance(input, MemoryMappedTensor):
-            if (
-                (filename is None and input._filename is None)
-                or (input._filename is not None and filename is not None and Path(filename).absolute() == Path(input.filename).absolute())
+            if filename is None or (
+                input._filename is not None
+                and filename is not None
+                and Path(filename).absolute() == Path(input.filename).absolute()
             ):
                 # either location was not specified, or memmap is already in the
                 # correct location, so just return the MemmapTensor unmodified
                 return input
-            elif (
-                not copy_existing
-                and (input._filename is not None and filename is not None and Path(filename).absolute() != Path(input.filename).absolute())
+            elif not copy_existing and (
+                input._filename is not None
+                and filename is not None
+                and Path(filename).absolute() != Path(input.filename).absolute()
             ):
                 raise RuntimeError(
                     f"A filename was provided but the tensor already has a file associated "

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -346,7 +346,7 @@ def _tensorclass_memmap(self, prefix: str | None = None, copy_existing: bool = F
             print("saving with type name", self.__class__.__name__)
             metadata = {"_type": self.__class__.__name__}
             for key, value in self._non_tensordict.items():
-                if isinstance(value, (int, bool, str, dict)):
+                if isinstance(value, (int, bool, str, float, dict)):
                     metadata[key] = value
             json.dump(metadata, f)
         prefix = prefix / "_tensordict"

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -346,7 +346,7 @@ def _tensorclass_memmap(self, prefix: str | None = None, copy_existing: bool = F
             print("saving with type name", self.__class__.__name__)
             metadata = {"_type": self.__class__.__name__}
             for key, value in self._non_tensordict.items():
-                if isinstance(value, (int, bool, str, float, dict)):
+                if isinstance(value, (int, bool, str, float, dict)) or value is None:
                     metadata[key] = value
             json.dump(metadata, f)
         prefix = prefix / "_tensordict"

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -364,9 +364,9 @@ def _tensorclass_load_memmap(cls, prefix: str):
                 f"type_name {type_name} in prefix {prefix} does not match {cls.__name__}."
             )
             # try to get the type from register
-            for cls in tensordict_lib.base._ACCEPTED_CLASSES:
-                if cls.__name__ == type_name:
-                    return cls.load_memmap(prefix)
+            for other_cls in tensordict_lib.base._ACCEPTED_CLASSES:
+                if other_cls.__name__ == type_name:
+                    return other_cls.load_memmap(prefix)
             else:
                 raise RuntimeError(
                     f"Could not find name {type_name} in {tensordict_lib.base._ACCEPTED_CLASSES}."

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -346,7 +346,10 @@ def _tensorclass_memmap(self, prefix: str | None = None, copy_existing: bool = F
             print("saving with type name", self.__class__.__name__)
             metadata = {"_type": self.__class__.__name__}
             for key, value in self._non_tensordict.items():
-                if isinstance(value, (int, bool, str, float, dict, tuple, list)) or value is None:
+                if (
+                    isinstance(value, (int, bool, str, float, dict, tuple, list))
+                    or value is None
+                ):
                     metadata[key] = value
             json.dump(metadata, f)
         prefix = prefix / "_tensordict"

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -346,7 +346,7 @@ def _tensorclass_memmap(self, prefix: str | None = None, copy_existing: bool = F
             print("saving with type name", self.__class__.__name__)
             metadata = {"_type": self.__class__.__name__}
             for key, value in self._non_tensordict.items():
-                if isinstance(value, (int, bool, str, float, dict)) or value is None:
+                if isinstance(value, (int, bool, str, float, dict, tuple, list)) or value is None:
                     metadata[key] = value
             json.dump(metadata, f)
         prefix = prefix / "_tensordict"


### PR DESCRIPTION
A simple script to test the feature

```python
import tempfile
from tensordict import tensorclass, TensorDict
import torch
import os

def print_directory_tree(path, indent=""):
    """
    Print the directory tree starting from the specified path.

    Parameters:
    - path (str): The path of the directory to print.
    - indent (str): The current indentation level for formatting.
    """
    if os.path.isdir(path):
        print(indent + os.path.basename(path) + "/")
        indent += "    "
        for item in os.listdir(path):
            print_directory_tree(os.path.join(path, item), indent)
    else:
        print(indent + os.path.basename(path))

@tensorclass
class MyClass:
    X: torch.Tensor
    td: TensorDict
    integer: int
    string: str
    dictionary: dict

@tensorclass
class MyOtherClass:
    Y: torch.Tensor

data = MyClass(
    X = torch.randn(10, 3),
    td=TensorDict({"y": torch.randn(10)}, batch_size=[10]),
    integer=3,
    string="a string",
    dictionary={"some_data": "a"},
    batch_size=[],
)

with tempfile.TemporaryDirectory() as tmpdir:
    print(tmpdir)
    data.memmap_(tmpdir)
    print_directory_tree(tmpdir)
    data2 = MyClass.load_memmap(tmpdir)
    print(data2)

    # the original class can be recovered
    data3 = MyOtherClass.load_memmap(tmpdir)
    assert isinstance(data3, MyClass)

```

cc @janeyx99 