### PR TITLE
[BugFix] Remove shared/memmap inheritance from clone / select / exclude

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1856,8 +1856,11 @@ class TensorDict(TensorDictBase):
             names=copy(self._td_dim_names),
             _run_checks=False,
         )
-        if not recurse:
-            self._maybe_set_shared_attributes(result)
+        # If this is uncommented, a shallow copy of a shared/memmap will be shared and locked too
+        # This may be undesirable, not sure if this should be the default behaviour
+        # (one usually does a copy to modify it).
+        # if not recurse:
+        #     self._maybe_set_shared_attributes(result)
         return result
 
     def contiguous(self) -> T:
@@ -1922,7 +1925,11 @@ class TensorDict(TensorDictBase):
         if inplace:
             self._tensordict = result._tensordict
             return self
-        self._maybe_set_shared_attributes(result)
+        # If this is uncommented, a shallow copy of a shared/memmap will be shared and locked too
+        # This may be undesirable, not sure if this should be the default behaviour
+        # (one usually does a copy to modify it).
+        # if set_shared:
+        #     self._maybe_set_shared_attributes(result)
         return result
 
     def _exclude(self, *keys: str, inplace: bool = False, set_shared: bool = True) -> T:
@@ -1961,8 +1968,11 @@ class TensorDict(TensorDictBase):
             names=self.names if self._has_names() else None,
             _run_checks=False,
         )
-        if set_shared:
-            self._maybe_set_shared_attributes(result)
+        # If this is uncommented, a shallow copy of a shared/memmap will be shared and locked too
+        # This may be undesirable, not sure if this should be the default behaviour
+        # (one usually does a copy to modify it).
+        # if set_shared:
+        #     self._maybe_set_shared_attributes(result)
         return result
 
     def keys(

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4421,7 +4421,8 @@ class TensorDictBase(MutableMapping):
                 result._set_str(
                     leaf_flat, self.get(leaf), validated=True, inplace=False
                 )
-            self._maybe_set_shared_attributes(result)
+            # Uncomment if you want key operations to propagate the shared status
+            # self._maybe_set_shared_attributes(result)
             if result._is_shared or result._is_memmap:
                 result.lock_()
             return result
@@ -4516,7 +4517,7 @@ class TensorDictBase(MutableMapping):
             result = self._clone(recurse=False).unflatten_keys(
                 separator=separator, inplace=True
             )
-            if self._is_shared or self._is_memmap:
+            if result._is_shared or result._is_memmap:
                 result.lock_()
             return result
         else:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -5744,19 +5744,20 @@ class TestLazyStackedTensorDict:
         assert "e" in td.keys()  # now all tds have the key c
         td.get("e")
 
-    def test_stack_memmap(self):
-        td = TensorDict({"a": [[1, 2]], "b": {"c": [[3, 4]]}}, [1, 2]).memmap_()
-        tdstack = torch.stack([td, td])
-        td_select = tdstack.select()
-        td_exclude = tdstack.exclude(*tdstack.keys(True))
-        td_exclude2 = tdstack.exclude(*tdstack.keys(True, True))
-        assert td_select.is_memmap()
-        assert td_select.is_locked
-        assert td_exclude.is_memmap()
-        assert td_exclude.is_locked
-        assert td_exclude2.is_memmap()
-        assert td_exclude2.is_locked
-        assert all(_td.is_locked for _td in td_exclude2.values(True))
+    # deprecated behaviour
+    # def test_stack_memmap(self):
+    #     td = TensorDict({"a": [[1, 2]], "b": {"c": [[3, 4]]}}, [1, 2]).memmap_()
+    #     tdstack = torch.stack([td, td])
+    #     td_select = tdstack.select()
+    #     td_exclude = tdstack.exclude(*tdstack.keys(True))
+    #     td_exclude2 = tdstack.exclude(*tdstack.keys(True, True))
+    #     assert td_select.is_memmap()
+    #     assert td_select.is_locked
+    #     assert td_exclude.is_memmap()
+    #     assert td_exclude.is_locked
+    #     assert td_exclude2.is_memmap()
+    #     assert td_exclude2.is_locked
+    #     assert all(_td.is_locked for _td in td_exclude2.values(True))
 
     @pytest.mark.parametrize("unsqueeze_dim", [0, 1, -1, -2])
     def test_stack_unsqueeze(self, unsqueeze_dim):


### PR DESCRIPTION
## Description

@shagunsodhani I may benefit from a bit of feedback on this.

## Context

When a tensordict is placed in shared memory or memmaped, it is blocked. We do this to avoid having people writing in it and hoping that these changes will be reflected in another process (which won't be the case). Locking the tensordict ensures that you must first unlock it (and hence loose the `is_shared()` attribute) before writing. 

For some operations (typically all the ops that don't change the `data_ptr()` ) I thought it was cool to keep the `is_shared()` attribute since we can be sure that the content is still shared. That means that coming from a shared / memmap tensordict all these ops would return a shared and locked tensordict:


```python
td.view(-1)
td.transpose(0, 1)
td.select("key")
td.exclude("key")
td.clone(recurse=False) # clones the tree structure but not the tensors
td.flatten_keys()
td.unflatten_keys()
```

## Problem

In the past we just copies the private `_is_memmap` and `_is_shared` but not the lock: that meant that you ended up with a shared but not locked TD (which is bad!) I solved this in #621 

Unfortunately that breaks a lot of stuff in torchrl:

Problem is that usually if you do `clone`, `select` or `exclude` you may want to modify the tensordict that you had.

So the plan now will be:
- For shape operations (unbind, view, transpose, permute, squeeze, unsqueeze) you keep the lock and the shared/memmap attribute because we assume that these ops are primarily there for you to present your data in a different format
- Key-based operations (clone(False), select, exclude, flatten_keys, unflatten_keys) do not propagate the shared and lock attribute

Thoughts?