### PR TITLE
[Performance] Make copy_ a no-op if tensors are identical

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1287,7 +1287,8 @@ class TensorDict(TensorDictBase):
                 if best_attempt and _is_tensor_collection(dest.__class__):
                     dest.update(value, inplace=True)
                 else:
-                    dest.copy_(value)
+                    if dest is not value:
+                        dest.copy_(value, non_blocking=True)
             except KeyError as err:
                 raise err
             except Exception as err:


### PR DESCRIPTION
Updated version of #510 