### PR TITLE
[Feature] _auto_make_functional and _dispatch_td_nn_modules

### DIFF
--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -38,10 +38,6 @@ __all__ = ["TensorDictSequential"]
 class TensorDictSequential(TensorDictModule):
     """A sequence of TensorDictModules.
 
-    By default, :class:`TensorDictSequential` subclasses are always functional,
-    meaning that they support the ``td_module(input, params=params)`` function
-    call signature.
-
     Similarly to :obj:`nn.Sequence` which passes a tensor through a chain of mappings that read and write a single tensor
     each, this module will read and write over a tensordict by querying each of the input modules.
     When calling a :obj:`TensorDictSequencial` instance with a functional module, it is expected that the parameter lists (and
@@ -115,8 +111,9 @@ class TensorDictSequential(TensorDictModule):
         ...    module=module2, in_keys=["hidden"], out_keys=["output"]
         ... )
         >>> td_module = TensorDictSequential(td_module1, td_module2)
-        >>> params = make_functional(td_module)
-        >>> _ = td_module(td, params=params)
+        >>> params = TensorDict.from_module(td_module)
+        >>> with params.to_module(td_module):
+        ...     _ = td_module(td)
         >>> print(td)
         TensorDict(
             fields={
@@ -134,7 +131,10 @@ class TensorDictSequential(TensorDictModule):
     In the vmap case:
         >>> from torch import vmap
         >>> params = params.expand(4)
-        >>> td_vmap = vmap(td_module, (None, 0))(td, params)
+        >>> def func(td, params):
+        ...     with params.to_module(td_module):
+        ...         return td_module(td)
+        >>> td_vmap = vmap(func, (None, 0))(td, params)
         >>> print(td_vmap)
         TensorDict(
             fields={

--- a/tensordict/nn/utils.py
+++ b/tensordict/nn/utils.py
@@ -298,11 +298,14 @@ from tensordict.utils import Buffer  # noqa
 
 
 def _auto_make_functional():
+    """Returns ``True`` if TensorDictModuleBase subclasses are automatically made functional with the old API."""
     global AUTO_MAKE_FUNCTIONAL
     return AUTO_MAKE_FUNCTIONAL
 
 
 class _set_auto_make_functional(_DecoratorContextManager):
+    """Controls if TensorDictModule subclasses should be made functional automatically with the old API."""
+
     def __init__(self, mode):
         self.mode = mode
 
@@ -320,11 +323,14 @@ class _set_auto_make_functional(_DecoratorContextManager):
 
 
 def _dispatch_td_nn_modules():
+    """Returns ``True`` if @dispatch should be used. Not using dispatch is faster and also better compatible with torch.compile."""
     global DISPATCH_TDNN_MODULES
     return DISPATCH_TDNN_MODULES
 
 
 class _set_dispatch_td_nn_modules(_DecoratorContextManager):
+    """Controls whether @dispatch should be used. Not using dispatch is faster and also better compatible with torch.compile."""
+
     def __init__(self, mode):
         self.mode = mode
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -34,7 +34,13 @@ from tensordict.nn.distributions.composite import CompositeDistribution
 from tensordict.nn.ensemble import EnsembleModule
 from tensordict.nn.functional_modules import is_functional, make_functional
 from tensordict.nn.probabilistic import InteractionType, set_interaction_type
-from tensordict.nn.utils import Buffer, set_skip_existing, skip_existing
+from tensordict.nn.utils import (
+    _set_auto_make_functional,
+    _set_dispatch_td_nn_modules,
+    Buffer,
+    set_skip_existing,
+    skip_existing,
+)
 from torch import distributions as d, nn
 from torch.distributions import Normal
 from torch.utils._pytree import tree_map
@@ -417,6 +423,28 @@ class TestTDModule:
     @pytest.mark.skipif(
         not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
     )
+    def test_functional_deactivate(self):
+        torch.manual_seed(0)
+        param_multiplier = 1
+
+        net = nn.Linear(3, 4 * param_multiplier)
+
+        td = TensorDict({"in": torch.randn(3, 3)}, [3])
+
+        with _set_auto_make_functional(False):
+            tensordict_module = TensorDictModule(
+                module=net, in_keys=["in"], out_keys=["out"]
+            )
+        assert not is_functional(tensordict_module)
+        params = TensorDict.from_module(tensordict_module)
+        with pytest.raises(TypeError):
+            tensordict_module(td, params=params)
+        make_functional(tensordict_module)
+        tensordict_module(td, params=params)
+
+    @pytest.mark.skipif(
+        not _has_functorch, reason=f"functorch not found: err={FUNCTORCH_ERR}"
+    )
     def test_functional(self):
         torch.manual_seed(0)
         param_multiplier = 1
@@ -734,6 +762,22 @@ class TestTDModule:
             tdmodule.__deepcopy__
         assert tdmodule.some_attribute == "a"
         assert isinstance(copy.deepcopy(tdmodule), TensorDictModule)
+
+    def test_dispatch_deactivate(self):
+        tdm = TensorDictModule(nn.Linear(1, 1), ["a"], ["b"])
+        td = TensorDict({"a": torch.zeros(1, 1)}, 1)
+        tdm(td)
+        with _set_dispatch_td_nn_modules(True):
+            out = tdm(a=torch.zeros(1, 1))
+            assert (out == td["b"]).all()
+        with _set_dispatch_td_nn_modules(False), pytest.raises(
+            TypeError, match="missing 1 required positional argument"
+        ):
+            tdm(a=torch.zeros(1, 1))
+
+        # checks that things are back in place
+        tdm = TensorDictModule(nn.Linear(1, 1), ["a"], ["b"])
+        tdm(a=torch.zeros(1, 1))
 
     def test_dispatch(self):
         tdm = TensorDictModule(nn.Linear(1, 1), ["a"], ["b"])

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1925,12 +1925,10 @@ def test_probabilistic_sequential_type_checks():
 def test_keyerr_msg():
     module = TensorDictModule(nn.Linear(2, 3), in_keys=["a"], out_keys=["b"])
     with pytest.raises(
-        RuntimeError, match="TensorDictModule failed with operation"
-    ) as err:
+        KeyError,
+        match="Some tensors that are necessary for the module call may not have not been found in the input tensordict",
+    ):
         module(TensorDict({"c": torch.randn(())}, []))
-    assert "Some tensors that are necessary for the module call" in str(
-        err.value.__cause__
-    )
 
 
 def test_input():


### PR DESCRIPTION
This PR prepares the deprecation of the previous functional API and makes it possible to ignore the `@dispatch` decorator