### PR TITLE
[BugFix, Feature] tensorclass.to_dict and from_dict

### DIFF
--- a/docs/source/reference/tensorclass.rst
+++ b/docs/source/reference/tensorclass.rst
@@ -285,6 +285,9 @@ Here is an example:
 Auto-casting
 ------------
 
+.. warning:: Auto-casting is an experimental feature and subject to changes in
+  the future. Compatibility with python<=3.9 is limited.
+
 ``@tensorclass`` partially supports auto-casting as an experimental feature.
 Methods such as ``__setattr__``, ``update``, ``update_`` and ``from_dict`` will
 attempt to cast type-annotated entries to the desired TensorDict / tensorclass

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -115,7 +115,10 @@ def _fails_exclusive_keys(func):
             raise RuntimeError(
                 f"the method {func.__name__} cannot complete when there are exclusive keys."
             )
-        return getattr(TensorDictBase, func.__name__)(self, *args, **kwargs)
+        parent_func = getattr(TensorDictBase, func.__name__, None)
+        if parent_func is None:
+            parent_func = getattr(TensorDict, func.__name__)
+        return parent_func(self, *args, **kwargs)
 
     return newfunc
 
@@ -2538,6 +2541,7 @@ class LazyStackedTensorDict(TensorDictBase):
     reshape = TensorDict.reshape
     split = TensorDict.split
     _to_module = TensorDict._to_module
+    from_dict_instance = TensorDict.from_dict_instance
 
 
 class _CustomOpTensorDict(TensorDictBase):
@@ -3070,6 +3074,7 @@ class _CustomOpTensorDict(TensorDictBase):
     expand = TensorDict.expand
     _unbind = TensorDict._unbind
     _get_names_idx = TensorDict._get_names_idx
+    from_dict_instance = TensorDict.from_dict_instance
 
 
 class _UnsqueezedTensorDict(_CustomOpTensorDict):

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -448,7 +448,9 @@ class TensorDict(TensorDictBase):
     def __ne__(self, other: object) -> T | bool:
         if _is_tensorclass(other):
             return other != self
-        if isinstance(other, (dict,)) or _is_tensor_collection(other.__class__):
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
             keys1 = set(self.keys())
             keys2 = set(other.keys())
             if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
@@ -470,7 +472,9 @@ class TensorDict(TensorDictBase):
     def __xor__(self, other: object) -> T | bool:
         if _is_tensorclass(other):
             return other ^ self
-        if isinstance(other, (dict,)) or _is_tensor_collection(other.__class__):
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
             keys1 = set(self.keys())
             keys2 = set(other.keys())
             if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
@@ -492,7 +496,9 @@ class TensorDict(TensorDictBase):
     def __or__(self, other: object) -> T | bool:
         if _is_tensorclass(other):
             return other | self
-        if isinstance(other, (dict,)) or _is_tensor_collection(other.__class__):
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
             keys1 = set(self.keys())
             keys2 = set(other.keys())
             if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
@@ -515,7 +521,7 @@ class TensorDict(TensorDictBase):
         if is_tensorclass(other):
             return other == self
         if isinstance(other, (dict,)):
-            other = self.empty(recurse=True).update(other)
+            other = self.from_dict_instance(other)
         if _is_tensor_collection(other.__class__):
             keys1 = set(self.keys())
             keys2 = set(other.keys())
@@ -570,7 +576,7 @@ class TensorDict(TensorDictBase):
         if isinstance(value, (TensorDictBase, dict)):
             indexed_bs = _getitem_batch_size(self.batch_size, index)
             if isinstance(value, dict):
-                value = TensorDict.from_dict(value, batch_size=indexed_bs)
+                value = self.from_dict_instance(value, batch_size=indexed_bs)
                 # value = self.empty(recurse=True)[index].update(value)
             if value.batch_size != indexed_bs:
                 if value.shape == indexed_bs[-len(value.shape) :]:
@@ -1309,6 +1315,41 @@ class TensorDict(TensorDictBase):
                 )
         # _run_checks=False breaks because a tensor may have the same batch-size as the tensordict
         out = cls(
+            input_dict,
+            batch_size=batch_size_set,
+            device=device,
+        )
+        if batch_size is None:
+            _set_max_batch_size(out, batch_dims)
+        else:
+            out.batch_size = batch_size
+        return out
+
+    def from_dict_instance(
+        self, input_dict, batch_size=None, device=None, batch_dims=None
+    ):
+        if batch_dims is not None and batch_size is not None:
+            raise ValueError(
+                "Cannot pass both batch_size and batch_dims to `from_dict`."
+            )
+        from tensordict import TensorDict
+
+        batch_size_set = torch.Size(()) if batch_size is None else batch_size
+        input_dict = copy(input_dict)
+        for key, value in list(input_dict.items()):
+            if isinstance(value, (dict,)):
+                cur_value = self.get(key, None)
+                if cur_value is not None:
+                    input_dict[key] = cur_value.from_dict_instance(
+                        value, batch_size=[], device=device, batch_dims=None
+                    )
+                    continue
+                # we don't know if another tensor of smaller size is coming
+                # so we can't be sure that the batch-size will still be valid later
+                input_dict[key] = TensorDict.from_dict(
+                    value, batch_size=[], device=device, batch_dims=None
+                )
+        out = TensorDict.from_dict(
             input_dict,
             batch_size=batch_size_set,
             device=device,
@@ -2339,6 +2380,8 @@ class _SubTensorDict(TensorDictBase):
         elif not inplace and self.is_locked:
             raise RuntimeError(_LOCK_ERROR)
         return inplace
+
+    from_dict_instance = TensorDict.from_dict_instance
 
     def _set_str(
         self,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1299,6 +1299,7 @@ class TensorDict(TensorDictBase):
             )
 
         batch_size_set = torch.Size(()) if batch_size is None else batch_size
+        input_dict = copy(input_dict)
         for key, value in list(input_dict.items()):
             if isinstance(value, (dict,)):
                 # we don't know if another tensor of smaller size is coming

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -821,6 +821,12 @@ class TensorDictParams(TensorDictBase, nn.Module):
         ...
 
     @_carry_over
+    def from_dict_instance(
+        self, input_dict, batch_size=None, device=None, batch_dims=None
+    ):
+        ...
+
+    @_carry_over
     def _legacy_transpose(self, dim0, dim1):
         ...
 

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -1199,6 +1199,7 @@ class PersistentTensorDict(TensorDictBase):
     _to_module = TensorDict._to_module
     _unbind = TensorDict._unbind
     _get_names_idx = TensorDict._get_names_idx
+    from_dict_instance = TensorDict.from_dict_instance
 
 
 def _set_max_batch_size(source: PersistentTensorDict):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1367,8 +1367,17 @@ def assert_allclose_td(
             assert_allclose_td(sub_actual, sub_expected, rtol=rtol, atol=atol)
         return True
 
-    set1 = set(actual.keys())
-    set2 = set(expected.keys())
+    try:
+        set1 = set(
+            actual.keys(is_leaf=lambda x: not is_non_tensor(x), leaves_only=True)
+        )
+        set2 = set(
+            expected.keys(is_leaf=lambda x: not is_non_tensor(x), leaves_only=True)
+        )
+    except ValueError:
+        # Persistent tensordicts do not work with is_leaf
+        set1 = set(actual.keys())
+        set2 = set(expected.keys())
     if not (len(set1.difference(set2)) == 0 and len(set2) == len(set1)):
         raise KeyError(
             "actual and expected tensordict keys mismatch, "

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -1968,10 +1968,11 @@ class TestAutoCasting:
 
         assert isinstance(obj.tc_global, AutoCast), (type(obj.tc), type(obj))
 
-        assert isinstance(obj.tc.tensor, torch.Tensor)
-        assert isinstance(obj.tc.non_tensor, str)
-        assert isinstance(obj.tc.td, TensorDict)
-        assert obj.tc.tc is None
+        if not PY8:
+            assert isinstance(obj.tc.tensor, torch.Tensor)
+            assert isinstance(obj.tc.non_tensor, str)
+            assert isinstance(obj.tc.td, TensorDict)
+            assert obj.tc.tc is None
 
     def test_autocast_or(self):
         with pytest.warns(

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -1801,6 +1801,32 @@ def test_decorator():
     assert not obj.is_locked
 
 
+def test_to_dict():
+    @tensorclass
+    class TestClass:
+        my_tensor: torch.Tensor
+        my_str: str
+
+    test_class = TestClass(
+        my_tensor=torch.tensor([1, 2, 3]), my_str="hello", batch_size=[3]
+    )
+
+    assert (test_class == TestClass.from_dict(test_class.to_dict())).all()
+
+    # Currently we don't test non-tensor in __eq__ because __eq__ can break with arrays and such
+    # test_class2 = TestClass(
+    #     my_tensor=torch.tensor([1, 2, 3]), my_str="goodbye", batch_size=[3]
+    # )
+    #
+    # assert not (test_class == TestClass.from_dict(test_class2.to_dict())).all()
+
+    test_class3 = TestClass(
+        my_tensor=torch.tensor([1, 2, 0]), my_str="hello", batch_size=[3]
+    )
+
+    assert not (test_class == TestClass.from_dict(test_class3.to_dict())).all()
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -62,6 +62,7 @@ class MyData:
     def stuff(self):
         return self.X + self.y
 
+
 PY8 = sys.version_info >= (3, 8) and sys.version_info < (3, 9)
 PY9 = sys.version_info >= (3, 9) and sys.version_info < (3, 10)
 PY10 = sys.version_info >= (3, 10)
@@ -1961,8 +1962,7 @@ class TestAutoCasting:
         assert isinstance(obj.non_tensor, str)
         assert isinstance(obj.td, TensorDict)
         if not PY8:
-            assert isinstance(obj.tc, self.ClsAutoCast), (
-                type(obj.tc), type(obj))
+            assert isinstance(obj.tc, self.ClsAutoCast), (type(obj.tc), type(obj))
         else:
             assert isinstance(obj.tc, dict), (type(obj.tc), type(obj))
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -41,7 +41,7 @@ from tensordict.functional import dense_stack_tds, pad, pad_sequence
 from tensordict.memmap import MemoryMappedTensor
 
 from tensordict.nn import TensorDictParams
-from tensordict.tensorclass import NonTensorData
+from tensordict.tensorclass import NonTensorData, tensorclass
 from tensordict.utils import (
     _getitem_batch_size,
     _LOCK_ERROR,
@@ -663,6 +663,29 @@ class TestGeneric:
             assert data["b"].batch_size == torch.Size(batch_size)
             assert data["d"].batch_size == torch.Size(batch_size)
             assert data["d", "g"].batch_size == torch.Size(batch_size)
+
+    def test_from_dict_instance(self):
+        @tensorclass
+        class MyClass:
+            x: torch.Tensor = None
+            y: int = None
+            z: "MyClass" = None
+
+        td = TensorDict(
+            {"a": torch.randn(()), "b": MyClass(x=torch.zeros(()), y=1, z=MyClass(y=2))}
+        )
+        td_dict = td.to_dict()
+        assert isinstance(td_dict["b"], dict)
+        assert isinstance(td_dict["b"]["y"], int)
+        assert isinstance(td_dict["b"]["z"], dict)
+        assert isinstance(td_dict["b"]["z"]["y"], int)
+        td_recon = td.from_dict_instance(td_dict)
+        assert isinstance(td_recon["a"], torch.Tensor)
+        assert isinstance(td_recon["b"], MyClass)
+        assert isinstance(td_recon["b"].x, torch.Tensor)
+        assert isinstance(td_recon["b"].y, int)
+        assert isinstance(td_recon["b"].z, MyClass)
+        assert isinstance(td_recon["b"].z.y, int)
 
     @pytest.mark.parametrize("memmap", [True, False])
     @pytest.mark.parametrize("params", [False, True])


### PR DESCRIPTION
Nested tensorclasses will need some form of autocasting to make sure that a dict within a dict is interpreted as the right class. 

The PR also proposes such auto-casting for tensor containers only (leaves are not auto-cast, as it is the case with tensordict).

The doc has been updated to account for this feature, and tests have been written for it too.

cc @maximilianigl