### PR TITLE
[Feature] Best intention stack

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -53,6 +53,7 @@ from tensordict.utils import (
     infer_size_impl,
     is_tensorclass,
     KeyedJaggedTensor,
+    lazy_legacy,
     lock_blocked,
     NestedKey,
 )
@@ -780,6 +781,13 @@ class LazyStackedTensorDict(TensorDictBase):
                     out.hook_out = self.hook_out
                     out.hook_in = self.hook_in
                     out._is_vmapped = self._is_vmapped
+                    incr = 0 if not self._is_vmapped else 1
+                    out._batch_size = (
+                        self._batch_size
+                        + out.batch_size[(len(self._batch_size) + incr) :]
+                    )
+                elif not lazy_legacy():
+                    # it must be a TensorDict
                     incr = 0 if not self._is_vmapped else 1
                     out._batch_size = (
                         self._batch_size

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -5546,6 +5546,19 @@ class TestLazyStackedTensorDict:
         stack = torch.stack([td, td2])
         assert set(stack.keys(True, True)) == {"a"}
 
+    def test_best_intention_stack(self):
+        td0 = TensorDict({"a": 1, "b": TensorDict({"c": 2}, [])}, [])
+        td1 = TensorDict({"a": 1, "b": TensorDict({"d": 2}, [])}, [])
+        with set_lazy_legacy(False):
+            td = torch.stack([td0, td1])
+        assert isinstance(td, TensorDict)
+        assert isinstance(td.get("b"), LazyStackedTensorDict)
+        td1 = TensorDict({"a": 1, "b": TensorDict({"c": [2]}, [])}, [])
+        with set_lazy_legacy(False):
+            td = torch.stack([td0, td1])
+        assert isinstance(td, TensorDict)
+        assert isinstance(td.get("b"), LazyStackedTensorDict)
+
 
 @pytest.mark.skipif(
     not _has_torchsnapshot, reason=f"torchsnapshot not found: err={TORCHSNAPSHOT_ERR}"


### PR DESCRIPTION
## Description

Allows torch.stack to return a TensorDict whenever possible, and a LazyStackedTensorDict otherwise.
This is aimed at simplifying stacking tensordicts together while preserving the features of LazyStackedTDs.

Currently, this behaviour is only enabled when `set_lazy_legacy(False)` is called. In the future, `lazy_legacy()` will be `False` by default making this behaviour the default in tensordict.

In the PyTorch PR, this will be the only accepted behaviour of `torch.stack`.

cc @shagunsodhani  @matteobettini 