### PR TITLE
[Feature] Improve in-place ops for TensorDictParams

### DIFF
--- a/tensordict/__init__.py
+++ b/tensordict/__init__.py
@@ -25,8 +25,8 @@ from tensordict.utils import (
     set_lazy_legacy,
 )
 from tensordict._pytree import *
-
 from tensordict._tensordict import unravel_key, unravel_key_list
+from tensordict.nn import TensorDictParams
 
 try:
     from tensordict.version import __version__
@@ -53,5 +53,3 @@ __all__ = [
     "dense_stack_tds",
     "NonTensorData",
 ]
-
-# from tensordict._pytree import *

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4017,8 +4017,11 @@ class TensorDictBase(MutableMapping):
     # Filling
     def zero_(self) -> T:
         """Zeros all tensors in the tensordict in-place."""
-        for key in self.keys():
-            self.fill_(key, 0)
+
+        def fn(item):
+            item.zero_()
+
+        self._fast_apply(fn=fn, call_on_nested=True)
         return self
 
     def fill_(self, key: NestedKey, value: float | bool) -> T:

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -213,6 +213,14 @@ def _carry_over(func):
     return new_func
 
 
+def _apply_on_data(func):
+    @wraps(func)
+    def new_func(self, *args, **kwargs):
+        return getattr(self.data, func.__name__)(*args, **kwargs)
+
+    return new_func
+
+
 class TensorDictParams(TensorDictBase, nn.Module):
     r"""Holds a TensorDictBase instance full of parameters.
 
@@ -428,10 +436,6 @@ class TensorDictParams(TensorDictBase, nn.Module):
     ) -> TensorDictBase:
         ...
 
-    @_unlock_and_set
-    def apply_(self, fn: Callable, *others) -> TensorDictBase:
-        ...
-
     def map(
         self,
         fn: Callable,
@@ -514,9 +518,14 @@ class TensorDictParams(TensorDictBase, nn.Module):
     def clone(self, recurse: bool = True) -> TensorDictBase:
         """Clones the TensorDictParams.
 
-        The effect of this call is different from a regular torch.Tensor.clone call
-        in that it will create a TensorDictParams instance with a new copy of the
-        parameters and buffers __detached__ from the current graph.
+        .. warning::
+            The effect of this call is different from a regular torch.Tensor.clone call
+            in that it will create a TensorDictParams instance with a new copy of the
+            parameters and buffers __detached__ from the current graph. For a
+            regular clone (ie, cloning leaf parameters onto a new tensor that
+            is part of the graph), simply call
+
+                >>> params.apply(torch.clone)
 
         See :meth:`tensordict.TensorDictBase.clone` for more info on the clone
         method.
@@ -650,10 +659,6 @@ class TensorDictParams(TensorDictBase, nn.Module):
 
     @_unlock_and_set
     def _create_nested_str(self, *args, **kwargs):
-        ...
-
-    @_fallback
-    def _stack_onto_(self, *args, **kwargs):
         ...
 
     @_fallback_property
@@ -983,6 +988,73 @@ class TensorDictParams(TensorDictBase, nn.Module):
                 yield k, v
                 continue
             yield k, self._apply_get_post_hook(v)
+
+    @_apply_on_data
+    def zero_(self) -> T:
+        ...
+
+    @_apply_on_data
+    def fill_(self, key: NestedKey, value: float | bool) -> T:
+        ...
+
+    @_apply_on_data
+    def copy_(self, tensordict: T, non_blocking: bool = None) -> T:
+        ...
+
+    @_apply_on_data
+    def set_at_(self, key: NestedKey, value: CompatibleType, index: IndexType) -> T:
+        ...
+
+    @_apply_on_data
+    def set_(
+        self,
+        key: NestedKey,
+        item: CompatibleType,
+    ) -> T:
+        ...
+
+    @_apply_on_data
+    def _stack_onto_(
+        self,
+        list_item: list[CompatibleType],
+        dim: int,
+    ) -> T:
+        ...
+
+    @_apply_on_data
+    def _stack_onto_at_(
+        self,
+        key: str,
+        list_item: list[CompatibleType],
+        dim: int,
+        idx: IndexType,
+    ) -> T:
+        ...
+
+    @_apply_on_data
+    def update_(
+        self,
+        input_dict_or_td: dict[str, CompatibleType] | T,
+        clone: bool = False,
+        *,
+        keys_to_update: Sequence[NestedKey] | None = None,
+    ) -> T:
+        ...
+
+    @_apply_on_data
+    def update_at_(
+        self,
+        input_dict_or_td: dict[str, CompatibleType] | T,
+        idx: IndexType,
+        clone: bool = False,
+        *,
+        keys_to_update: Sequence[NestedKey] | None = None,
+    ) -> T:
+        ...
+
+    @_apply_on_data
+    def apply_(self, fn: Callable, *others) -> T:
+        ...
 
     def _apply(self, fn, recurse=True):
         """Modifies torch.nn.Module._apply to work with Buffer class."""

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -514,6 +514,11 @@ class PersistentTensorDict(TensorDictBase):
             names=self.names if self._has_names() else None,
         )
 
+    def zero_(self) -> T:
+        for key in self.keys():
+            self.fill_(key, 0)
+        return self
+
     def entry_class(self, key: NestedKey) -> type:
         entry_class = self._get_metadata(key)
         is_array = entry_class.get("array", None)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2915,6 +2915,21 @@ class TestTensorDictParams:
             assert val.data_ptr() != td.get(key).data_ptr()
             assert (val == td.get(key)).all()
 
+    def test_tdparams_clone_tying(self):
+        c = nn.Parameter(torch.zeros((), requires_grad=True))
+        td = TensorDict(
+            {
+                "a": {
+                    "b": {"c": c},
+                },
+                "c": c,
+            },
+            [],
+        )
+        td = TensorDictParams(td, no_convert=True)
+        td_clone = td.clone()
+        assert td_clone["c"] is td_clone["a", "b", "c"]
+
     def test_inplace_ops(self):
         td = TensorDict(
             {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2915,6 +2915,23 @@ class TestTensorDictParams:
             assert val.data_ptr() != td.get(key).data_ptr()
             assert (val == td.get(key)).all()
 
+    def test_inplace_ops(self):
+        td = TensorDict(
+            {
+                "a": {
+                    "b": {"c": torch.zeros((), requires_grad=True)},
+                    "d": torch.zeros((), requires_grad=True),
+                },
+                "e": torch.zeros((), requires_grad=True),
+            },
+            [],
+        )
+        param_td = TensorDictParams(td)
+        param_td.copy_(param_td.data.apply(lambda x: x + 1))
+        assert (param_td == 1).all()
+        param_td.zero_()
+        assert (param_td == 0).all()
+
 
 class TestCompositeDist:
     def test_const(self):


### PR DESCRIPTION
Makes it possible to call `zero_` and such on TensorDictParams, and makes these ops active on the data.

Also clarifies the docstring of `clone`