### PR TITLE
[Feature] Storing non-tensor data in tensordicts

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -183,11 +183,6 @@ class LazyStackedTensorDict(TensorDictBase):
                 "at least one tensordict must be provided to "
                 "StackedTensorDict to be instantiated"
             )
-        if not isinstance(tensordicts[0], TensorDictBase):
-            raise TypeError(
-                f"Expected input to be TensorDictBase instance"
-                f" but got {type(tensordicts[0])} instead."
-            )
         if stack_dim < 0:
             raise RuntimeError(
                 f"stack_dim must be non negative, got stack_dim={stack_dim}"
@@ -196,7 +191,7 @@ class LazyStackedTensorDict(TensorDictBase):
         device = tensordicts[0].device
 
         for td in tensordicts[1:]:
-            if not isinstance(td, TensorDictBase):
+            if not is_tensor_collection(td):
                 raise TypeError(
                     "Expected all inputs to be TensorDictBase instances but got "
                     f"{type(td)} instead."
@@ -1976,6 +1971,7 @@ class LazyStackedTensorDict(TensorDictBase):
     unlock = _renamed_inplace_method(unlock_)
 
     __xor__ = TensorDict.__xor__
+    __or__ = TensorDict.__or__
     _check_device = TensorDict._check_device
     _check_is_shared = TensorDict._check_is_shared
     _convert_to_tensordict = TensorDict._convert_to_tensordict
@@ -2455,6 +2451,7 @@ class _CustomOpTensorDict(TensorDictBase):
         return self._source.sorted_keys
 
     __xor__ = TensorDict.__xor__
+    __or__ = TensorDict.__or__
     __eq__ = TensorDict.__eq__
     __ne__ = TensorDict.__ne__
     __setitem__ = TensorDict.__setitem__

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -393,7 +393,7 @@ class TensorDict(TensorDictBase):
             d = {}
             for key, item1 in self.items():
                 d[key] = item1 == other.get(key)
-            return TensorDict(batch_size=self.batch_size, source=d, device=self.device)
+            return TensorDict(source=d, batch_size=self.batch_size, device=self.device)
         if isinstance(other, (numbers.Number, Tensor)):
             return TensorDict(
                 {key: value == other for key, value in self.items()},

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1062,7 +1062,7 @@ class TensorDict(TensorDictBase):
                 "Cannot pass both batch_size and batch_dims to `from_dict`."
             )
 
-        batch_size_set = [] if batch_size is None else batch_size
+        batch_size_set = torch.Size(()) if batch_size is None else batch_size
         for key, value in list(input_dict.items()):
             if isinstance(value, (dict,)):
                 # we don't know if another tensor of smaller size is coming

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1287,7 +1287,8 @@ class TensorDict(TensorDictBase):
                 if best_attempt and _is_tensor_collection(dest.__class__):
                     dest.update(value, inplace=True)
                 else:
-                    dest.copy_(value)
+                    if dest is not value:
+                        dest.copy_(value, non_blocking=True)
             except KeyError as err:
                 raise err
             except Exception as err:

--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -337,6 +337,12 @@ def _stack(
 ) -> T:
     if not list_of_tensordicts:
         raise RuntimeError("list_of_tensordicts cannot be empty")
+
+    from tensordict.tensorclass import NonTensorData
+
+    if all(isinstance(tensordict, NonTensorData) for tensordict in list_of_tensordicts):
+        return NonTensorData._stack_non_tensor(list_of_tensordicts, dim=dim)
+
     batch_size = list_of_tensordicts[0].batch_size
     if dim < 0:
         dim = len(batch_size) + dim + 1

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3684,7 +3684,14 @@ class TensorDictBase(MutableMapping):
         except Exception:
             if hasattr(array, "shape"):
                 return torch.full(array.shape, float("NaN"))
-            raise
+            from tensordict.tensorclass import NonTensorData
+
+            return NonTensorData(
+                array,
+                batch_size=self.batch_size,
+                device=self.device,
+                names=self.names if self._has_names() else None,
+            )
 
     @abc.abstractmethod
     def _convert_to_tensordict(self, dict_value: dict[str, Any]) -> T:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2126,8 +2126,14 @@ class TensorDictBase(MutableMapping):
         if len(key) > 1:
             td._create_nested_tuple(key[1:])
 
-    def copy_(self, tensordict: T) -> T:
-        """See :obj:`TensorDictBase.update_`."""
+    def copy_(self, tensordict: T, non_blocking: bool = None) -> T:
+        """See :obj:`TensorDictBase.update_`.
+
+        The non-blocking argument will be ignored and is just present for
+        compatibility with :func:`torch.Tensor.copy_`.
+        """
+        if non_blocking is False:
+            raise ValueError("non_blocking=False isn't supported in TensorDict.")
         return self.update_(tensordict)
 
     def copy_at_(self, tensordict: T, idx: IndexType) -> T:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -142,6 +142,22 @@ class TensorDictBase(MutableMapping):
         ...
 
     @abc.abstractmethod
+    def __or__(self, other):
+        """OR operation over two tensordicts, for evey key.
+
+        The two tensordicts must have the same key set.
+
+        Args:
+            other (TensorDictBase, dict, or float): the value to compare against.
+
+        Returns:
+            a new TensorDict instance with all tensors are boolean
+            tensors of the same shape as the original tensors.
+
+        """
+        ...
+
+    @abc.abstractmethod
     def __eq__(self, other: object) -> T:
         """Compares two tensordicts against each other, for every key. The two tensordicts must have the same key set.
 
@@ -1946,6 +1962,18 @@ class TensorDictBase(MutableMapping):
         if isinstance(value, NonTensorData):
             return value.data
         return value
+
+    def filter_non_tensor_data(self) -> T:
+        """Filters out all non-tensor-data."""
+        from tensordict.tensorclass import NonTensorData
+
+        def _filter(x):
+            if not isinstance(x, NonTensorData):
+                if is_tensor_collection(x):
+                    return x.filter_non_tensor_data()
+                return x
+
+        return self._apply_nest(_filter, call_on_nested=True)
 
     def _convert_inplace(self, inplace, key):
         if inplace is not False:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3511,15 +3511,15 @@ class TensorDictBase(MutableMapping):
             array = array.item()
         if isinstance(array, list):
             array = np.asarray(array)
-        if not isinstance(array, np.ndarray) and hasattr(array, 'numpy'):
+        if not isinstance(array, np.ndarray) and hasattr(array, "numpy"):
             # tf.Tensor with no shape can't be converted otherwise
             array = array.numpy()
         try:
             return torch.as_tensor(array, device=self.device)
         except Exception:
-            if hasattr(array, 'shape'):
+            if hasattr(array, "shape"):
                 return torch.full(array.shape, float("NaN"))
-            return torch.tensor(float('nan'))
+            return torch.tensor(float("nan"))
 
     @abc.abstractmethod
     def _convert_to_tensordict(self, dict_value: dict[str, Any]) -> T:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3684,7 +3684,7 @@ class TensorDictBase(MutableMapping):
         except Exception:
             if hasattr(array, "shape"):
                 return torch.full(array.shape, float("NaN"))
-            return torch.tensor(float("nan"))
+            raise
 
     @abc.abstractmethod
     def _convert_to_tensordict(self, dict_value: dict[str, Any]) -> T:

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -585,6 +585,7 @@ class MemoryMappedTensor(torch.Tensor):
 #####################
 # File handler
 # borrowed from mp.heap
+
 if sys.platform == "win32":
     import _winapi
 
@@ -647,8 +648,7 @@ else:
                 st = os.statvfs(d)
                 if st.f_bavail * st.f_frsize >= size:  # enough free space?
                     return d
-            tmpdir = util.get_temp_dir()
-            return tmpdir
+            return util.get_temp_dir()
 
     def _reduce_handler(handler):
         if handler.fd == -1:

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -133,17 +133,18 @@ class MemoryMappedTensor(torch.Tensor):
 
         """
         if isinstance(input, MemoryMappedTensor):
-            if (
-                filename is None
-                or Path(filename).absolute() == Path(input._filename).absolute()
+            if filename is None or (
+                input._filename is not None
+                and filename is not None
+                and Path(filename).absolute() == Path(input.filename).absolute()
             ):
                 # either location was not specified, or memmap is already in the
                 # correct location, so just return the MemmapTensor unmodified
                 return input
-            elif (
-                not copy_existing
+            elif not copy_existing and (
+                input._filename is not None
                 and filename is not None
-                and Path(filename).absolute() != Path(input._filename).absolute()
+                and Path(filename).absolute() != Path(input.filename).absolute()
             ):
                 raise RuntimeError(
                     f"A filename was provided but the tensor already has a file associated "

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -561,8 +561,8 @@ class MemoryMappedTensor(torch.Tensor):
             out.parent_shape = self.parent_shape
         return out
 
-    @implement_for("torch", None, "2.0")  # noqa: F811
-    def __getitem__(self, item):
+    @implement_for("torch", None, "2.0")
+    def __getitem__(self, item):  # noqa: F811
         try:
             out = super().__getitem__(item)
         except ValueError as err:

--- a/tensordict/memmap_deprec.py
+++ b/tensordict/memmap_deprec.py
@@ -526,7 +526,9 @@ class MemmapTensor:
     def numpy(self) -> np.ndarray:
         return self._tensor.numpy()
 
-    def copy_(self, other: torch.Tensor | MemmapTensor) -> MemmapTensor:
+    def copy_(
+        self, other: torch.Tensor | MemmapTensor, non_blocking: bool = False
+    ) -> MemmapTensor:
         if isinstance(other, MemmapTensor) and other.filename == self.filename:
             if not self.shape == other.shape:
                 raise ValueError(

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 import torch
 from cloudpickle import dumps as cloudpickle_dumps, loads as cloudpickle_loads
 from tensordict._td import is_tensor_collection, TensorDictBase
-from tensordict._tensordict import unravel_key_list
+from tensordict._tensordict import _unravel_key_to_tuple, unravel_key_list
 from tensordict.functional import make_tensordict
 
 from tensordict.nn.functional_modules import (
@@ -255,9 +255,7 @@ class dispatch:
                 if isinstance(dest, str):
                     dest = getattr(_self, dest)
                 for key in source:
-                    expected_key = (
-                        self.separator.join(key) if isinstance(key, tuple) else key
-                    )
+                    expected_key = self.separator.join(_unravel_key_to_tuple(key))
                     if len(args):
                         tensordict_values[key] = args[0]
                         args = args[1:]

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -841,6 +841,10 @@ class TensorDictParams(TensorDictBase, nn.Module):
     def __xor__(self, other):
         ...
 
+    @_fallback
+    def __or__(self, other):
+        ...
+
     _check_device = TensorDict._check_device
     _check_is_shared = TensorDict._check_is_shared
 

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -509,7 +509,7 @@ class PersistentTensorDict(TensorDictBase):
             return out
         return TensorDict(
             {},
-            device=torch.device("cpu"),
+            device=self.device,
             batch_size=self.batch_size,
             names=self.names if self._has_names() else None,
         )

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -498,6 +498,22 @@ class PersistentTensorDict(TensorDictBase):
     def device(self):
         return self._device
 
+    def empty(self, recurse=False) -> T:
+        if recurse:
+            out = self.empty(recurse=False)
+            for key, val in self.items():
+                if is_tensor_collection(val):
+                    out._set_str(
+                        key, val.empty(recurse=True), inplace=False, validated=True
+                    )
+            return out
+        return TensorDict(
+            {},
+            device=torch.device("cpu"),
+            batch_size=self.batch_size,
+            names=self.names if self._has_names() else None,
+        )
+
     def entry_class(self, key: NestedKey) -> type:
         entry_class = self._get_metadata(key)
         is_array = entry_class.get("array", None)
@@ -1017,6 +1033,7 @@ class PersistentTensorDict(TensorDictBase):
     __eq__ = TensorDict.__eq__
     __ne__ = TensorDict.__ne__
     __xor__ = TensorDict.__xor__
+    __or__ = TensorDict.__or__
     _apply_nest = TensorDict._apply_nest
     _check_device = TensorDict._check_device
     _check_is_shared = TensorDict._check_is_shared

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1319,6 +1319,7 @@ class NonTensorData:
 
         return LazyStackedTensorDict(*list_of_non_tensor, stack_dim=dim)
 
+    @classmethod
     def __torch_function__(
         cls,
         func: Callable,

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1247,11 +1247,7 @@ class NonTensorData:
 
             @functools.wraps(_or)
             def __or__(self, other):
-                if not is_tensor_collection(other):
-                    return torch.full(
-                        self.batch_size, self.data | other, device=self.device
-                    )
-                elif isinstance(other, NonTensorData):
+                if isinstance(other, NonTensorData):
                     return torch.full(
                         self.batch_size, self.data | other.data, device=self.device
                     )

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1205,7 +1205,6 @@ class NonTensorData:
 
         old_eq = self.__class__.__eq__
         if old_eq is _eq:
-            print("upgrading")
 
             @functools.wraps(_eq)
             def __eq__(self, other):

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1295,7 +1295,7 @@ class NonTensorData:
 
     def empty(self, recurse=False):
         return NonTensorData(
-            data=None,
+            data=self.data,
             batch_size=self.batch_size,
             names=self.names if self._has_names() else None,
             device=self.device,

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1205,6 +1205,7 @@ class NonTensorData:
 
         old_eq = self.__class__.__eq__
         if old_eq is _eq:
+            # Patch only the first time a class is created
 
             @functools.wraps(_eq)
             def __eq__(self, other):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1153,6 +1153,8 @@ def _split_tensordict(td, chunksize, num_chunks, num_workers, dim):
         num_chunks = min(td.shape[dim], num_chunks)
         return td.chunk(num_chunks, dim=dim)
     else:
+        if chunksize == 0:
+            return td.unbind(dim=dim)
         chunksize = min(td.shape[dim], chunksize)
         return td.split(chunksize, dim=dim)
 

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import math
+import pathlib
+import shutil
 import tempfile
 
 import numpy as np
@@ -199,8 +201,13 @@ class TestTensorDictsBase:
     for device in get_available_devices():
         TYPES_DEVICES += [["sub_td2", device]]
 
+    temp_path_memmap = tempfile.TemporaryDirectory()
+
     def memmap_td(self, device):
-        return self.td(device).memmap_()
+        path = pathlib.Path(self.temp_path_memmap.name)
+        shutil.rmtree(path)
+        path.mkdir()
+        return self.td(device).memmap_(path)
 
     TYPES_DEVICES += [["memmap_td", torch.device("cpu")]]
     TYPES_DEVICES_NOLAZY += [["memmap_td", torch.device("cpu")]]

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -301,6 +301,7 @@ class TestTensorDictsBase:
         td = self.td(device)
         return td.set_non_tensor(
             ("data", "non_tensor"),
+            # this is allowed since nested NonTensorData are automatically unwrapped
             NonTensorData(
                 "some text data",
                 batch_size=td.batch_size,

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -337,3 +337,6 @@ def decompose(td):
 class DummyPicklableClass:
     def __init__(self, value):
         self.value = value
+
+    def __eq__(self, other):
+        return self.value == other.value

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2231,8 +2231,7 @@ class TestTensorDicts(TestTensorDictsBase):
         assert recursive_checker(td_dict)
         if td_name == "td_with_non_tensor":
             assert td_dict["data"]["non_tensor"] == "some text data"
-        # TODO: https://github.com/pytorch/tensordict/pull/594 will make this possible
-        # assert (TensorDict.from_dict(td_dict) == td).all()
+        assert (TensorDict.from_dict(td_dict) == td).all()
 
     @pytest.mark.parametrize(
         "index", ["tensor1", "mask", "int", "range", "tensor2", "slice_tensor"]


### PR DESCRIPTION
## Description

The only bit remaining with this API is a proper interaction with elements in a state_dict that are not tensors. 
We just need to detect if an item is or isn't a tensor and if not call `set_non_tensor`. At load time, loading from the `memmap` file structure is already coded, the only thing will be to make sure that the `load_state_dict` hooks are compatible with this. GIven that this is a slightly different track than the core functionality proposed by this PR, I will make this in a separate one.

@fegin 
