### PR TITLE
[BugFix,Feature] filter_empty in apply

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -1354,8 +1354,9 @@ class LazyStackedTensorDict(TensorDictBase):
         named: bool = False,
         nested_keys: bool = False,
         prefix: tuple = (),
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> T:
+    ) -> T | None:
         if inplace and any(
             arg for arg in (batch_size, device, names, constructor_kwargs)
         ):
@@ -1378,6 +1379,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 nested_keys=nested_keys,
                 prefix=prefix,
                 inplace=inplace,
+                filter_empty=filter_empty,
                 **constructor_kwargs,
             )
 
@@ -1392,11 +1394,14 @@ class LazyStackedTensorDict(TensorDictBase):
                 default=default,
                 named=named,
                 nested_keys=nested_keys,
-                prefix=prefix + (i,),
+                prefix=prefix,  # + (i,),
                 inplace=inplace,
+                filter_empty=filter_empty,
             )
             for i, (td, *oth) in enumerate(zip(self.tensordicts, *others))
         ]
+        if filter_empty and all(r is None for r in results):
+            return
         if not inplace:
             out = LazyStackedTensorDict(
                 *results,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -868,7 +868,10 @@ class TensorDict(TensorDictBase):
 
         names = [None] * (len(shape) - tensordict_dims) + self.names
         return self._fast_apply(
-            _expand, batch_size=shape, call_on_nested=True, names=names
+            _expand,
+            batch_size=shape,
+            call_on_nested=True,
+            names=names,
         )
 
     def _unbind(self, dim: int):

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -643,33 +643,42 @@ class TensorDict(TensorDictBase):
         named: bool = False,
         nested_keys: bool = False,
         prefix: tuple = (),
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> T:
+    ) -> T | None:
         if inplace:
-            out = self
+            result = self
+            is_locked = result.is_locked
         elif batch_size is not None:
-            out = TensorDict(
-                {},
-                batch_size=torch.Size(batch_size),
-                names=names,
-                device=self.device if not device else device,
-                _run_checks=False,
-                **constructor_kwargs,
-            )
+
+            def make_result():
+                return TensorDict(
+                    {},
+                    batch_size=torch.Size(batch_size),
+                    names=names,
+                    device=self.device if not device else device,
+                    _run_checks=False,
+                    **constructor_kwargs,
+                )
+
+            result = None
+            is_locked = False
         else:
-            out = TensorDict(
-                {},
-                batch_size=self.batch_size,
-                device=self.device if not device else device,
-                names=self.names if self._has_names() else None,
-                _run_checks=False,
-                **constructor_kwargs,
-            )
 
-        is_locked = out.is_locked
-        if not inplace and is_locked:
-            out.unlock_()
+            def make_result():
+                return TensorDict(
+                    {},
+                    batch_size=self.batch_size,
+                    device=self.device if not device else device,
+                    names=self.names if self._has_names() else None,
+                    _run_checks=False,
+                    **constructor_kwargs,
+                )
 
+            result = None
+            is_locked = False
+
+        any_set = False
         for key, item in self.items():
             if not call_on_nested and _is_tensor_collection(item.__class__):
                 if default is not NO_DEFAULT:
@@ -694,6 +703,7 @@ class TensorDict(TensorDictBase):
                     nested_keys=nested_keys,
                     default=default,
                     prefix=prefix + (key,),
+                    filter_empty=filter_empty,
                     **constructor_kwargs,
                 )
             else:
@@ -706,19 +716,36 @@ class TensorDict(TensorDictBase):
                 else:
                     item_trsf = fn(item, *_others)
             if item_trsf is not None:
+                if not any_set:
+                    if result is None:
+                        result = make_result()
+                    any_set = True
                 if isinstance(self, _SubTensorDict):
-                    out.set(key, item_trsf, inplace=inplace)
+                    result.set(key, item_trsf, inplace=inplace)
                 else:
-                    out._set_str(
+                    result._set_str(
                         key,
                         item_trsf,
                         inplace=BEST_ATTEMPT_INPLACE if inplace else False,
                         validated=checked,
                     )
 
+        if filter_empty and not any_set:
+            return
+        elif filter_empty is None and not any_set:
+            warn(
+                "Your resulting tensordict has no leaves but you did not specify filter_empty=False. "
+                "Currently, this returns an empty tree (filter_empty=True), but from v0.5 it will return "
+                "a None unless filter_empty=False. "
+                "To silcence this warning, set filter_empty to the desired value in your call to `apply`.",
+                category=DeprecationWarning,
+            )
+        if result is None:
+            result = make_result()
+
         if not inplace and is_locked:
-            out.lock_()
-        return out
+            result.lock_()
+        return result
 
     # Functorch compatibility
     @cache  # noqa: B019

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3614,8 +3614,10 @@ To temporarily permute a tensordict you can still user permute() as a context ma
                 raise a `KeyError`.
             filter_empty (bool, optional): if ``True``, empty tensordicts will be
                 filtered out. This also comes with a lower computational cost as
-                empty data structures won't be created and destroyed. Defaults to
-                ``False`` for backward compatibility.
+                empty data structures won't be created and destroyed. Non-tensor data
+                is considered as a leaf and thereby will be kept in the tensordict even
+                if left untouched by the function.
+                Defaults to ``False`` for backward compatibility.
             **constructor_kwargs: additional keyword arguments to be passed to the
                 TensorDict constructor.
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3843,7 +3843,9 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         default: Any = NO_DEFAULT,
         named: bool = False,
         nested_keys: bool = False,
-        filter_empty: bool | None = None,
+        # filter_empty must be False because we use _fast_apply for all sorts of ops like expand etc
+        # and non-tensor data will disappear if we use True by default.
+        filter_empty: bool | None = False,
         **constructor_kwargs,
     ) -> T | None:
         """A faster apply method.

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3556,7 +3556,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             return
 
     # Apply and map functionality
-    def apply_(self, fn: Callable, *others) -> T:
+    def apply_(self, fn: Callable, *others, **kwargs) -> T:
         """Applies a callable to all values stored in the tensordict and re-writes them in-place.
 
         Args:
@@ -3564,6 +3564,8 @@ To temporarily permute a tensordict you can still user permute() as a context ma
                 tensordict.
             *others (sequence of TensorDictBase, optional): the other
                 tensordicts to be used.
+
+        Keyword Args: See :meth:`~.apply`.
 
         Returns:
             self or a copy of self with the function applied
@@ -3580,8 +3582,9 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         names: Sequence[str] | None = None,
         inplace: bool = False,
         default: Any = NO_DEFAULT,
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> T:
+    ) -> T | None:
         """Applies a callable to all values stored in the tensordict and sets them in a new tensordict.
 
         The callable signature must be ``Callable[Tuple[Tensor, ...], Optional[Union[Tensor, TensorDictBase]]]``.
@@ -3609,6 +3612,10 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             default (Any, optional): default value for missing entries in the
                 other tensordicts. If not provided, missing entries will
                 raise a `KeyError`.
+            filter_empty (bool, optional): if ``True``, empty tensordicts will be
+                filtered out. This also comes with a lower computational cost as
+                empty data structures won't be created and destroyed. Defaults to
+                ``False`` for backward compatibility.
             **constructor_kwargs: additional keyword arguments to be passed to the
                 TensorDict constructor.
 
@@ -3666,6 +3673,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             inplace=inplace,
             checked=False,
             default=default,
+            filter_empty=filter_empty,
             **constructor_kwargs,
         )
 
@@ -3679,8 +3687,9 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         names: Sequence[str] | None = None,
         inplace: bool = False,
         default: Any = NO_DEFAULT,
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> T:
+    ) -> T | None:
         """Applies a key-conditioned callable to all values stored in the tensordict and sets them in a new atensordict.
 
         The callable signature must be ``Callable[Tuple[str, Tensor, ...], Optional[Union[Tensor, TensorDictBase]]]``.
@@ -3710,6 +3719,10 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             default (Any, optional): default value for missing entries in the
                 other tensordicts. If not provided, missing entries will
                 raise a `KeyError`.
+            filter_empty (bool, optional): if ``True``, empty tensordicts will be
+                filtered out. This also comes with a lower computational cost as
+                empty data structures won't be created and destroyed. Defaults to
+                ``False`` for backward compatibility.
             **constructor_kwargs: additional keyword arguments to be passed to the
                 TensorDict constructor.
 
@@ -3794,6 +3807,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             default=default,
             named=True,
             nested_keys=nested_keys,
+            filter_empty=filter_empty,
             **constructor_kwargs,
         )
 
@@ -3812,8 +3826,9 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         named: bool = False,
         nested_keys: bool = False,
         prefix: tuple = (),
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> T:
+    ) -> T | None:
         ...
 
     def _fast_apply(
@@ -3828,8 +3843,9 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         default: Any = NO_DEFAULT,
         named: bool = False,
         nested_keys: bool = False,
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> T:
+    ) -> T | None:
         """A faster apply method.
 
         This method does not run any check after performing the func. This
@@ -3849,6 +3865,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             named=named,
             default=default,
             nested_keys=nested_keys,
+            filter_empty=filter_empty,
             **constructor_kwargs,
         )
 

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -465,8 +465,9 @@ class TensorDictParams(TensorDictBase, nn.Module):
         names: Sequence[str] | None = None,
         inplace: bool = False,
         default: Any = NO_DEFAULT,
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> TensorDictBase:
+    ) -> TensorDictBase | None:
         ...
 
     @_unlock_and_set(inplace=True)
@@ -479,8 +480,9 @@ class TensorDictParams(TensorDictBase, nn.Module):
         names: Sequence[str] | None = None,
         inplace: bool = False,
         default: Any = NO_DEFAULT,
+        filter_empty: bool | None = None,
         **constructor_kwargs,
-    ) -> TensorDictBase:
+    ) -> TensorDictBase | None:
         ...
 
     @_unlock_and_set(inplace=True)
@@ -1082,7 +1084,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
         ...
 
     @_apply_on_data
-    def apply_(self, fn: Callable, *others) -> T:
+    def apply_(self, fn: Callable, *others, **kwargs) -> T:
         ...
 
     def _apply(self, fn, recurse=True):

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1383,3 +1383,15 @@ class NonTensorData:
         if not escape_conversion:
             return _from_tensordict_with_copy(tensorclass_instance, result)
         return result
+
+    def _apply_nest(self, *args, **kwargs):
+        kwargs["filter_empty"] = False
+        return _wrap_method(self, "_apply_nest", self._tensordict._apply_nest)(
+            *args, **kwargs
+        )
+
+    def _fast_apply(self, *args, **kwargs):
+        kwargs["filter_empty"] = False
+        return _wrap_method(self, "_fast_apply", self._tensordict._fast_apply)(
+            *args, **kwargs
+        )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1829,7 +1829,10 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_apply_filter(self, td_name, device, inplace):
         td = getattr(self, td_name)(device)
         assert td.apply(lambda x: None, filter_empty=False) is not None
-        assert td.apply(lambda x: None, filter_empty=True) is None
+        if td_name != "td_with_non_tensor":
+            assert td.apply(lambda x: None, filter_empty=True) is None
+        else:
+            assert td.apply(lambda x: None, filter_empty=True) is not None
 
     @pytest.mark.parametrize("inplace", [False, True])
     def test_apply_other(self, td_name, device, inplace):
@@ -4209,6 +4212,7 @@ class TestTensorDicts(TestTensorDictsBase):
         assert (td_stack == td_out).all()
 
     @pytest.mark.filterwarnings("error")
+    @set_lazy_legacy(True)
     def test_stack_subclasses_on_td(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1826,6 +1826,12 @@ class TestTensorDicts(TestTensorDictsBase):
                     assert (td_1[key] == 0).all()
 
     @pytest.mark.parametrize("inplace", [False, True])
+    def test_apply_filter(self, td_name, device, inplace):
+        td = getattr(self, td_name)(device)
+        assert td.apply(lambda x: None, filter_empty=False) is not None
+        assert td.apply(lambda x: None, filter_empty=True) is None
+
+    @pytest.mark.parametrize("inplace", [False, True])
     def test_apply_other(self, td_name, device, inplace):
         td = getattr(self, td_name)(device)
         td_c = td.to_tensordict()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -4156,6 +4156,7 @@ class TestTensorDicts(TestTensorDictsBase):
             assert (td.get("a") == 1).all()
 
     @pytest.mark.filterwarnings("error")
+    @set_lazy_legacy(True)
     def test_stack_onto(self, td_name, device, tmpdir):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)


### PR DESCRIPTION
Using apply to filter data returns an empty tensordict, but one could expect to receive nothing at all if the operation doesn't return anything.
This PR solves this issue.