### PR TITLE
[Feature] Robust to lazy_legacy set to false and context managers for reshape ops

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2355,8 +2355,8 @@ class LazyStackedTensorDict(TensorDictBase):
             result._td_dim_name = result._td_dim_name
         else:
             result = self
-            for dim in self.batch_size:
-                if dim == 1:
+            for dim in range(self.batch_dims - 1, -1, -1):
+                if self.batch_size[dim] == 1:
                     result = result.squeeze(dim)
         return result
 

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -38,6 +38,7 @@ from tensordict.memmap import MemoryMappedTensor as MemmapTensor
 from tensordict.utils import (
     _broadcast_tensors,
     _check_keys,
+    _get_shape_from_args,
     _getitem_batch_size,
     _is_number,
     _parse_to,
@@ -2314,19 +2315,70 @@ class LazyStackedTensorDict(TensorDictBase):
         *args,
         **kwargs,
     ):
-        raise RuntimeError(
-            "Cannot call `permute` on a lazy stacked tensordict. Make it dense before calling this method by calling `to_tensordict`."
+        dims_list = _get_shape_from_args(*args, kwarg_name="dims", **kwargs)
+        dims_list = [dim if dim >= 0 else self.ndim + dim for dim in dims_list]
+        dims_list_sort = np.argsort(dims_list)
+        # find the new stack dim
+        stack_dim = dims_list_sort[self.stack_dim]
+        # remove that dim from the dims_list
+        dims_list = [
+            d if d < self.stack_dim else d - 1 for d in dims_list if d != self.stack_dim
+        ]
+        result = LazyStackedTensorDict.lazy_stack(
+            [td.permute(dims_list) for td in self.tensordicts], stack_dim
         )
+        result._td_dim_name = self._td_dim_name
+        return result
 
     def _squeeze(self, dim=None):
-        raise RuntimeError(
-            "Cannot call `squeeze` on a lazy stacked tensordict. Make it dense before calling this method by calling `to_tensordict`."
-        )
+        if dim is not None:
+            new_dim = dim
+            if new_dim < 0:
+                new_dim = self.batch_dims + new_dim
+            if new_dim > self.batch_dims - 1 or new_dim < 0:
+                raise RuntimeError(
+                    f"The dim provided to squeeze is incompatible with the tensordict shape: dim={dim} and batch_size={self.batch_size}."
+                )
+            dim = new_dim
+            if self.batch_size[dim] != 1:
+                return self
+            if dim == self.stack_dim:
+                return self.tensordicts[0]
+            if dim > self.stack_dim:
+                dim = dim - 1
+                stack_dim = self.stack_dim
+            else:
+                stack_dim = self.stack_dim - 1
+            result = LazyStackedTensorDict.lazy_stack(
+                [td.squeeze(dim) for td in self.tensordicts], stack_dim
+            )
+            result._td_dim_name = result._td_dim_name
+        else:
+            result = self
+            for dim in self.batch_size:
+                if dim == 1:
+                    result = result.squeeze(dim)
+        return result
 
     def _unsqueeze(self, dim):
-        raise RuntimeError(
-            "Cannot call `unsqueeze` on a lazy stacked tensordict. Make it dense before calling this method by calling `to_tensordict`."
+        new_dim = dim
+        if new_dim < 0:
+            new_dim = self.batch_dims + new_dim + 1
+        if new_dim > self.batch_dims or new_dim < 0:
+            raise RuntimeError(
+                f"The dim provided to unsqueeze is incompatible with the tensordict shape: dim={dim} and batch_size={self.batch_size}."
+            )
+        dim = new_dim
+        if dim > self.stack_dim:
+            dim = dim - 1
+            stack_dim = self.stack_dim
+        else:
+            stack_dim = self.stack_dim + 1
+        result = LazyStackedTensorDict.lazy_stack(
+            [td.unsqueeze(dim) for td in self.tensordicts], stack_dim
         )
+        result._td_dim_name = result._td_dim_name
+        return result
 
     lock_ = TensorDictBase.lock_
     lock = _renamed_inplace_method(lock_)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1034,7 +1034,14 @@ class TensorDict(TensorDictBase):
         batch_size = [batch_size[p] for p in dims_list] + list(
             batch_size[len(dims_list) :]
         )
-        result = self._fast_apply(_permute, batch_size=batch_size, call_on_nested=True)
+        if self._has_names():
+            names = self.names
+            names = [names[i] for i in dims_list]
+        else:
+            names = None
+        result = self._fast_apply(
+            _permute, batch_size=batch_size, call_on_nested=True, names=names
+        )
         self._maybe_set_shared_attributes(result)
         return result
 
@@ -1109,7 +1116,7 @@ class TensorDict(TensorDictBase):
         batch_size = torch.Size(batch_size)
 
         names = copy(self.names)
-        names.insert(dim, None)
+        names.insert(newdim, None)
 
         def _unsqueeze(tensor):
             return tensor.unsqueeze(newdim)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1027,16 +1027,6 @@ class TensorDict(TensorDictBase):
         if np.array_equal(dims_list, range(len(dims_list))):
             return self
 
-        # min_dim, max_dim = -self.batch_dims, self.batch_dims - 1
-        # seen = [False for dim in range(max_dim + 1)]
-        # for idx in dims_list:
-        #     if idx < min_dim or idx > max_dim:
-        #         raise IndexError(
-        #             f"dimension out of range (expected to be in range of [{min_dim}, {max_dim}], but got {idx})"
-        #         )
-        #     if seen[idx]:
-        #         raise RuntimeError("repeated dim in permute")
-        #     seen[idx] = True
         def _permute(tensor):
             return tensor.permute(*dims_list, *range(len(dims_list), tensor.ndim))
 

--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 import functools
-import logging
+
+import warnings
 from typing import Any, Callable, Sequence, TypeVar
 
 import torch
@@ -23,7 +24,6 @@ from tensordict.utils import (
     set_lazy_legacy,
 )
 from torch import Tensor
-
 
 TD_HANDLED_FUNCTIONS: dict[Callable, Callable] = {}
 LAZY_TD_HANDLED_FUNCTIONS: dict[Callable, Callable] = {}
@@ -370,18 +370,22 @@ def _stack(
     # Read lazy_legacy
     _lazy_legacy = lazy_legacy(allow_none=True)
     if _lazy_legacy is None:
-        logging.warning(
-            "You did not define if torch.stack was to return a dense or lazy "
-            "stack of tensordicts. Up until v0.3 included, a lazy stack was returned. "
-            "From v0.4 onward, a dense stack will be returned and to build a "
-            "lazy stack, an explicit call to LazyStackedTensorDict.lazy_stack will be required. "
-            "To silence this warning, choose one of the following options: \n"
-            "- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on "
-            "the behaviour you want to use. "
-            "- set the decorator/context manager tensordict.set_lazy_legacy(True) (recommended) around "
-            "the function or code block where stack is used. "
-            "- Use LazyStackedTensorDict.lazy_stack if it is a lazy stack that you wish to use."
+        warnings.warn(
+            """You did not define if torch.stack was to return a dense or lazy
+stack of tensordicts. Up until v0.3 included, a lazy stack was returned.
+From v0.4 onward, a dense stack will be returned and to build a
+lazy stack, an explicit call to LazyStackedTensorDict.lazy_stack will be required.
+To silence this warning, choose one of the following options:
+- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on
+  the behaviour you want to use. Another way to achieve this is to call
+  `tensordict.set_lazy_legacy(True).set()` at the beginning of your script.
+- set the decorator/context manager `tensordict.set_lazy_legacy(True)` (recommended) around
+  the function or code block where stack is used.
+- Use `LazyStackedTensorDict.lazy_stack()` if it is a lazy stack that you wish to use.""",
+            category=DeprecationWarning,
         )
+        # get default
+        _lazy_legacy = lazy_legacy()
 
     if out is None:
         # We need to handle tensordicts with exclusive keys and tensordicts with
@@ -390,11 +394,11 @@ def _stack(
         # don't match exactly.
         # The second requires a check over the tensor shapes.
         device = list_of_tensordicts[0].device
-        if contiguous or not lazy_legacy():
+        if contiguous or not _lazy_legacy:
             try:
                 keys = _check_keys(list_of_tensordicts, strict=True)
             except KeyError:
-                if not lazy_legacy() and not contiguous:
+                if not _lazy_legacy and not contiguous:
                     with set_lazy_legacy(True):
                         return _stack(list_of_tensordicts, dim=dim)
                 raise

--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -6,13 +6,13 @@
 from __future__ import annotations
 
 import functools
+import logging
 from typing import Any, Callable, Sequence, TypeVar
 
 import torch
 
 from tensordict._lazy import LazyStackedTensorDict
 from tensordict._td import TensorDict
-
 from tensordict.base import _is_leaf_nontensor, NO_DEFAULT, TensorDictBase
 from tensordict.persistent import PersistentTensorDict
 from tensordict.utils import (
@@ -367,6 +367,21 @@ def _stack(
             )
 
     # check that all tensordict match
+    # Read lazy_legacy
+    _lazy_legacy = lazy_legacy(allow_none=True)
+    if _lazy_legacy is None:
+        logging.warning(
+            "You did not define if torch.stack was to return a dense or lazy "
+            "stack of tensordicts. Up until v0.3 included, a lazy stack was returned. "
+            "From v0.4 onward, a dense stack will be returned and to build a "
+            "lazy stack, an explicit call to LazyStackedTensorDict.lazy_stack will be required. "
+            "To silence this warning, choose one of the following options: \n"
+            "- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on "
+            "the behaviour you want to use. "
+            "- set the decorator/context manager tensordict.set_lazy_legacy(True) (recommended) around "
+            "the function or code block where stack is used. "
+            "- Use LazyStackedTensorDict.lazy_stack if it is a lazy stack that you wish to use."
+        )
 
     if out is None:
         # We need to handle tensordicts with exclusive keys and tensordicts with

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -68,7 +68,6 @@ from tensordict.utils import (
 from torch import distributed as dist, multiprocessing as mp, nn, Tensor
 from torch.utils._pytree import tree_map
 
-
 # NO_DEFAULT is used as a placeholder whenever the default is not provided.
 # Using None is not an option since `td.get(key, default=None)` is a valid usage.
 NO_DEFAULT = "_no_default_"
@@ -676,7 +675,27 @@ class TensorDictBase(MutableMapping):
             >>> assert td.get("y").shape == [3, 4]
 
         """
-        if lazy_legacy():
+        _lazy_legacy = lazy_legacy(allow_none=True)
+        if _lazy_legacy is None:
+            warnings.warn(
+                """You did not define if TensorDict.unsqueeze was to return a dense or lazy
+version of the unsqueezed tensordict. Up until v0.3 included, a lazy unsqueezed tensordict was returned.
+From v0.4 onward, a dense unsqueeze will be returned.
+To silence this warning, choose one of the following options:
+- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on
+  the behaviour you want to use. Another way to achieve this is to call
+  `tensordict.set_lazy_legacy(True).set()` at the beginning of your script.
+- set the decorator/context manager `tensordict.set_lazy_legacy(True)` (recommended) around
+  the function or code block where stack is used.
+
+To temporarily unsqueeze a tensordict you can still user unsqueeze() as a context manager (see docstrings).
+""",
+                category=DeprecationWarning,
+            )
+            # get default
+            _lazy_legacy = lazy_legacy()
+
+        if _lazy_legacy:
             return self._legacy_unsqueeze(*args, **kwargs)
         else:
             result = self._unsqueeze(*args, **kwargs)
@@ -745,7 +764,27 @@ class TensorDictBase(MutableMapping):
             >>> assert td.get("y").shape == [3, 1, 4]
 
         """
-        if lazy_legacy():
+        _lazy_legacy = lazy_legacy(allow_none=True)
+        if _lazy_legacy is None:
+            warnings.warn(
+                """You did not define if TensorDict.squeeze was to return a dense or lazy
+version of the squeezed tensordict. Up until v0.3 included, a lazy squeezed tensordict was returned.
+From v0.4 onward, a dense squeeze will be returned.
+To silence this warning, choose one of the following options:
+- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on
+  the behaviour you want to use. Another way to achieve this is to call
+  `tensordict.set_lazy_legacy(True).set()` at the beginning of your script.
+- set the decorator/context manager `tensordict.set_lazy_legacy(True)` (recommended) around
+  the function or code block where stack is used.
+
+To temporarily squeeze a tensordict you can still user squeeze() as a context manager (see docstrings).
+""",
+                category=DeprecationWarning,
+            )
+            # get default
+            _lazy_legacy = lazy_legacy()
+
+        if _lazy_legacy:
             return self._legacy_squeeze(*args, **kwargs)
         else:
             result = self._squeeze(*args, **kwargs)
@@ -937,7 +976,27 @@ class TensorDictBase(MutableMapping):
             >>> print(td_view.get("b").shape)  # torch.Size([1, 4, 3, 10, 1])
 
         """
-        if lazy_legacy():
+        _lazy_legacy = lazy_legacy(allow_none=True)
+        if _lazy_legacy is None:
+            warnings.warn(
+                """You did not define if TensorDict.view was to return a dense or lazy
+version of the viewed tensordict. Up until v0.3 included, a lazy view of the tensordict was returned.
+From v0.4 onward, a proper view will be returned.
+To silence this warning, choose one of the following options:
+- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on
+  the behaviour you want to use. Another way to achieve this is to call
+  `tensordict.set_lazy_legacy(True).set()` at the beginning of your script.
+- set the decorator/context manager `tensordict.set_lazy_legacy(True)` (recommended) around
+  the function or code block where stack is used.
+
+To temporarily view a tensordict you can still user view() as a context manager (see docstrings).
+""",
+                category=DeprecationWarning,
+            )
+            # get default
+            _lazy_legacy = lazy_legacy()
+
+        if _lazy_legacy:
             return self._legacy_view(*shape, size=size)
         else:
             result = self._view(size=size) if size is not None else self._view(*shape)
@@ -986,7 +1045,27 @@ class TensorDictBase(MutableMapping):
             >>> print(tensordict.get("b").shape)
             torch.Size([3, 4])
         """
-        if lazy_legacy():
+        _lazy_legacy = lazy_legacy(allow_none=True)
+        if _lazy_legacy is None:
+            warnings.warn(
+                """You did not define if TensorDict.transpose was to return a dense or lazy
+version of the transposed tensordict. Up until v0.3 included, a lazy transpose of the tensordict was returned.
+From v0.4 onward, a proper transpose will be returned.
+To silence this warning, choose one of the following options:
+- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on
+  the behaviour you want to use. Another way to achieve this is to call
+  `tensordict.set_lazy_legacy(True).set()` at the beginning of your script.
+- set the decorator/context manager `tensordict.set_lazy_legacy(True)` (recommended) around
+  the function or code block where stack is used.
+
+To temporarily transpose a tensordict you can still user transpose() as a context manager (see docstrings).
+""",
+                category=DeprecationWarning,
+            )
+            # get default
+            _lazy_legacy = lazy_legacy()
+
+        if _lazy_legacy:
             return self._legacy_transpose(dim0, dim1)
         else:
             ndim = self.ndim
@@ -1081,7 +1160,27 @@ class TensorDictBase(MutableMapping):
                     is_shared=False),
                 op=permute(dims=[1, 0]))
         """
-        if lazy_legacy():
+        _lazy_legacy = lazy_legacy(allow_none=True)
+        if _lazy_legacy is None:
+            warnings.warn(
+                """You did not define if TensorDict.permute was to return a dense or lazy
+version of the permuted tensordict. Up until v0.3 included, a lazy permute of the tensordict was returned.
+From v0.4 onward, a proper permute will be returned.
+To silence this warning, choose one of the following options:
+- set the LAZY_LEGACY_OP to 'True' (recommended) or 'False' depending on
+  the behaviour you want to use. Another way to achieve this is to call
+  `tensordict.set_lazy_legacy(True).set()` at the beginning of your script.
+- set the decorator/context manager `tensordict.set_lazy_legacy(True)` (recommended) around
+  the function or code block where stack is used.
+
+To temporarily permute a tensordict you can still user permute() as a context manager (see docstrings).
+""",
+                category=DeprecationWarning,
+            )
+            # get default
+            _lazy_legacy = lazy_legacy()
+
+        if _lazy_legacy:
             return self._legacy_permute(*args, **kwargs)
         else:
             result = self._permute(*args, **kwargs)

--- a/tensordict/nn/ensemble.py
+++ b/tensordict/nn/ensemble.py
@@ -6,7 +6,7 @@
 import warnings
 
 import torch
-from tensordict import TensorDict
+from tensordict import LazyStackedTensorDict, TensorDict
 from tensordict.nn.common import TensorDictBase, TensorDictModuleBase
 
 from tensordict.nn.params import TensorDictParams
@@ -114,7 +114,7 @@ class EnsembleModule(TensorDictModuleBase):
             for params_copy in parameters.unbind(0):
                 self.reset_parameters_recursive(params_copy)
                 params_pointers.append(params_copy)
-            return torch.stack(params_pointers, -1)
+            return LazyStackedTensorDict.lazy_stack(params_pointers, -1)
         else:
             # In case the user has added other neural networks to the EnsembleModule
             # besides those in self.module

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1691,7 +1691,7 @@ def _getitem_batch_size(batch_size, index):
 
 
 # Lazy classes control (legacy feature)
-_LAZY_OP = strtobool(os.environ.get("LAZY_LEGACY_OP", "True"))
+_LAZY_OP = strtobool(os.environ.get("LAZY_LEGACY_OP", "False"))
 
 
 class set_lazy_legacy(_DecoratorContextManager):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1691,7 +1691,8 @@ def _getitem_batch_size(batch_size, index):
 
 
 # Lazy classes control (legacy feature)
-_LAZY_OP = strtobool(os.environ.get("LAZY_LEGACY_OP", "False"))
+_DEFAULT_LAZY_OP = False
+_LAZY_OP = os.environ.get("LAZY_LEGACY_OP", None)
 
 
 class set_lazy_legacy(_DecoratorContextManager):
@@ -1728,10 +1729,14 @@ class set_lazy_legacy(_DecoratorContextManager):
         os.environ["LAZY_LEGACY_OP"] = str(_LAZY_OP)
 
 
-def lazy_legacy():
+def lazy_legacy(allow_none=False):
     """Returns `True` if lazy representations will be used for selected methods."""
     global _LAZY_OP
-    return _LAZY_OP
+    if _LAZY_OP is None and allow_none:
+        return None
+    elif _LAZY_OP is None:
+        return _DEFAULT_LAZY_OP
+    return strtobool(_LAZY_OP) if isinstance(_LAZY_OP, str) else _LAZY_OP
 
 
 def _legacy_lazy(func):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1691,7 +1691,7 @@ def _getitem_batch_size(batch_size, index):
 
 
 # Lazy classes control (legacy feature)
-_DEFAULT_LAZY_OP = False
+_DEFAULT_LAZY_OP = True
 _LAZY_OP = os.environ.get("LAZY_LEGACY_OP", None)
 
 

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1717,6 +1717,9 @@ class set_lazy_legacy(_DecoratorContextManager):
         return self.__class__(self.mode)
 
     def __enter__(self) -> None:
+        self.set()
+
+    def set(self) -> None:
         global _LAZY_OP
         self._old_mode = _LAZY_OP
         _LAZY_OP = bool(self.mode)

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -16,6 +16,7 @@ from tensordict._torch_func import _stack as stack_td
 from tensordict.base import is_tensor_collection
 from tensordict.nn.params import TensorDictParams
 from tensordict.persistent import _has_h5 as _has_h5py
+from tensordict.utils import set_lazy_legacy
 
 
 def prod(sequence):
@@ -113,6 +114,7 @@ class TestTensorDictsBase:
         TYPES_DEVICES += [["nested_tensorclass", device]]
         TYPES_DEVICES_NOLAZY += [["nested_tensorclass", device]]
 
+    @set_lazy_legacy(True)
     def nested_stacked_td(self, device):
         td = TensorDict(
             source={
@@ -133,6 +135,7 @@ class TestTensorDictsBase:
         TYPES_DEVICES += [["nested_stacked_td", device]]
         TYPES_DEVICES_NOLAZY += [["nested_stacked_td", device]]
 
+    @set_lazy_legacy(True)
     def stacked_td(self, device):
         td1 = TensorDict(
             source={
@@ -213,6 +216,7 @@ class TestTensorDictsBase:
     TYPES_DEVICES += [["memmap_td", torch.device("cpu")]]
     TYPES_DEVICES_NOLAZY += [["memmap_td", torch.device("cpu")]]
 
+    @set_lazy_legacy(True)
     def permute_td(self, device):
         return TensorDict(
             source={
@@ -227,6 +231,7 @@ class TestTensorDictsBase:
     for device in get_available_devices():
         TYPES_DEVICES += [["permute_td", device]]
 
+    @set_lazy_legacy(True)
     def unsqueezed_td(self, device):
         td = TensorDict(
             source={
@@ -242,6 +247,7 @@ class TestTensorDictsBase:
     for device in get_available_devices():
         TYPES_DEVICES += [["unsqueezed_td", device]]
 
+    @set_lazy_legacy(True)
     def squeezed_td(self, device):
         td = TensorDict(
             source={

--- a/test/test_functorch.py
+++ b/test/test_functorch.py
@@ -308,8 +308,8 @@ class TestVmap:
         )
         td0 = TensorDict({key: [1.0]}, [1])
         td1 = TensorDict({key: [2.0]}, [1])
-        x = torch.stack([td0, td0.clone()], stack_dim)
-        y = torch.stack([td1, td1.clone()], stack_dim)
+        x = LazyStackedTensorDict.lazy_stack([td0, td0.clone()], stack_dim)
+        y = LazyStackedTensorDict.lazy_stack([td1, td1.clone()], stack_dim)
         if lock_x:
             x.lock_()
         if lock_y:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -274,7 +274,7 @@ class TestGeneric:
 
         td1 = TensorDict({}, [5], device="cuda:0")
         td2 = TensorDict({}, [5], device="cuda:0")
-        stackedtd = stack_td([td1, td2], 0)
+        stackedtd = LazyStackedTensorDict.lazy_stack([td1, td2], 0)
         stackedtd.set("a", torch.randn(2, 5, 1))
         assert stackedtd.get("a").device == device
         assert td1.get("a").device == device

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -482,6 +482,10 @@ class TestGeneric:
         "td_type", ["tensordict", "view", "unsqueeze", "squeeze", "stack"]
     )
     @pytest.mark.parametrize("update", [True, False])
+    # getting values from lazy tensordicts in non-lazy contexts messes things up
+    # so we set it to True. When we'll deprecate lazy tensordicts, we will just
+    # remove this decorator
+    @set_lazy_legacy(True)
     def test_filling_empty_tensordict(self, device, td_type, update):
         if td_type == "tensordict":
             td = TensorDict({}, batch_size=[16], device=device)
@@ -2085,6 +2089,10 @@ class TestTensorDicts(TestTensorDictsBase):
         assert td_device.device == torch.device("cuda")
         assert td_back.device == torch.device("cpu")
 
+    # getting values from lazy tensordicts in non-lazy contexts messes things up
+    # so we set it to True. When we'll deprecate lazy tensordicts, we will just
+    # remove this decorator
+    @set_lazy_legacy(True)
     def test_create_nested(self, td_name, device):
         td = getattr(self, td_name)(device)
         with td.unlock_():
@@ -2652,6 +2660,10 @@ class TestTensorDicts(TestTensorDictsBase):
                 continue
             assert val.names[: td.ndim] == [str(-i) for i in range(td.ndim)]
 
+    # getting values from lazy tensordicts in non-lazy contexts messes things up
+    # so we set it to True. When we'll deprecate lazy tensordicts, we will just
+    # remove this decorator
+    @set_lazy_legacy(True)
     def test_lock_nested(self, td_name, device):
         td = getattr(self, td_name)(device)
         if td_name in ("sub_td", "sub_td2") and td.is_locked:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -339,7 +339,9 @@ class TestGeneric:
         td_container_clone.apply_(lambda x: x + 1)
 
         assert td_lazy.stack_dim == nested_stack_dim
-        td_stack = LazyStackedTensorDict.lazy_stack([td_container, td_container_clone], dim=stack_dim)
+        td_stack = LazyStackedTensorDict.lazy_stack(
+            [td_container, td_container_clone], dim=stack_dim
+        )
         assert td_stack.stack_dim == stack_dim
 
         assert isinstance(td_stack, LazyStackedTensorDict)
@@ -490,7 +492,9 @@ class TestGeneric:
         elif td_type == "squeeze":
             td = TensorDict({}, batch_size=[16, 1], device=device).squeeze(-1)
         elif td_type == "stack":
-            td = LazyStackedTensorDict.lazy_stack([TensorDict({}, [], device=device) for _ in range(16)], 0)
+            td = LazyStackedTensorDict.lazy_stack(
+                [TensorDict({}, [], device=device) for _ in range(16)], 0
+            )
         else:
             raise NotImplementedError
 
@@ -4057,14 +4061,18 @@ class TestTensorDicts(TestTensorDictsBase):
             else:
                 td1.apply_(lambda x: x.zero_() + 1)
 
-        is_lazy = td_name in (
-            "sub_td",
-            "sub_td2",
-            "permute_td",
-            "unsqueezed_td",
-            "squeezed_td",
-            "td_h5",
-        ) and not lazy_legacy()
+        is_lazy = (
+            td_name
+            in (
+                "sub_td",
+                "sub_td2",
+                "permute_td",
+                "unsqueezed_td",
+                "squeezed_td",
+                "td_h5",
+            )
+            and not lazy_legacy()
+        )
         error_dec = (
             pytest.raises(RuntimeError, match="Make it dense")
             if is_lazy
@@ -5706,7 +5714,10 @@ class TestLazyStackedTensorDict:
         td = TensorDict(
             {"a": torch.rand(3, 4, 5), ("b", "c"): torch.rand(3, 4, 5)}, [3, 4, 5]
         )
-        td = TensorDict({"parent": LazyStackedTensorDict.lazy_stack([td, td.clone()], 0)}, [2, 3, 4, 5])
+        td = TensorDict(
+            {"parent": LazyStackedTensorDict.lazy_stack([td, td.clone()], 0)},
+            [2, 3, 4, 5],
+        )
         from tensordict.nn import TensorDictModule  # noqa
         from torch import vmap
 
@@ -6065,7 +6076,9 @@ class TestLazyStackedTensorDict:
             },
             [3],
         )
-        td = TensorDict({"parent": LazyStackedTensorDict.lazy_stack([td0, td1], 0)}, [2])
+        td = TensorDict(
+            {"parent": LazyStackedTensorDict.lazy_stack([td0, td1], 0)}, [2]
+        )
         td2 = td.clone()
         tdapply = td.apply(lambda x, y: x + y, td2)
         assert isinstance(tdapply["parent", "a", "b"], LazyStackedTensorDict)
@@ -6190,7 +6203,9 @@ class TestLazyStackedTensorDict:
             device=device,
         )
 
-        tds = LazyStackedTensorDict.lazy_stack(list(tensordict.unbind(stack_dim)), stack_dim)
+        tds = LazyStackedTensorDict.lazy_stack(
+            list(tensordict.unbind(stack_dim)), stack_dim
+        )
 
         for item, expected_shape in (
             ((2, 2), torch.Size([5])),
@@ -6315,7 +6330,9 @@ class TestLazyStackedTensorDict:
             },
             [3],
         )
-        td = TensorDict({"parent": LazyStackedTensorDict.lazy_stack([td0, td1], 0)}, [2])
+        td = TensorDict(
+            {"parent": LazyStackedTensorDict.lazy_stack([td0, td1], 0)}, [2]
+        )
 
         td_void = TensorDict(
             {
@@ -7469,7 +7486,9 @@ class TestNonTensorData:
 
     def test_stack(self, non_tensor_data):
         assert (
-            LazyStackedTensorDict.lazy_stack([non_tensor_data, non_tensor_data], 0).get(("nested", "int"))
+            LazyStackedTensorDict.lazy_stack([non_tensor_data, non_tensor_data], 0).get(
+                ("nested", "int")
+            )
             == NonTensorData(3, batch_size=[2])
         ).all()
         assert (


### PR DESCRIPTION
Soon we will make all ops non-lazy by default (for v0.3)
I expect this to be bc-breaking for some users, but most should not be impacted. In fact, life will be much easier (a lot of `.contiguous()` calls  will be unnecessary).

The plan is to keep `LazyStackedTensorDict` there, as it's a useful abstraction to carry heterogeneous data structures or whenever one does not want to stack all the tensors of a data source.

In this PR, I set the lazy_legacy to False and test if all the tests pass. The plan it to reset it to True before merging, in such a way that we're sure that this PR does not break everything in torchrl for instance.

The plan for `torch.stack` is that we'll be looking at the lazy_legacy env variable for 1 release:
- if None, then the user has not said if she wanted a lazy legacy stack or not. We raise a warning asking to make this clear either with the decorator or with the environment variable. 
- If True, we use the previous API
- if False, we use the dense stack.
