### PR TITLE
[Performance] Better shared/memmap inheritance and faster exclude

### DIFF
--- a/benchmarks/distributed/distributed_benchmark_test.py
+++ b/benchmarks/distributed/distributed_benchmark_test.py
@@ -10,7 +10,7 @@ import time
 import pytest
 import torch
 
-from tensordict import MemoryMappedTensor, TensorDict
+from tensordict import TensorDict
 from torch.distributed import rpc
 
 MAIN_NODE = "Main"
@@ -66,15 +66,12 @@ def exec_distributed_test(rank_node):
             # create a tensordict is 1Gb big, stored on disk, assuming that both nodes have access to /tmp/
             tensordict = TensorDict(
                 {
-                    "memmap": MemoryMappedTensor.empty(
-                        (1000, 640, 640, 3),
-                        dtype=torch.uint8,
-                        filename=tmpdir / "mmap.memmap",
+                    "memmap": torch.empty((), dtype=torch.uint8).expand(
+                        (1000, 640, 640, 3)
                     )
                 },
                 [1000],
-                _is_memmap=True,
-            )
+            ).memmap_(tmpdir, copy_existing=False)
             assert tensordict.is_memmap()
 
             while True:

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2574,9 +2574,7 @@ class _CustomOpTensorDict(TensorDictBase):
             raise RuntimeError("Cannot call select inplace on a lazy tensordict.")
         return self.to_tensordict()._select(*keys, inplace=False, strict=strict)
 
-    def _exclude(
-        self, *keys: str, inplace: bool = False
-    ) -> _CustomOpTensorDict:
+    def _exclude(self, *keys: str, inplace: bool = False) -> _CustomOpTensorDict:
         if inplace:
             raise RuntimeError("Cannot call exclude inplace on a lazy tensordict.")
         return self.to_tensordict()._exclude(*keys, inplace=False)
@@ -2791,6 +2789,10 @@ class _CustomOpTensorDict(TensorDictBase):
     @erase_cache
     def _propagate_lock(self, lock_ids):
         return self._source._propagate_lock(lock_ids)
+
+    @erase_cache
+    def _propagate_unlock(self):
+        return self._source._propagate_unlock()
 
     lock = _renamed_inplace_method(lock_)
     unlock = _renamed_inplace_method(unlock_)

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2283,7 +2283,7 @@ class LazyStackedTensorDict(TensorDictBase):
             if dim1 == dim0 + 1:
                 return LazyStackedTensorDict(*self.tensordicts, stack_dim=dim1)
             return LazyStackedTensorDict(
-                *map(lambda td: td.transpose(dim0, dim1 - 1), self.tensordicts),
+                *(td.transpose(dim0, dim1 - 1) for td in self.tensordicts),
                 stack_dim=dim1,
             )
         elif dim1 == self.stack_dim:
@@ -2292,14 +2292,14 @@ class LazyStackedTensorDict(TensorDictBase):
             if dim0 + 1 == dim1:
                 return LazyStackedTensorDict(*self.tensordicts, stack_dim=dim0)
             return LazyStackedTensorDict(
-                *map(lambda td: td.transpose(dim0 + 1, dim1), self.tensordicts),
+                *(td.transpose(dim0 + 1, dim1) for td in self.tensordicts),
                 stack_dim=dim0,
             )
         else:
             dim0 = dim0 if dim0 < self.stack_dim else dim0 - 1
             dim1 = dim1 if dim1 < self.stack_dim else dim1 - 1
             return LazyStackedTensorDict(
-                *map(lambda td: td.transpose(dim0, dim1), self.tensordicts),
+                *(td.transpose(dim0, dim1) for td in self.tensordicts),
                 stack_dim=self.stack_dim,
             )
 
@@ -2485,7 +2485,6 @@ class _CustomOpTensorDict(TensorDictBase):
             return self._set_str(key[0], value, inplace=inplace, validated=validated)
         source = self._source._get_str(key[0], None)
         if source is None:
-            print("self", self)
             source = self._source._create_nested_str(key[0])
         nested = type(self)(
             source,

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2522,8 +2522,6 @@ class _CustomOpTensorDict(TensorDictBase):
             batch_size=self.batch_size,
             device=self.device,
             _run_checks=False,
-            _is_memmap=self.is_memmap(),
-            _is_shared=self.is_shared(),
         ).exclude(*keys, inplace=True)
 
     def clone(self, recurse: bool = True) -> T:

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1813,18 +1813,17 @@ class TensorDict(TensorDictBase):
                     subkey = []
                 else:
                     key, subkey = key[0], key[1:]
-                try:
-                    source[key] = self.get(key)
-                    if len(subkey):
-                        if keys_to_select is None:
-                            # delay creation of defaultdict
-                            keys_to_select = defaultdict(list)
-                        keys_to_select[key].append(subkey)
-                except KeyError as err:
-                    if not strict:
-                        continue
-                    else:
-                        raise KeyError(f"select failed to get key {key}") from err
+
+                val = self._get_str(key, default=None if not strict else NO_DEFAULT)
+                if val is None:
+                    continue
+                source[key] = val
+                if len(subkey):
+                    if keys_to_select is None:
+                        # delay creation of defaultdict
+                        keys_to_select = defaultdict(list)
+                    keys_to_select[key].append(subkey)
+
             if keys_to_select is not None:
                 for key, val in keys_to_select.items():
                     source[key] = source[key].select(

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2531,21 +2531,19 @@ class _SubTensorDict(TensorDictBase):
             _run_checks=False,
         )
 
-    def _select(self, *keys: str, inplace: bool = False, strict: bool = True) -> T:
+    def _select(
+        self, *keys: str, inplace: bool = False, strict: bool = True
+    ) -> _CustomOpTensorDict:
         if inplace:
-            self._source = self._source._select(*keys, strict=strict)
-            return self
-        result = self._source._select(*keys, strict=strict)._get_sub_tensordict(
-            self.idx
-        )
-        return result
+            raise RuntimeError("Cannot call select inplace on a lazy tensordict.")
+        return self.to_tensordict()._select(*keys, inplace=False, strict=strict)
 
-    def _exclude(self, *keys: str, inplace: bool = False) -> T:
+    def _exclude(
+        self, *keys: str, inplace: bool = False
+    ) -> _CustomOpTensorDict:
         if inplace:
-            self._source = self._source._exclude(*keys)
-            return self
-        result = self._source._exclude(*keys)._get_sub_tensordict(self.idx)
-        return result
+            raise RuntimeError("Cannot call exclude inplace on a lazy tensordict.")
+        return self.to_tensordict()._exclude(*keys, inplace=False)
 
     def expand(self, *args: int, inplace: bool = False) -> T:
         if len(args) == 1 and isinstance(args[0], Sequence):

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1614,7 +1614,7 @@ class TensorDict(TensorDictBase):
             if not prefix.exists():
                 os.makedirs(prefix, exist_ok=True)
             metadata = {}
-        if inplace and self.is_shared() and self.device.type == "cpu":
+        if inplace and self._is_shared:
             raise RuntimeError(
                 "memmap and shared memory are mutually exclusive features."
             )
@@ -2207,9 +2207,9 @@ class _SubTensorDict(TensorDictBase):
                     dtype=value.dtype,
                     device=self.device,
                 )
-                if self.is_shared() and self.device.type == "cpu":
+                if self._is_shared:
                     value_expand.share_memory_()
-                elif self.is_memmap():
+                elif self._is_memmap:
                     value_expand = MemoryMappedTensor.from_tensor(value_expand)
             parent._set_str(key, value_expand, inplace=False, validated=validated)
 

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2531,9 +2531,7 @@ class _SubTensorDict(TensorDictBase):
             _run_checks=False,
         )
 
-    def _select(
-        self, *keys: str, inplace: bool = False, strict: bool = True
-    ) -> T:
+    def _select(self, *keys: str, inplace: bool = False, strict: bool = True) -> T:
         if inplace:
             raise RuntimeError("Cannot call select inplace on a lazy tensordict.")
         return self.to_tensordict()._select(*keys, inplace=False, strict=strict)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2533,14 +2533,12 @@ class _SubTensorDict(TensorDictBase):
 
     def _select(
         self, *keys: str, inplace: bool = False, strict: bool = True
-    ) -> _CustomOpTensorDict:
+    ) -> T:
         if inplace:
             raise RuntimeError("Cannot call select inplace on a lazy tensordict.")
         return self.to_tensordict()._select(*keys, inplace=False, strict=strict)
 
-    def _exclude(
-        self, *keys: str, inplace: bool = False
-    ) -> _CustomOpTensorDict:
+    def _exclude(self, *keys: str, inplace: bool = False) -> T:
         if inplace:
             raise RuntimeError("Cannot call exclude inplace on a lazy tensordict.")
         return self.to_tensordict()._exclude(*keys, inplace=False)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -785,10 +785,10 @@ class TensorDict(TensorDictBase):
             names=names,
             _run_checks=False,
         )
-        if self.is_memmap() and _index_preserve_data_ptr(index):
+        if self._is_memmap and _index_preserve_data_ptr(index):
             result._is_memmap = True
             result.lock_()
-        elif self.is_shared() and _index_preserve_data_ptr(index):
+        elif self._is_shared and _index_preserve_data_ptr(index):
             result._is_shared = True
             result.lock_()
         return result
@@ -2042,8 +2042,6 @@ class TensorDict(TensorDictBase):
 class _SubTensorDict(TensorDictBase):
     """A TensorDict that only sees an index of the stored tensors."""
 
-    _is_shared = False
-    _is_memmap = False
     _lazy = True
     _inplace_set = True
     _safe = False
@@ -2078,6 +2076,15 @@ class _SubTensorDict(TensorDictBase):
 
         if batch_size is not None and batch_size != self.batch_size:
             raise RuntimeError("batch_size does not match self.batch_size.")
+
+    # These attributes should never be set
+    @property
+    def _is_shared(self):
+        return self._source._is_shared
+
+    @property
+    def _is_memmap(self):
+        return self._source._is_memmap
 
     @staticmethod
     def _convert_ellipsis(idx, shape):

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4031,11 +4031,15 @@ class TensorDictBase(MutableMapping):
                 del target[key]
         return target
 
-    def _maybe_set_shared_attributes(self, result):
+    def _maybe_set_shared_attributes(self, result, lock=False):
         if self.is_shared():
             result._is_shared = True
+            if lock:
+                result.lock_()
         elif self.is_memmap():
             result._is_memmap = True
+            if lock:
+                result.lock_()
 
     def to_tensordict(self) -> T:
         """Returns a regular TensorDict instance from the TensorDictBase.
@@ -4058,7 +4062,7 @@ class TensorDictBase(MutableMapping):
             names=self.names if self._has_names() else None,
         )
 
-    def clone(self, recurse: bool = True) -> T:
+    def clone(self, recurse: bool = True, **kwargs) -> T:
         """Clones a TensorDictBase subclass instance onto a new TensorDictBase subclass of the same type.
 
         To create a TensorDict instance from any other TensorDictBase subtype, call the :meth:`~.to_tensordict` method
@@ -4070,7 +4074,7 @@ class TensorDictBase(MutableMapping):
                 tree structure will be copied. Defaults to ``True``.
 
         """
-        result = self._clone(recurse=recurse)
+        result = self._clone(recurse=recurse, **kwargs)
         if not recurse and (result.is_shared() or result.is_memmap()):
             result.lock_()
         return result

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4032,7 +4032,8 @@ class TensorDictBase(MutableMapping):
         return target
 
     def _maybe_set_shared_attributes(self, result, lock=False):
-        if self.is_shared():
+        # We must use _is_shared to avoid having issues with CUDA tensordicts
+        if self._is_shared:
             result._is_shared = True
             if lock:
                 result.lock_()
@@ -4513,7 +4514,7 @@ class TensorDictBase(MutableMapping):
             result = self._clone(recurse=False).unflatten_keys(
                 separator=separator, inplace=True
             )
-            if self.is_shared() or self.is_memmap():
+            if self._is_shared or self._is_memmap:
                 result.lock_()
             return result
         else:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4418,10 +4418,9 @@ class TensorDictBase(MutableMapping):
                 result._set_str(
                     leaf_flat, self.get(leaf), validated=True, inplace=False
                 )
-            shared = result._is_shared = self._is_shared
-            mmap = result._is_memmap = self._is_memmap
-            if shared or mmap:
-                result._is_locked = True
+            self._maybe_set_shared_attributes(result)
+            if result._is_shared or result._is_memmap:
+                result.lock_()
             return result
 
     @cache  # noqa: B019

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -616,7 +616,7 @@ class TensorDictBase(MutableMapping):
             return self._legacy_unsqueeze(*args, **kwargs)
         else:
             result = self._unsqueeze(*args, **kwargs)
-            if result.is_memmap() or result.is_shared():
+            if result._is_memmap or result._is_shared:
                 result.lock_()
             return result
 
@@ -671,7 +671,7 @@ class TensorDictBase(MutableMapping):
             return self._legacy_squeeze(*args, **kwargs)
         else:
             result = self._squeeze(*args, **kwargs)
-            if result.is_memmap() or result.is_shared():
+            if result._is_memmap or result._is_shared:
                 result.lock_()
             return result
 
@@ -862,7 +862,7 @@ class TensorDictBase(MutableMapping):
             return self._legacy_view(*shape, size=size)
         else:
             result = self._view(size=size) if size is not None else self._view(*shape)
-            if result.is_shared() or result.is_memmap():
+            if result._is_shared or result._is_memmap:
                 result.lock_()
             return result
 
@@ -922,7 +922,7 @@ class TensorDictBase(MutableMapping):
             if dim0 == dim1:
                 return self
             result = self._transpose(dim0, dim1)
-            if result.is_shared() or result.is_memmap():
+            if result._is_shared or result._is_memmap:
                 result.lock_()
             return result
 
@@ -1004,7 +1004,7 @@ class TensorDictBase(MutableMapping):
             return self._legacy_permute(*args, **kwargs)
         else:
             result = self._permute(*args, **kwargs)
-            if result.is_shared() or result.is_memmap():
+            if result._is_shared or result._is_memmap:
                 result.lock_()
             return result
 
@@ -4037,7 +4037,7 @@ class TensorDictBase(MutableMapping):
             result._is_shared = True
             if lock:
                 result.lock_()
-        elif self.is_memmap():
+        elif self._is_memmap:
             result._is_memmap = True
             if lock:
                 result.lock_()
@@ -4076,7 +4076,7 @@ class TensorDictBase(MutableMapping):
 
         """
         result = self._clone(recurse=recurse, **kwargs)
-        if not recurse and (result.is_shared() or result.is_memmap()):
+        if not recurse and (result._is_shared or result._is_memmap):
             result.lock_()
         return result
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -596,8 +596,7 @@ class TensorDictBase(MutableMapping):
     def unsqueeze(self, dim: int) -> T:
         ...
 
-    @property
-    def unsqueeze(self):
+    def unsqueeze(self, *args, **kwargs):
         """Unsqueezes all tensors for a dimension comprised in between `-td.batch_dims` and `td.batch_dims` and returns them in a new tensordict.
 
         Args:
@@ -614,40 +613,16 @@ class TensorDictBase(MutableMapping):
             torch.Size([3, 1, 4, 2])
         """
         if lazy_legacy():
-            return self._legacy_unsqueeze
+            return self._legacy_unsqueeze(*args, **kwargs)
         else:
-            return self._unsqueeze
+            result = self._unsqueeze(*args, **kwargs)
+            if result.is_memmap() or result.is_shared():
+                result.lock_()
+            return result
 
+    @abc.abstractmethod
     def _unsqueeze(self, dim):
-        # make the dim positive
-        if dim < 0:
-            newdim = self.batch_dims + dim + 1
-        else:
-            newdim = dim
-
-        if (newdim > self.batch_dims) or (newdim < 0):
-            raise RuntimeError(
-                f"unsqueezing is allowed for dims comprised between "
-                f"`-td.batch_dims - 1` and `td.batch_dims` only. Got "
-                f"dim={dim} with a batch size of {self.batch_size}."
-            )
-        batch_size = list(self.batch_size)
-        batch_size.insert(newdim, 1)
-        batch_size = torch.Size(batch_size)
-
-        names = copy(self.names)
-        names.insert(dim, None)
-
-        def _unsqueeze(tensor):
-            return tensor.unsqueeze(newdim)
-
-        return self._fast_apply(
-            _unsqueeze,
-            batch_size=batch_size,
-            names=names,
-            inplace=False,
-            call_on_nested=True,
-        )
+        ...
 
     def _legacy_unsqueeze(self, dim: int) -> T:
         if dim < 0:
@@ -673,8 +648,7 @@ class TensorDictBase(MutableMapping):
     def squeeze(self, dim: int | None = None) -> T:
         ...
 
-    @property
-    def squeeze(self):
+    def squeeze(self, *args, **kwargs):
         """Squeezes all tensors for a dimension in between `-self.batch_dims+1` and `self.batch_dims-1` and returns them in a new tensordict.
 
         Args:
@@ -694,60 +668,16 @@ class TensorDictBase(MutableMapping):
 
         """
         if lazy_legacy():
-            return self._legacy_squeeze
+            return self._legacy_squeeze(*args, **kwargs)
         else:
-            return self._squeeze
+            result = self._squeeze(*args, **kwargs)
+            if result.is_memmap() or result.is_shared():
+                result.lock_()
+            return result
 
+    @abc.abstractmethod
     def _squeeze(self, dim=None):
-        batch_size = self.batch_size
-        if dim is None:
-            names = list(self.names)
-            batch_size, names = zip(
-                *[(size, name) for size, name in zip(batch_size, names) if size != 1]
-            )
-            batch_size = torch.Size(batch_size)
-            if batch_size == self.batch_size:
-                return self
-
-            # we only want to squeeze dimensions lower than the batch dim, and view
-            # is the perfect op for this
-            def _squeeze(tensor):
-                return tensor.view(*batch_size, *tensor.shape[self.batch_dims :])
-
-            return self._fast_apply(
-                _squeeze,
-                batch_size=batch_size,
-                names=names,
-                inplace=False,
-                call_on_nested=True,
-            )
-        # make the dim positive
-        if dim < 0:
-            newdim = self.batch_dims + dim
-        else:
-            newdim = dim
-
-        if (newdim >= self.batch_dims) or (newdim < 0):
-            raise RuntimeError(
-                f"squeezing is allowed for dims comprised between "
-                f"`-td.batch_dims` and `td.batch_dims - 1` only. Got "
-                f"dim={dim} with a batch size of {self.batch_size}."
-            )
-        if batch_size[dim] != 1:
-            return self
-        batch_size = list(batch_size)
-        batch_size.pop(dim)
-        batch_size = list(batch_size)
-        names = list(self.names)
-        names.pop(dim)
-
-        return self._fast_apply(
-            lambda x: x.squeeze(newdim),
-            batch_size=batch_size,
-            names=names,
-            inplace=False,
-            call_on_nested=True,
-        )
+        ...
 
     def _legacy_squeeze(self, dim: int | None = None) -> T:
         from tensordict._lazy import _SqueezedTensorDict
@@ -903,8 +833,11 @@ class TensorDictBase(MutableMapping):
     ) -> T:
         ...
 
-    @property
-    def view(self):
+    def view(
+        self,
+        *shape: int,
+        size: list | tuple | torch.Size | None = None,
+    ):
         """Returns a tensordict with views of the tensors according to a new shape, compatible with the tensordict batch_size.
 
         Args:
@@ -926,9 +859,12 @@ class TensorDictBase(MutableMapping):
 
         """
         if lazy_legacy():
-            return self._legacy_view
+            return self._legacy_view(*shape, size=size)
         else:
-            return self._view
+            result = self._view(size=size) if size is not None else self._view(*shape)
+            if result.is_shared() or result.is_memmap():
+                result.lock_()
+            return result
 
     def _legacy_view(
         self,
@@ -954,12 +890,7 @@ class TensorDictBase(MutableMapping):
             inv_op_kwargs={"size": self.batch_size},
         )
 
-    @overload
     def transpose(self, dim0, dim1):
-        ...
-
-    @property
-    def transpose(self):
         """Returns a tensordict that is a transposed version of input. The given dimensions ``dim0`` and ``dim1`` are swapped.
 
         In-place or out-place modifications of the transposed tensordict will
@@ -976,9 +907,24 @@ class TensorDictBase(MutableMapping):
             torch.Size([3, 4])
         """
         if lazy_legacy():
-            return self._legacy_transpose
+            return self._legacy_transpose(dim0, dim1)
         else:
-            return self._transpose
+            ndim = self.ndim
+            if dim0 < 0:
+                dim0 = ndim + dim0
+            if dim1 < 0:
+                dim1 = ndim + dim1
+            if dim0 < 0 or dim1 < 0 or dim0 >= ndim or dim1 >= ndim:
+                raise ValueError(
+                    "dim0 and dim1 must be within the range of the number of dimensions."
+                )
+            dim0, dim1 = min(dim0, dim1), max(dim0, dim1)
+            if dim0 == dim1:
+                return self
+            result = self._transpose(dim0, dim1)
+            if result.is_shared() or result.is_memmap():
+                result.lock_()
+            return result
 
     @abc.abstractmethod
     def _transpose(self, dim0, dim1):
@@ -1013,8 +959,7 @@ class TensorDictBase(MutableMapping):
     def permute(self, dims: list | tuple):
         ...
 
-    @property
-    def permute(self):
+    def permute(self, *args, **kwargs):
         """Returns a view of a tensordict with the batch dimensions permuted according to dims.
 
         Args:
@@ -1056,9 +1001,12 @@ class TensorDictBase(MutableMapping):
                 op=permute(dims=[1, 0]))
         """
         if lazy_legacy():
-            return self._legacy_permute
+            return self._legacy_permute(*args, **kwargs)
         else:
-            return self._permute
+            result = self._permute(*args, **kwargs)
+            if result.is_shared() or result.is_memmap():
+                result.lock_()
+            return result
 
     @abc.abstractmethod
     def _permute(
@@ -3963,9 +3911,8 @@ class TensorDictBase(MutableMapping):
         return self
 
     # Clone, select, exclude, empty
-    @abc.abstractmethod
     def select(self, *keys: str, inplace: bool = False, strict: bool = True) -> T:
-        """Selects the keys of the tensordict and returns an new tensordict with only the selected keys.
+        """Selects the keys of the tensordict and returns a new tensordict with only the selected keys.
 
         The values are not copied: in-place modifications a tensor of either
         of the original or new tensordict will result in a change in both
@@ -3974,22 +3921,121 @@ class TensorDictBase(MutableMapping):
         Args:
             *keys (str): keys to select
             inplace (bool): if True, the tensordict is pruned in place.
-                Default is :obj:`False`.
+                Default is ``False``.
             strict (bool, optional): whether selecting a key that is not present
                 will return an error or not. Default: :obj:`True`.
 
         Returns:
-            A new tensordict with the selected keys only.
+            A new tensordict (or the same if ``inplace=True``) with the selected keys only.
 
+        Examples:
+            >>> from tensordict import TensorDict
+            >>> td = TensorDict({"a": 0, "b": {"c": 1, "d": 2}}, [])
+            >>> td.select("a", ("b", "c"))
+            TensorDict(
+                fields={
+                    a: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.int64, is_shared=False),
+                    b: TensorDict(
+                        fields={
+                            c: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.int64, is_shared=False)},
+                        batch_size=torch.Size([]),
+                        device=None,
+                        is_shared=False)},
+                batch_size=torch.Size([]),
+                device=None,
+                is_shared=False)
+            >>> td.select("a", "b")
+            TensorDict(
+                fields={
+                    a: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.int64, is_shared=False),
+                    b: TensorDict(
+                        fields={
+                            c: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.int64, is_shared=False),
+                            d: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.int64, is_shared=False)},
+                        batch_size=torch.Size([]),
+                        device=None,
+                        is_shared=False)},
+                batch_size=torch.Size([]),
+                device=None,
+                is_shared=False)
+            >>> td.select("this key does not exist", strict=False)
+            TensorDict(
+                fields={
+                },
+                batch_size=torch.Size([]),
+                device=None,
+                is_shared=False)
         """
+        result = self._select(*keys, inplace=inplace, strict=strict)
+        if not inplace and (result._is_memmap or result._is_shared):
+            result.lock_()
+        return result
+
+    @abc.abstractmethod
+    def _select(self, *keys: str, inplace: bool = False, strict: bool = True) -> T:
         ...
 
     def exclude(self, *keys: str, inplace: bool = False) -> T:
+        """Excludes the keys of the tensordict and returns a new tensordict without these entries.
+
+        The values are not copied: in-place modifications a tensor of either
+        of the original or new tensordict will result in a change in both
+        tensordicts.
+
+        Args:
+            *keys (str): keys to exclude.
+            inplace (bool): if True, the tensordict is pruned in place.
+                Default is ``False``.
+
+        Returns:
+            A new tensordict (or the same if ``inplace=True``) without the excluded entries.
+
+        Examples:
+            >>> from tensordict import TensorDict
+            >>> td = TensorDict({"a": 0, "b": {"c": 1, "d": 2}}, [])
+            >>> td.exclude("a", ("b", "c"))
+            TensorDict(
+                fields={
+                    b: TensorDict(
+                        fields={
+                            d: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.int64, is_shared=False)},
+                        batch_size=torch.Size([]),
+                        device=None,
+                        is_shared=False)},
+                batch_size=torch.Size([]),
+                device=None,
+                is_shared=False)
+            >>> td.exclude("a", "b")
+            TensorDict(
+                fields={
+                },
+                batch_size=torch.Size([]),
+                device=None,
+                is_shared=False)
+
+        """
+        result = self._exclude(*keys, inplace=inplace)
+        if not inplace and (result._is_memmap or result._is_shared):
+            result.lock_()
+        return result
+
+    @abc.abstractmethod
+    def _exclude(
+        self,
+        *keys: str,
+        inplace: bool = False,
+    ) -> T:
         target = self if inplace else self.clone(recurse=False)
         for key in keys:
             if key in self.keys(True):
                 del target[key]
         return target
+
+    def _maybe_set_shared_attributes(self, result):
+        if self.is_shared():
+            result._is_shared = True
+        elif self.is_memmap():
+            result._is_memmap = True
 
     def to_tensordict(self) -> T:
         """Returns a regular TensorDict instance from the TensorDictBase.
@@ -4012,7 +4058,6 @@ class TensorDictBase(MutableMapping):
             names=self.names if self._has_names() else None,
         )
 
-    @abc.abstractmethod
     def clone(self, recurse: bool = True) -> T:
         """Clones a TensorDictBase subclass instance onto a new TensorDictBase subclass of the same type.
 
@@ -4025,6 +4070,13 @@ class TensorDictBase(MutableMapping):
                 tree structure will be copied. Defaults to ``True``.
 
         """
+        result = self._clone(recurse=recurse)
+        if not recurse and (result.is_shared() or result.is_memmap()):
+            result.lock_()
+        return result
+
+    @abc.abstractmethod
+    def _clone(self, recurse: bool = False):
         ...
 
     def copy(self):
@@ -4117,9 +4169,9 @@ class TensorDictBase(MutableMapping):
 
         """
         if not recurse:
-            return self.select()
+            return self.select().unlock_()
         # simply exclude the leaves
-        return self.exclude(*self.keys(True, True))
+        return self.exclude(*self.keys(True, True)).unlock_()
 
     # Filling
     def zero_(self) -> T:
@@ -4454,7 +4506,12 @@ class TensorDictBase(MutableMapping):
 
         """
         if not inplace:
-            return self.copy().unflatten_keys(separator=separator, inplace=True)
+            result = self._clone(recurse=False).unflatten_keys(
+                separator=separator, inplace=True
+            )
+            if self.is_shared() or self.is_memmap():
+                result.lock_()
+            return result
         else:
             for key in list(self.keys()):
                 if separator in key:

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -518,7 +518,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
             return self
         return TensorDictParams(params)
 
-    def clone(self, recurse: bool = True) -> TensorDictBase:
+    def _clone(self, recurse: bool = True) -> TensorDictBase:
         """Clones the TensorDictParams.
 
         .. warning::
@@ -539,7 +539,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
 
         """
         if not recurse:
-            return TensorDictParams(self._param_td.clone(False), no_convert=True)
+            return TensorDictParams(self._param_td._clone(False), no_convert=True)
 
         memo = {}
 
@@ -739,7 +739,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
         ...
 
     @_unlock_and_set
-    def select(self, *args, **kwargs):
+    def _select(self, *args, **kwargs):
         ...
 
     @_fallback
@@ -809,7 +809,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
         ...
 
     @_unlock_and_set(inplace=True)
-    def exclude(self, *keys: str, inplace: bool = False) -> TensorDictBase:
+    def _exclude(self, *keys: str, inplace: bool = False) -> TensorDictBase:
         ...
 
     @_carry_over

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -791,9 +791,6 @@ class TensorDictParams(TensorDictBase, nn.Module):
         # if we end up here, we can clear the graph associated with this td
         self._is_locked = False
 
-        self._is_shared = False
-        self._is_memmap = False
-
         if not self._lock_content:
             return self._param_td._propagate_unlock()
 

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -763,6 +763,14 @@ class TensorDictParams(TensorDictBase, nn.Module):
     def is_memmap(self) -> bool:
         ...
 
+    @property
+    def _is_shared(self) -> bool:
+        return self._param_td._is_shared
+
+    @property
+    def _is_memmap(self) -> bool:
+        return self._param_td._is_memmap
+
     @_fallback_property
     def shape(self) -> torch.Size:
         ...

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -597,8 +597,6 @@ class PersistentTensorDict(TensorDictBase):
             else TensorDict(
                 {},
                 batch_size=self.batch_size,
-                _is_memmap=True,
-                _is_shared=False,
                 names=self.names if self._has_names() else None,
                 device=torch.device("cpu"),
             )
@@ -660,6 +658,8 @@ class PersistentTensorDict(TensorDictBase):
                 futures.append(
                     executor.submit(save_metadata, dest, prefix / "meta.json", metadata)
                 )
+        dest._is_memmap = True
+        dest.lock_()
         return dest
 
     _load_memmap = TensorDict._load_memmap

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -744,7 +744,7 @@ class PersistentTensorDict(TensorDictBase):
         target_td = self._get_str(key)
         return target_td
 
-    def select(
+    def _select(
         self, *keys: str, inplace: bool = False, strict: bool = True
     ) -> PersistentTensorDict:
         raise NotImplementedError(
@@ -752,7 +752,7 @@ class PersistentTensorDict(TensorDictBase):
             "Create a regular tensordict first using the `to_tensordict` method."
         )
 
-    def exclude(self, *keys: str, inplace: bool = False) -> PersistentTensorDict:
+    def _exclude(self, *keys: str, inplace: bool = False) -> PersistentTensorDict:
         raise NotImplementedError(
             "Cannot call exclude on a PersistentTensorDict. "
             "Create a regular tensordict first using the `to_tensordict` method."
@@ -953,7 +953,7 @@ class PersistentTensorDict(TensorDictBase):
             self._nested_tensordicts[key].names = td._td_dim_names
             self._nested_tensordicts[key]._set_metadata(td)
 
-    def clone(self, recurse: bool = True, newfile=None) -> PersistentTensorDict:
+    def _clone(self, recurse: bool = True, newfile=None) -> PersistentTensorDict:
         if recurse:
             # this should clone the h5 to a new location indicated by newfile
             if newfile is None:
@@ -1035,6 +1035,35 @@ class PersistentTensorDict(TensorDictBase):
         # not accessible
         ...
 
+    def _view(self, *args, **kwargs):
+        raise RuntimeError(
+            "Cannot call `view` on a persistent tensordict. Call `reshape` instead."
+        )
+
+    def _transpose(self, dim0, dim1):
+        raise RuntimeError(
+            "Cannot call `transpose` on a persistent tensordict. Make it dense before calling this method by calling `to_tensordict`."
+        )
+
+    def _permute(
+        self,
+        *args,
+        **kwargs,
+    ):
+        raise RuntimeError(
+            "Cannot call `permute` on a persistent tensordict. Make it dense before calling this method by calling `to_tensordict`."
+        )
+
+    def _squeeze(self, dim=None):
+        raise RuntimeError(
+            "Cannot call `squeeze` on a persistent tensordict. Make it dense before calling this method by calling `to_tensordict`."
+        )
+
+    def _unsqueeze(self, dim):
+        raise RuntimeError(
+            "Cannot call `unsqueeze` on a persistent tensordict. Make it dense before calling this method by calling `to_tensordict`."
+        )
+
     __eq__ = TensorDict.__eq__
     __ne__ = TensorDict.__ne__
     __xor__ = TensorDict.__xor__
@@ -1052,9 +1081,6 @@ class PersistentTensorDict(TensorDictBase):
     split = TensorDict.split
     to_module = TensorDict.to_module
     unbind = TensorDict.unbind
-    _view = TensorDict._view
-    _permute = TensorDict._permute
-    _transpose = TensorDict._transpose
     _get_names_idx = TensorDict._get_names_idx
 
 

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -156,7 +156,7 @@ class PersistentTensorDict(TensorDictBase):
                 f"Either group or filename must be provided, and not both. Got group={group} and filename={filename}."
             )
         self._batch_size = torch.Size(batch_size)
-        self._device = device
+        self._device = torch.device(device) if device is not None else None
         self._is_shared = False
         self._is_memmap = False
         self.kwargs = kwargs
@@ -568,6 +568,7 @@ class PersistentTensorDict(TensorDictBase):
     ) -> T:
         if inplace:
             raise RuntimeError("Cannot call memmap inplace in a persistent tensordict.")
+
         # re-implements this to make it faster using the meta-data
         def save_metadata(data: TensorDictBase, filepath, metadata=None):
             if metadata is None:
@@ -593,11 +594,11 @@ class PersistentTensorDict(TensorDictBase):
                 "populated. Set a tensor first."
             )
         dest = TensorDict(
-                {},
-                batch_size=self.batch_size,
-                names=self.names if self._has_names() else None,
-                device=torch.device("cpu"),
-            )
+            {},
+            batch_size=self.batch_size,
+            names=self.names if self._has_names() else None,
+            device=torch.device("cpu"),
+        )
         dest._is_memmap = True
         for key, value in self._items_metadata():
             if not value["array"]:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1833,3 +1833,15 @@ def print_directory_tree(path, indent="", display_metadata=True):
             )
     else:
         logging.info(indent + os.path.basename(path))
+
+
+def _index_preserve_data_ptr(index):
+    if isinstance(index, tuple):
+        return all(_index_preserve_data_ptr(idx) for idx in index)
+    if index in (None, Ellipsis):
+        return True
+    if isinstance(index, int):
+        return True
+    if isinstance(index, slice) and (index.start == 0 or index.start is None):
+        return True
+    return False

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1472,9 +1472,10 @@ def _clone_value(value, recurse: bool):
     from tensordict.base import _is_tensor_collection
 
     if recurse:
+        # this is not a problem for locked tds as we will not lock it
         return value.clone()
     elif _is_tensor_collection(value.__class__):
-        return value.clone(recurse=False)
+        return value._clone(recurse=False)
     else:
         return value
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2295,6 +2295,13 @@ class TestTensorDicts(TestTensorDictsBase):
                 td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
             return
         else:
+            if inplace and td_name in ("sub_td", "sub_td2", "squeezed_td", "unsqueezed_td", "permute_td"):
+                with pytest.raises(RuntimeError, match="Cannot call exclude"):
+                    td_flatten = td.flatten_keys(
+                        inplace=inplace,
+                        separator=separator
+                        )
+                return
             td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
         for value in td_flatten.values():
             assert not isinstance(value, TensorDictBase)
@@ -4097,6 +4104,14 @@ class TestTensorDicts(TestTensorDictsBase):
                 ):
                     td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
                 return
+            if inplace and td_name in ("sub_td", "sub_td2", "permute_td", "squeezed_td", "unsqueezed_td"):
+                with pytest.raises(RuntimeError, match="Cannot call exclude"):
+                    td_flatten = td.flatten_keys(
+                        inplace=inplace,
+                        separator=separator
+                        )
+                return
+
             td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
             td_unflatten = td_flatten.unflatten_keys(
                 inplace=inplace, separator=separator

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2044,8 +2044,10 @@ class TestTensorDicts(TestTensorDictsBase):
             _ = nested.get("key")
             assert td.get(("some", "nested", "key")).shape == td.shape
             assert is_tensor_collection(td.get(("some", "nested", "key")))
+            del td["root"]
         if td_name in ("sub_td", "sub_td2"):
             return
+
         with td.lock_(), pytest.raises(RuntimeError):
             td.create_nested("root")
 
@@ -2180,7 +2182,12 @@ class TestTensorDicts(TestTensorDictsBase):
         )
 
         if td_name in (
-        "sub_td", "sub_td2", "permute_td", "squeezed_td", "unsqueezed_td"):
+            "sub_td",
+            "sub_td2",
+            "permute_td",
+            "squeezed_td",
+            "unsqueezed_td",
+        ):
             with pytest.raises(RuntimeError, match="Cannot call exclude"):
                 td.exclude("a", inplace=True)
             return
@@ -2301,12 +2308,15 @@ class TestTensorDicts(TestTensorDictsBase):
                 td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
             return
         else:
-            if inplace and td_name in ("sub_td", "sub_td2", "squeezed_td", "unsqueezed_td", "permute_td"):
+            if inplace and td_name in (
+                "sub_td",
+                "sub_td2",
+                "squeezed_td",
+                "unsqueezed_td",
+                "permute_td",
+            ):
                 with pytest.raises(RuntimeError, match="Cannot call exclude"):
-                    td_flatten = td.flatten_keys(
-                        inplace=inplace,
-                        separator=separator
-                        )
+                    td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
                 return
             td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
         for value in td_flatten.values():
@@ -2621,8 +2631,12 @@ class TestTensorDicts(TestTensorDictsBase):
             td.lock_()
         else:
             if td_name in (
-                "sub_td", "sub_td2", "permute_td", "squeezed_td",
-                "unsqueezed_td"):
+                "sub_td",
+                "sub_td2",
+                "permute_td",
+                "squeezed_td",
+                "unsqueezed_td",
+            ):
                 # we can't call select inplace on these guys so we exit here
                 return
             with td.unlock_() if td.is_locked else contextlib.nullcontext():
@@ -3328,7 +3342,12 @@ class TestTensorDicts(TestTensorDictsBase):
             keys += [("my_nested_td", "inner")]
 
         if inplace and td_name in (
-        "sub_td", "sub_td2", "permute_td", "squeezed_td", "unsqueezed_td"):
+            "sub_td",
+            "sub_td2",
+            "permute_td",
+            "squeezed_td",
+            "unsqueezed_td",
+        ):
             with pytest.raises(RuntimeError, match="Cannot call select"):
                 td.select(*keys, strict=strict, inplace=inplace)
             return
@@ -4120,12 +4139,15 @@ class TestTensorDicts(TestTensorDictsBase):
                 ):
                     td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
                 return
-            if inplace and td_name in ("sub_td", "sub_td2", "permute_td", "squeezed_td", "unsqueezed_td"):
+            if inplace and td_name in (
+                "sub_td",
+                "sub_td2",
+                "permute_td",
+                "squeezed_td",
+                "unsqueezed_td",
+            ):
                 with pytest.raises(RuntimeError, match="Cannot call exclude"):
-                    td_flatten = td.flatten_keys(
-                        inplace=inplace,
-                        separator=separator
-                        )
+                    td_flatten = td.flatten_keys(inplace=inplace, separator=separator)
                 return
 
             td_flatten = td.flatten_keys(inplace=inplace, separator=separator)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2620,6 +2620,11 @@ class TestTensorDicts(TestTensorDictsBase):
                 del td[key]
             td.lock_()
         else:
+            if td_name in (
+                "sub_td", "sub_td2", "permute_td", "squeezed_td",
+                "unsqueezed_td"):
+                # we can't call select inplace on these guys so we exit here
+                return
             with td.unlock_() if td.is_locked else contextlib.nullcontext():
                 td = td.select(inplace=True)
         for key, item in td_clone.items(True):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2179,6 +2179,12 @@ class TestTensorDicts(TestTensorDictsBase):
             and "a" not in td2.clone().keys()
         )
 
+        if td_name in (
+        "sub_td", "sub_td2", "permute_td", "squeezed_td", "unsqueezed_td"):
+            with pytest.raises(RuntimeError, match="Cannot call exclude"):
+                td.exclude("a", inplace=True)
+            return
+
         with td.unlock_():
             td2 = td.exclude("a", inplace=True)
         assert td2 is td
@@ -3316,6 +3322,11 @@ class TestTensorDicts(TestTensorDictsBase):
         if td_name in ("nested_stacked_td", "nested_td"):
             keys += [("my_nested_td", "inner")]
 
+        if inplace and td_name in (
+        "sub_td", "sub_td2", "permute_td", "squeezed_td", "unsqueezed_td"):
+            with pytest.raises(RuntimeError, match="Cannot call select"):
+                td.select(*keys, strict=strict, inplace=inplace)
+            return
         with td.unlock_() if td.is_locked else contextlib.nullcontext():
             td2 = td.select(*keys, strict=strict, inplace=inplace)
         if inplace:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3346,7 +3346,17 @@ class TestTensorDicts(TestTensorDictsBase):
             assert len(list(td2.keys())) == 0
 
     def test_set_lazy_legacy(self, td_name, device):
-        if td_name in ("sub_td", "sub_td2", "td_h5", "squeezed_td", "unsqueezed_td", "permute_td", "transpose_td", "nested_stacked_td", "stacked_td"):
+        if td_name in (
+            "sub_td",
+            "sub_td2",
+            "td_h5",
+            "squeezed_td",
+            "unsqueezed_td",
+            "permute_td",
+            "transpose_td",
+            "nested_stacked_td",
+            "stacked_td",
+        ):
             raiser = pytest.raises(RuntimeError)
         else:
             raiser = contextlib.nullcontext()


### PR DESCRIPTION
I'm grouping #620 and this PR.

The pitch is that we used to have a `_is_memmap` and `_is_shared` args in the tensordict constructor, but that is messy: is_shared() should only be true when the tensordict is locked, but when a td was created from another one the locked attribute wasn't passed whereas the shared attributee was.

To solve this, we will make sure that ops that are not modifying the tensors pass explicitly the shared and locked attributes.

I take the opportunity of the refactoring to make `exclude` faster.