### PR TITLE
[Feature] Pointwise arithmetic operations using foreach

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You can also store non-tensor data in tensordicts:
 
 ### Tensor-like features
 
-TensorDict supports many common point-wise arithmetic operations such as `==` or `+`, `+=`
+**\[Nightly feature\]** TensorDict supports many common point-wise arithmetic operations such as `==` or `+`, `+=`
 and similar (provided that the underlying tensors support the said operation):
 ```python
 >>> td = TensorDict.fromkeys(["a", "b", "c"], 0)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ You can also store non-tensor data in tensordicts:
 
 ### Tensor-like features
 
+TensorDict supports many common point-wise arithmetic operations such as `==` or `+`, `+=`
+and similar (provided that the underlying tensors support the said operation):
+```python
+>>> td = TensorDict.fromkeys(["a", "b", "c"], 0)
+>>> td += 1
+>>> assert (td==1).all()
+```
+
 TensorDict objects can be indexed exactly like tensors. The resulting of indexing
 a TensorDict is another TensorDict containing tensors indexed along the required dimension:
 ```python

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -26,6 +26,7 @@ from tensordict._td import _SubTensorDict, _TensorDictKeysView, TensorDict
 from tensordict._tensordict import _unravel_key_to_tuple, unravel_key_list
 from tensordict.base import (
     _is_tensor_collection,
+    _NESTED_TENSORS_AS_LISTS,
     _register_tensor_class,
     BEST_ATTEMPT_INPLACE,
     CompatibleType,
@@ -61,6 +62,7 @@ from tensordict.utils import (
 )
 from torch import Tensor
 
+
 _has_functorch = False
 try:
     try:
@@ -88,7 +90,14 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
         return len(self._keys())
 
     def _keys(self) -> list[str]:
-        return self.tensordict._key_list()
+        result = self.tensordict._key_list()
+        if self.is_leaf is _NESTED_TENSORS_AS_LISTS:
+            return [
+                (key, i)
+                for key in result
+                for i in range(len(self.tensordict.tensordicts))
+            ]
+        return result
 
     def __contains__(self, item):
         item = _unravel_key_to_tuple(item)
@@ -1413,6 +1422,31 @@ class LazyStackedTensorDict(TensorDictBase):
         )
         return keys
 
+    def values(self, include_nested=False, leaves_only=False, is_leaf=None):
+        if is_leaf is not _NESTED_TENSORS_AS_LISTS:
+            yield from super().values(
+                include_nested=include_nested, leaves_only=leaves_only, is_leaf=is_leaf
+            )
+        for td in self.tensordicts:
+            yield from td.values(
+                include_nested=include_nested, leaves_only=leaves_only, is_leaf=is_leaf
+            )
+
+    def items(self, include_nested=False, leaves_only=False, is_leaf=None):
+        if is_leaf is not _NESTED_TENSORS_AS_LISTS:
+            yield from super().items(
+                include_nested=include_nested, leaves_only=leaves_only, is_leaf=is_leaf
+            )
+        for i, td in enumerate(self.tensordicts):
+            for key, val in td.items(
+                include_nested=include_nested, leaves_only=leaves_only, is_leaf=is_leaf
+            ):
+                if isinstance(key, str):
+                    key = (i, key)
+                else:
+                    key = (i, *key)
+                yield key, val
+
     valid_keys = keys
 
     # def _iterate_over_keys(self) -> None:
@@ -1512,7 +1546,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 default=default,
                 named=named,
                 nested_keys=nested_keys,
-                prefix=prefix,  # + (i,),
+                prefix=prefix + (i,) if is_leaf is _NESTED_TENSORS_AS_LISTS else prefix,
                 inplace=inplace,
                 filter_empty=filter_empty,
                 is_leaf=is_leaf,
@@ -1766,104 +1800,32 @@ class LazyStackedTensorDict(TensorDictBase):
                 return result
 
     def __eq__(self, other):
-        if is_tensorclass(other):
-            return other == self
-        if isinstance(other, (dict,)):
-            # we may want to broadcast it instead
-            other = TensorDict.from_dict(other, batch_size=self.batch_size)
-        if _is_tensor_collection(other.__class__):
-            if other.batch_size != self.batch_size:
-                if self.ndim < other.ndim:
-                    self_expand = self.expand(other.batch_size)
-                elif self.ndim > other.ndim:
-                    other = other.expand(self.batch_size)
-                    self_expand = self
-                else:
-                    raise RuntimeError(
-                        f"Could not compare tensordicts with shapes {self.shape} and {other.shape}"
-                    )
-            else:
-                self_expand = self
-            out = []
-            for td0, td1 in zip(
-                self_expand.tensordicts, other.unbind(self_expand.stack_dim)
-            ):
-                out.append(td0 == td1)
-            return LazyStackedTensorDict.lazy_stack(out, self.stack_dim)
-        if isinstance(other, (numbers.Number, Tensor)):
-            return LazyStackedTensorDict.lazy_stack(
-                [td == other for td in self.tensordicts],
-                self.stack_dim,
-            )
-        return False
+        return self._dispatch_comparison(other, "__eq__", "__eq__")
 
     def __ne__(self, other):
-        if is_tensorclass(other):
-            return other != self
-        if isinstance(other, (dict,)):
-            # we may want to broadcast it instead
-            other = TensorDict.from_dict(other, batch_size=self.batch_size)
-        if _is_tensor_collection(other.__class__):
-            if other.batch_size != self.batch_size:
-                if self.ndim < other.ndim:
-                    self_expand = self.expand(other.batch_size)
-                elif self.ndim > other.ndim:
-                    other = other.expand(self.batch_size)
-                    self_expand = self
-                else:
-                    raise RuntimeError(
-                        f"Could not compare tensordicts with shapes {self.shape} and {other.shape}"
-                    )
-            else:
-                self_expand = self
-            out = []
-            for td0, td1 in zip(
-                self_expand.tensordicts, other.unbind(self_expand.stack_dim)
-            ):
-                out.append(td0 != td1)
-            return LazyStackedTensorDict.lazy_stack(out, self.stack_dim)
-        if isinstance(other, (numbers.Number, Tensor)):
-            return LazyStackedTensorDict.lazy_stack(
-                [td != other for td in self.tensordicts],
-                self.stack_dim,
-            )
-        return True
-
-    def __xor__(self, other):
-        if is_tensorclass(other):
-            return other == self
-        if isinstance(other, (dict,)):
-            # we may want to broadcast it instead
-            other = TensorDict.from_dict(other, batch_size=self.batch_size)
-        if _is_tensor_collection(other.__class__):
-            if other.batch_size != self.batch_size:
-                if self.ndim < other.ndim:
-                    self_expand = self.expand(other.batch_size)
-                elif self.ndim > other.ndim:
-                    other = other.expand(self.batch_size)
-                    self_expand = self
-                else:
-                    raise RuntimeError(
-                        f"Could not compare tensordicts with shapes {self.shape} and {other.shape}"
-                    )
-            else:
-                self_expand = self
-            out = []
-            for td0, td1 in zip(
-                self_expand.tensordicts, other.unbind(self_expand.stack_dim)
-            ):
-                out.append(td0 ^ td1)
-            return LazyStackedTensorDict.lazy_stack(out, self.stack_dim)
-        if isinstance(other, (numbers.Number, Tensor)):
-            return LazyStackedTensorDict.lazy_stack(
-                [td ^ other for td in self.tensordicts],
-                self.stack_dim,
-            )
-        return False
+        return self._dispatch_comparison(other, "__ne__", "__ne__")
 
     def __or__(self, other):
+        return self._dispatch_comparison(other, "__or__", "__or__")
+
+    def __xor__(self, other):
+        return self._dispatch_comparison(other, "__xor__", "__xor__")
+
+    def __ge__(self, other):
+        return self._dispatch_comparison(other, "__ge__", "__le__")
+
+    def __gt__(self, other):
+        return self._dispatch_comparison(other, "__gt__", "__lt__")
+
+    def __le__(self, other):
+        return self._dispatch_comparison(other, "__le__", "__ge__")
+
+    def __lt__(self, other):
+        return self._dispatch_comparison(other, "__lt__", "__gt__")
+
+    def _dispatch_comparison(self, other, comparison_str, inverse_str):
         if is_tensorclass(other):
-            return other == self
+            return getattr(other, inverse_str)(self)
         if isinstance(other, (dict,)):
             # we may want to broadcast it instead
             other = TensorDict.from_dict(other, batch_size=self.batch_size)
@@ -1884,11 +1846,11 @@ class LazyStackedTensorDict(TensorDictBase):
             for td0, td1 in zip(
                 self_expand.tensordicts, other.unbind(self_expand.stack_dim)
             ):
-                out.append(td0 | td1)
+                out.append(getattr(td0, comparison_str)(td1))
             return LazyStackedTensorDict.lazy_stack(out, self.stack_dim)
         if isinstance(other, (numbers.Number, Tensor)):
             return LazyStackedTensorDict.lazy_stack(
-                [td | other for td in self.tensordicts],
+                [getattr(td, comparison_str)(other) for td in self.tensordicts],
                 self.stack_dim,
             )
         return False
@@ -3159,6 +3121,10 @@ class _CustomOpTensorDict(TensorDictBase):
     __or__ = TensorDict.__or__
     __eq__ = TensorDict.__eq__
     __ne__ = TensorDict.__ne__
+    __ge__ = TensorDict.__ge__
+    __gt__ = TensorDict.__gt__
+    __le__ = TensorDict.__le__
+    __lt__ = TensorDict.__lt__
     __setitem__ = TensorDict.__setitem__
     _add_batch_dim = TensorDict._add_batch_dim
     _check_device = TensorDict._check_device

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -93,7 +93,7 @@ class _LazyStackedTensorDictKeysView(_TensorDictKeysView):
         result = self.tensordict._key_list()
         if self.is_leaf is _NESTED_TENSORS_AS_LISTS:
             return [
-                (key, i)
+                (key, str(i))
                 for key in result
                 for i in range(len(self.tensordict.tensordicts))
             ]
@@ -1442,9 +1442,9 @@ class LazyStackedTensorDict(TensorDictBase):
                 include_nested=include_nested, leaves_only=leaves_only, is_leaf=is_leaf
             ):
                 if isinstance(key, str):
-                    key = (i, key)
+                    key = (str(i), key)
                 else:
-                    key = (i, *key)
+                    key = (str(i), *key)
                 yield key, val
 
     valid_keys = keys
@@ -1546,7 +1546,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 default=default,
                 named=named,
                 nested_keys=nested_keys,
-                prefix=prefix + (i,) if is_leaf is _NESTED_TENSORS_AS_LISTS else prefix,
+                prefix=prefix + (str(i),) if is_leaf is _NESTED_TENSORS_AS_LISTS else prefix,
                 inplace=inplace,
                 filter_empty=filter_empty,
                 is_leaf=is_leaf,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -560,6 +560,126 @@ class TensorDict(TensorDictBase):
             )
         return False
 
+    def __ge__(self, other: object) -> T | bool:
+        if is_tensorclass(other):
+            return other <= self
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
+            keys1 = set(self.keys())
+            keys2 = set(other.keys())
+            if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
+                keys1 = sorted(
+                    keys1,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                keys2 = sorted(
+                    keys2,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                raise KeyError(f"keys in tensordicts mismatch, got {keys1} and {keys2}")
+            d = {}
+            for key, item1 in self.items():
+                d[key] = item1 >= other.get(key)
+            return TensorDict(source=d, batch_size=self.batch_size, device=self.device)
+        if isinstance(other, (numbers.Number, Tensor)):
+            return TensorDict(
+                {key: value >= other for key, value in self.items()},
+                self.batch_size,
+                device=self.device,
+            )
+        return False
+
+    def __gt__(self, other: object) -> T | bool:
+        if is_tensorclass(other):
+            return other < self
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
+            keys1 = set(self.keys())
+            keys2 = set(other.keys())
+            if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
+                keys1 = sorted(
+                    keys1,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                keys2 = sorted(
+                    keys2,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                raise KeyError(f"keys in tensordicts mismatch, got {keys1} and {keys2}")
+            d = {}
+            for key, item1 in self.items():
+                d[key] = item1 > other.get(key)
+            return TensorDict(source=d, batch_size=self.batch_size, device=self.device)
+        if isinstance(other, (numbers.Number, Tensor)):
+            return TensorDict(
+                {key: value > other for key, value in self.items()},
+                self.batch_size,
+                device=self.device,
+            )
+        return False
+
+    def __le__(self, other: object) -> T | bool:
+        if is_tensorclass(other):
+            return other >= self
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
+            keys1 = set(self.keys())
+            keys2 = set(other.keys())
+            if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
+                keys1 = sorted(
+                    keys1,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                keys2 = sorted(
+                    keys2,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                raise KeyError(f"keys in tensordicts mismatch, got {keys1} and {keys2}")
+            d = {}
+            for key, item1 in self.items():
+                d[key] = item1 <= other.get(key)
+            return TensorDict(source=d, batch_size=self.batch_size, device=self.device)
+        if isinstance(other, (numbers.Number, Tensor)):
+            return TensorDict(
+                {key: value <= other for key, value in self.items()},
+                self.batch_size,
+                device=self.device,
+            )
+        return False
+
+    def __lt__(self, other: object) -> T | bool:
+        if is_tensorclass(other):
+            return other > self
+        if isinstance(other, (dict,)):
+            other = self.from_dict_instance(other)
+        if _is_tensor_collection(other.__class__):
+            keys1 = set(self.keys())
+            keys2 = set(other.keys())
+            if len(keys1.difference(keys2)) or len(keys1) != len(keys2):
+                keys1 = sorted(
+                    keys1,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                keys2 = sorted(
+                    keys2,
+                    key=lambda key: "".join(key) if isinstance(key, tuple) else key,
+                )
+                raise KeyError(f"keys in tensordicts mismatch, got {keys1} and {keys2}")
+            d = {}
+            for key, item1 in self.items():
+                d[key] = item1 < other.get(key)
+            return TensorDict(source=d, batch_size=self.batch_size, device=self.device)
+        if isinstance(other, (numbers.Number, Tensor)):
+            return TensorDict(
+                {key: value < other for key, value in self.items()},
+                self.batch_size,
+                device=self.device,
+            )
+        return False
+
     def __setitem__(
         self,
         index: IndexType,
@@ -758,7 +878,9 @@ class TensorDict(TensorDictBase):
                 _others = [_other._get_str(key, default=default) for _other in others]
                 if named:
                     if nested_keys:
-                        item_trsf = fn(unravel_key(prefix + (key,)), item, *_others)
+                        item_trsf = fn(
+                            prefix + (key,) if prefix != () else key, item, *_others
+                        )
                     else:
                         item_trsf = fn(key, item, *_others)
                 else:
@@ -3076,6 +3198,10 @@ class _SubTensorDict(TensorDictBase):
     # TODO: check these implementations
     __eq__ = TensorDict.__eq__
     __ne__ = TensorDict.__ne__
+    __ge__ = TensorDict.__ge__
+    __gt__ = TensorDict.__gt__
+    __le__ = TensorDict.__le__
+    __lt__ = TensorDict.__lt__
     __setitem__ = TensorDict.__setitem__
     __xor__ = TensorDict.__xor__
     __or__ = TensorDict.__or__

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4507,7 +4507,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         return out
 
     # pointwise arithmetic ops
-    def add_(self, other, alpha: float | None=None):
+    def add_(self, other, alpha: float | None = None):
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4518,7 +4518,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             torch._foreach_add_(self._values_list(True, True), other_val)
         return self
 
-    def add(self, other, alpha: float | None=None):
+    def add(self, other, alpha: float | None = None):
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4596,6 +4596,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
     def sqrt_(self):
         torch._foreach_sqrt_(self._values_list(True, True))
         return self
+
     def sqrt(self):
         keys, vals = self._items_list(True, True)
         vals = torch._foreach_sqrt(vals)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4592,15 +4592,133 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         return out
 
     # pointwise arithmetic ops
-    def add_(self, other, alpha: float | None = None):
-        if _is_tensor_collection(type(other)):
-            other_val = other._values_list(True, True)
-        else:
-            other_val = other
-        if alpha is not None:
-            torch._foreach_add_(self._values_list(True, True), other_val, alpha=alpha)
-        else:
-            torch._foreach_add_(self._values_list(True, True), other_val)
+    def __add__(self, other):
+        return self.add(other)
+
+    def __iadd__(self, other):
+        return self.add_(other)
+
+    def __abs__(self):
+        return self.abs()
+
+    def __truediv__(self, other):
+        return self.div(other)
+
+    def __itruediv__(self, other):
+        return self.div_(other)
+
+    def __mul__(self, other):
+        return self.mul(other)
+
+    def __imul__(self, other):
+        return self.mul_(other)
+
+    def __sub__(self, other):
+        return self.sub(other)
+
+    def __isub__(self, other):
+        return self.sub_(other)
+
+    def __pow__(self, other):
+        return self.pow(other)
+
+    def __ipow__(self, other):
+        return self.pow_(other)
+
+    def abs(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_abs(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def abs_(self) -> T:
+        torch._foreach_abs_(self._values_list(True, True))
+        return self
+
+    def exp(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_exp(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def exp_(self) -> T:
+        torch._foreach_exp_(self._values_list(True, True))
+        return self
+
+    def expm1(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_expm1(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def expm1_(self) -> T:
+        torch._foreach_expm1_(self._values_list(True, True))
+        return self
+
+    def log(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_log(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def log_(self) -> T:
+        torch._foreach_log_(self._values_list(True, True))
+        return self
+
+    def ceil(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_ceil(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def ceil_(self) -> T:
+        torch._foreach_ceil_(self._values_list(True, True))
+        return self
+
+    def floor(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_floor(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def floor_(self) -> T:
+        torch._foreach_floor_(self._values_list(True, True))
+        return self
+
+    def round(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_round(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def round_(self) -> T:
+        torch._foreach_round_(self._values_list(True, True))
+        return self
+
+    def erf(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_erf(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def erf_(self) -> T:
+        torch._foreach_erf_(self._values_list(True, True))
         return self
 
     def add(self, other, alpha: float | None = None):
@@ -4618,6 +4736,43 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
+    def add_(self, other, alpha: float | None = None):
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        if alpha is not None:
+            torch._foreach_add_(self._values_list(True, True), other_val, alpha=alpha)
+        else:
+            torch._foreach_add_(self._values_list(True, True), other_val)
+        return self
+
+    def sub(self, other, alpha: float | None = None):
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        if alpha is not None:
+            vals = torch._foreach_sub(vals, other_val, alpha=alpha)
+        else:
+            vals = torch._foreach_sub(vals, other_val)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def sub_(self, other, alpha: float | None = None):
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        if alpha is not None:
+            torch._foreach_sub_(self._values_list(True, True), other_val, alpha=alpha)
+        else:
+            torch._foreach_sub_(self._values_list(True, True), other_val)
+        return self
+
     def mul_(self, other):
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4633,6 +4788,46 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         else:
             other_val = other
         vals = torch._foreach_mul(vals, other_val)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def clamp_max_(self, other):
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        torch._foreach_clamp_max_(self._values_list(True, True), other_val)
+        return self
+
+    def clamp_max(self, other):
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        vals = torch._foreach_clamp_max(vals, other_val)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def clamp_min_(self, other):
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        torch._foreach_clamp_min_(self._values_list(True, True), other_val)
+        return self
+
+    def clamp_min(self, other):
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        vals = torch._foreach_clamp_min(vals, other_val)
         items = dict(zip(keys, vals))
         return self._fast_apply(
             lambda name, val: items[name], named=True, nested_keys=True

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -730,6 +730,32 @@ class TensorDictBase(MutableMapping):
             return self.batch_size
         return self.batch_size[dim]
 
+    @property
+    def data(self):
+        """Returns a tensordict containing the .data attributes of the leaf tensors."""
+        return self._data()
+
+    @property
+    def grad(self):
+        """Returns a tensordict containing the .grad attributes of the leaf tensors."""
+        return self._grad()
+
+    @cache  # noqa
+    def _dtype(self):
+        dtype = None
+        for val in self.values(True, True):
+            val_dtype = getattr(val, "dtype", None)
+            if dtype is None and val_dtype is not None:
+                dtype = val_dtype
+            elif dtype is not None and val_dtype is not None and dtype != val_dtype:
+                return None
+        return dtype
+
+    @property
+    def dtype(self):
+        """Returns the dtype of the values in the tensordict, if it is unique."""
+        return self._dtype()
+
     def _batch_size_setter(self, new_batch_size: torch.Size) -> None:
         if new_batch_size == self.batch_size:
             return

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -146,7 +146,7 @@ class TensorDictBase(MutableMapping):
         ...
 
     @abc.abstractmethod
-    def __xor__(self, other):
+    def __xor__(self, other: TensorDictBase | float):
         """XOR operation over two tensordicts, for evey key.
 
         The two tensordicts must have the same key set.
@@ -162,7 +162,7 @@ class TensorDictBase(MutableMapping):
         ...
 
     @abc.abstractmethod
-    def __or__(self, other):
+    def __or__(self, other: TensorDictBase | float) -> T:
         """OR operation over two tensordicts, for evey key.
 
         The two tensordicts must have the same key set.
@@ -4591,38 +4591,38 @@ To temporarily permute a tensordict you can still user permute() as a context ma
                 out = torch.cat(imaplist, dim)
         return out
 
-    # pointwise arithmetic ops
-    def __add__(self, other):
+    # point-wise arithmetic ops
+    def __add__(self, other: TensorDictBase | float) -> T:
         return self.add(other)
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: TensorDictBase | float) -> T:
         return self.add_(other)
 
     def __abs__(self):
         return self.abs()
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: TensorDictBase | float) -> T:
         return self.div(other)
 
-    def __itruediv__(self, other):
+    def __itruediv__(self, other: TensorDictBase | float) -> T:
         return self.div_(other)
 
-    def __mul__(self, other):
+    def __mul__(self, other: TensorDictBase | float) -> T:
         return self.mul(other)
 
-    def __imul__(self, other):
+    def __imul__(self, other: TensorDictBase | float) -> T:
         return self.mul_(other)
 
-    def __sub__(self, other):
+    def __sub__(self, other: TensorDictBase | float) -> T:
         return self.sub(other)
 
-    def __isub__(self, other):
+    def __isub__(self, other: TensorDictBase | float) -> T:
         return self.sub_(other)
 
-    def __pow__(self, other):
+    def __pow__(self, other: TensorDictBase | float) -> T:
         return self.pow(other)
 
-    def __ipow__(self, other):
+    def __ipow__(self, other: TensorDictBase | float) -> T:
         return self.pow_(other)
 
     def abs(self) -> T:
@@ -4637,6 +4637,18 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_abs_(self._values_list(True, True))
         return self
 
+    def acos(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_acos(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def acos_(self) -> T:
+        torch._foreach_acos_(self._values_list(True, True))
+        return self
+
     def exp(self) -> T:
         keys, vals = self._items_list(True, True)
         vals = torch._foreach_exp(vals)
@@ -4647,6 +4659,149 @@ To temporarily permute a tensordict you can still user permute() as a context ma
 
     def exp_(self) -> T:
         torch._foreach_exp_(self._values_list(True, True))
+        return self
+
+    def neg(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_neg(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def neg_(self) -> T:
+        torch._foreach_neg_(self._values_list(True, True))
+        return self
+
+    def reciprocal(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_reciprocal(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def reciprocal_(self) -> T:
+        torch._foreach_reciprocal_(self._values_list(True, True))
+        return self
+
+    def sigmoid(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_sigmoid(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def sigmoid_(self) -> T:
+        torch._foreach_sigmoid_(self._values_list(True, True))
+        return self
+
+    def sign(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_sign(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def sign_(self) -> T:
+        torch._foreach_sign_(self._values_list(True, True))
+        return self
+
+    def sin(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_sin(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def sin_(self) -> T:
+        torch._foreach_sin_(self._values_list(True, True))
+        return self
+
+    def sinh(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_sinh(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def sinh_(self) -> T:
+        torch._foreach_sinh_(self._values_list(True, True))
+        return self
+
+    def tan(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_tan(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def tan_(self) -> T:
+        torch._foreach_tan_(self._values_list(True, True))
+        return self
+
+    def tanh(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_tanh(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def tanh_(self) -> T:
+        torch._foreach_tanh_(self._values_list(True, True))
+        return self
+
+    def trunc(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_trunc(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def trunc_(self) -> T:
+        torch._foreach_trunc_(self._values_list(True, True))
+        return self
+
+    def norm(self, p="fro", dim=None, keepdim=False, out=None, dtype=None):
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_norm(vals, p=p, dim=dim, keepdim=keepdim, dtype=dtype)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name],
+            named=True,
+            nested_keys=True,
+            batch_size=[],
+        )
+
+    def lgamma(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_lgamma(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def lgamma_(self) -> T:
+        torch._foreach_lgamma_(self._values_list(True, True))
+        return self
+
+    def frac(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_frac(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def frac_(self) -> T:
+        torch._foreach_frac_(self._values_list(True, True))
         return self
 
     def expm1(self) -> T:
@@ -4671,6 +4826,42 @@ To temporarily permute a tensordict you can still user permute() as a context ma
 
     def log_(self) -> T:
         torch._foreach_log_(self._values_list(True, True))
+        return self
+
+    def log10(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_log10(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def log10_(self) -> T:
+        torch._foreach_log10_(self._values_list(True, True))
+        return self
+
+    def log1p(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_log1p(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def log1p_(self) -> T:
+        torch._foreach_log1p_(self._values_list(True, True))
+        return self
+
+    def log2(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_log2(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def log2_(self) -> T:
+        torch._foreach_log2_(self._values_list(True, True))
         return self
 
     def ceil(self) -> T:
@@ -4721,7 +4912,67 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_erf_(self._values_list(True, True))
         return self
 
-    def add(self, other, alpha: float | None = None):
+    def erfc(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_erfc(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def erfc_(self) -> T:
+        torch._foreach_erfc_(self._values_list(True, True))
+        return self
+
+    def asin(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_asin(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def asin_(self) -> T:
+        torch._foreach_asin_(self._values_list(True, True))
+        return self
+
+    def atan(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_atan(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def atan_(self) -> T:
+        torch._foreach_atan_(self._values_list(True, True))
+        return self
+
+    def cos(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_cos(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def cos_(self) -> T:
+        torch._foreach_cos_(self._values_list(True, True))
+        return self
+
+    def cosh(self) -> T:
+        keys, vals = self._items_list(True, True)
+        vals = torch._foreach_cosh(vals)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def cosh_(self) -> T:
+        torch._foreach_cosh_(self._values_list(True, True))
+        return self
+
+    def add(self, other: TensorDictBase | float, alpha: float | None = None):
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4736,7 +4987,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
-    def add_(self, other, alpha: float | None = None):
+    def add_(self, other: TensorDictBase | float, alpha: float | None = None):
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4747,7 +4998,95 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             torch._foreach_add_(self._values_list(True, True), other_val)
         return self
 
-    def sub(self, other, alpha: float | None = None):
+    def lerp(self, end: TensorDictBase | float, weight: TensorDictBase | float):
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(end)):
+            end_val = end._values_list(True, True)
+        else:
+            end_val = end
+        if _is_tensor_collection(type(weight)):
+            weight_val = weight._values_list(True, True)
+        else:
+            weight_val = weight
+        vals = torch._foreach_lerp(vals, end_val, weight_val)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def lerp_(self, end: TensorDictBase | float, weight: TensorDictBase | float):
+        if _is_tensor_collection(type(end)):
+            end_val = end._values_list(True, True)
+        else:
+            end_val = end
+        if _is_tensor_collection(type(weight)):
+            weight_val = weight._values_list(True, True)
+        else:
+            weight_val = weight
+        torch._foreach_lerp_(self._values_list(True, True), end_val, weight_val)
+        return self
+
+    def addcdiv(self, other1, other2, value: float | None = 1):
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other1)):
+            other1_val = other1._values_list(True, True)
+        else:
+            other1_val = other1
+        if _is_tensor_collection(type(other2)):
+            other2_val = other2._values_list(True, True)
+        else:
+            other2_val = other2
+        vals = torch._foreach_addcdiv(vals, other1_val, other2_val, value=value)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def addcdiv_(self, other1, other2, value: float | None = 1):
+        if _is_tensor_collection(type(other1)):
+            other1_val = other1._values_list(True, True)
+        else:
+            other1_val = other1
+        if _is_tensor_collection(type(other2)):
+            other2_val = other2._values_list(True, True)
+        else:
+            other2_val = other2
+        torch._foreach_addcdiv_(
+            self._values_list(True, True), other1_val, other2_val, value=value
+        )
+        return self
+
+    def addcmul(self, other1, other2, value: float | None = 1):
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other1)):
+            other1_val = other1._values_list(True, True)
+        else:
+            other1_val = other1
+        if _is_tensor_collection(type(other2)):
+            other2_val = other2._values_list(True, True)
+        else:
+            other2_val = other2
+        vals = torch._foreach_addcmul(vals, other1_val, other2_val, value=value)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def addcmul_(self, other1, other2, value: float | None = 1):
+        if _is_tensor_collection(type(other1)):
+            other1_val = other1._values_list(True, True)
+        else:
+            other1_val = other1
+        if _is_tensor_collection(type(other2)):
+            other2_val = other2._values_list(True, True)
+        else:
+            other2_val = other2
+        torch._foreach_addcmul_(
+            self._values_list(True, True), other1_val, other2_val, value=value
+        )
+        return self
+
+    def sub(self, other: TensorDictBase | float, alpha: float | None = None):
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4762,7 +5101,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
-    def sub_(self, other, alpha: float | None = None):
+    def sub_(self, other: TensorDictBase | float, alpha: float | None = None):
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4773,7 +5112,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             torch._foreach_sub_(self._values_list(True, True), other_val)
         return self
 
-    def mul_(self, other):
+    def mul_(self, other: TensorDictBase | float) -> T:
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4781,7 +5120,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_mul_(self._values_list(True, True), other_val)
         return self
 
-    def mul(self, other):
+    def mul(self, other: TensorDictBase | float) -> T:
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4793,7 +5132,47 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
-    def clamp_max_(self, other):
+    def maximum_(self, other: TensorDictBase | float) -> T:
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        torch._foreach_maximum_(self._values_list(True, True), other_val)
+        return self
+
+    def maximum(self, other: TensorDictBase | float) -> T:
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        vals = torch._foreach_maximum(vals, other_val)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def minimum_(self, other: TensorDictBase | float) -> T:
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        torch._foreach_minimum_(self._values_list(True, True), other_val)
+        return self
+
+    def minimum(self, other: TensorDictBase | float) -> T:
+        keys, vals = self._items_list(True, True)
+        if _is_tensor_collection(type(other)):
+            other_val = other._values_list(True, True)
+        else:
+            other_val = other
+        vals = torch._foreach_minimum(vals, other_val)
+        items = dict(zip(keys, vals))
+        return self._fast_apply(
+            lambda name, val: items[name], named=True, nested_keys=True
+        )
+
+    def clamp_max_(self, other: TensorDictBase | float) -> T:
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4801,7 +5180,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_clamp_max_(self._values_list(True, True), other_val)
         return self
 
-    def clamp_max(self, other):
+    def clamp_max(self, other: TensorDictBase | float) -> T:
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4813,7 +5192,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
-    def clamp_min_(self, other):
+    def clamp_min_(self, other: TensorDictBase | float) -> T:
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4821,7 +5200,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_clamp_min_(self._values_list(True, True), other_val)
         return self
 
-    def clamp_min(self, other):
+    def clamp_min(self, other: TensorDictBase | float) -> T:
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4833,7 +5212,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
-    def pow_(self, other):
+    def pow_(self, other: TensorDictBase | float) -> T:
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4841,7 +5220,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_pow_(self._values_list(True, True), other_val)
         return self
 
-    def pow(self, other):
+    def pow(self, other: TensorDictBase | float) -> T:
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
@@ -4853,7 +5232,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             lambda name, val: items[name], named=True, nested_keys=True
         )
 
-    def div_(self, other):
+    def div_(self, other: TensorDictBase | float) -> T:
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)
         else:
@@ -4861,7 +5240,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         torch._foreach_div_(self._values_list(True, True), other_val)
         return self
 
-    def div(self, other):
+    def div(self, other: TensorDictBase | float) -> T:
         keys, vals = self._items_list(True, True)
         if _is_tensor_collection(type(other)):
             other_val = other._values_list(True, True)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3163,7 +3163,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             for k in self.keys():
                 yield self._get_str(k, NO_DEFAULT)
 
-    @cache
+    @cache  # noqa: B019
     def _values_list(
         self,
         include_nested: bool = False,
@@ -3176,7 +3176,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             )
         )
 
-    @cache
+    @cache  # noqa: B019
     def _items_list(
         self,
         include_nested: bool = False,

--- a/tensordict/csrc/utils.h
+++ b/tensordict/csrc/utils.h
@@ -11,14 +11,11 @@ namespace py = pybind11;
 py::tuple _unravel_key_to_tuple(const py::object &key) {
   bool is_tuple = py::isinstance<py::tuple>(key);
   bool is_str = py::isinstance<py::str>(key);
-  bool is_int = py::isinstance<py::int_>(key);
 
   if (is_tuple) {
     py::list newkey;
     for (const auto &subkey : key) {
       if (py::isinstance<py::str>(subkey)) {
-        newkey.append(subkey);
-      } else if (py::isinstance<py::int_>(subkey)) {
         newkey.append(subkey);
       } else {
         auto _key = _unravel_key_to_tuple(subkey.cast<py::object>());
@@ -31,8 +28,6 @@ py::tuple _unravel_key_to_tuple(const py::object &key) {
     return py::tuple(newkey);
   }
   if (is_str) {
-    return py::make_tuple(key);
-  } else if (is_int) {
     return py::make_tuple(key);
   } else {
     return py::make_tuple();

--- a/tensordict/csrc/utils.h
+++ b/tensordict/csrc/utils.h
@@ -11,11 +11,14 @@ namespace py = pybind11;
 py::tuple _unravel_key_to_tuple(const py::object &key) {
   bool is_tuple = py::isinstance<py::tuple>(key);
   bool is_str = py::isinstance<py::str>(key);
+  bool is_int = py::isinstance<py::int_>(key);
 
   if (is_tuple) {
     py::list newkey;
     for (const auto &subkey : key) {
       if (py::isinstance<py::str>(subkey)) {
+        newkey.append(subkey);
+      } else if (py::isinstance<py::int_>(subkey)) {
         newkey.append(subkey);
       } else {
         auto _key = _unravel_key_to_tuple(subkey.cast<py::object>());
@@ -28,6 +31,8 @@ py::tuple _unravel_key_to_tuple(const py::object &key) {
     return py::tuple(newkey);
   }
   if (is_str) {
+    return py::make_tuple(key);
+  } else if (is_int) {
     return py::make_tuple(key);
   } else {
     return py::make_tuple();

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -602,6 +602,30 @@ class TensorDictParams(TensorDictBase, nn.Module):
     def __ne__(self, other: object) -> TensorDictBase:
         ...
 
+    @_fallback
+    def __xor__(self, other: object) -> TensorDictBase:
+        ...
+
+    @_fallback
+    def __or__(self, other: object) -> TensorDictBase:
+        ...
+
+    @_fallback
+    def __ge__(self, other: object) -> TensorDictBase:
+        ...
+
+    @_fallback
+    def __gt__(self, other: object) -> TensorDictBase:
+        ...
+
+    @_fallback
+    def __le__(self, other: object) -> TensorDictBase:
+        ...
+
+    @_fallback
+    def __lt__(self, other: object) -> TensorDictBase:
+        ...
+
     def __getattr__(self, item: str) -> Any:
         if not item.startswith("_"):
             try:
@@ -883,14 +907,6 @@ class TensorDictParams(TensorDictBase, nn.Module):
 
     @_carry_over
     def _legacy_unsqueeze(self, dim: int) -> TensorDictBase:
-        ...
-
-    @_fallback
-    def __xor__(self, other):
-        ...
-
-    @_fallback
-    def __or__(self, other):
         ...
 
     _check_device = TensorDict._check_device

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -806,7 +806,10 @@ class TensorDictParams(TensorDictBase, nn.Module):
 
     @property
     def data(self):
-        return self._param_td.detach()
+        return self._param_td._data()
+    @property
+    def grad(self):
+        return self._param_td._grad()
 
     @_unlock_and_set(inplace=True)
     def flatten_keys(

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -807,6 +807,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
     @property
     def data(self):
         return self._param_td._data()
+
     @property
     def grad(self):
         return self._param_td._grad()

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -1233,6 +1233,10 @@ class PersistentTensorDict(TensorDictBase):
     __ne__ = TensorDict.__ne__
     __xor__ = TensorDict.__xor__
     __or__ = TensorDict.__or__
+    __ge__ = TensorDict.__ge__
+    __gt__ = TensorDict.__gt__
+    __le__ = TensorDict.__le__
+    __lt__ = TensorDict.__lt__
     _apply_nest = TensorDict._apply_nest
     _check_device = TensorDict._check_device
     _check_is_shared = TensorDict._check_is_shared

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -2466,6 +2466,10 @@ class NonTensorStack(LazyStackedTensorDict):
             _BREAK_ON_MEMMAP = True
         return self
 
+    @property
+    def data(self):
+        raise AttributeError
+
 
 _register_tensor_class(NonTensorStack)
 

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -172,7 +172,7 @@ def tensorclass(cls: T) -> T:
     expected_keys = set(cls.__dataclass_fields__)
 
     for attr in cls.__dataclass_fields__:
-        if attr in dir(TensorDict) and attr != "_is_non_tensor":
+        if attr in dir(TensorDict) and attr not in ("_is_non_tensor", "data"):
             raise AttributeError(
                 f"Attribute name {attr} can't be used with @tensorclass"
             )

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1522,7 +1522,9 @@ def _expand_to_match_shape(
     self_batch_dims: int,
     self_device: DeviceType,
 ) -> Tensor | TensorDictBase:
-    if hasattr(tensor, "dtype"):
+    from tensordict.base import _is_tensor_collection
+
+    if not _is_tensor_collection(type(tensor)):
         return torch.zeros(
             (
                 *parent_batch_size,
@@ -1542,11 +1544,11 @@ def _expand_to_match_shape(
 
 def _set_max_batch_size(source: T, batch_dims=None):
     """Updates a tensordict with its maximium batch size."""
+    from tensordict.base import _is_tensor_collection
+
     tensor_data = [val for val in source.values() if not is_non_tensor(val)]
 
     for val in tensor_data:
-        from tensordict.base import _is_tensor_collection
-
         if _is_tensor_collection(val.__class__):
             _set_max_batch_size(val, batch_dims=batch_dims)
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1952,6 +1952,15 @@ class TestPointwiseOps:
             other.lock_()
         assert (td.add(other) == 1).all()
 
+        td = self.dummy_td_0
+        if locked:
+            td.lock_()
+        assert (td + 1 == 1).all()
+        other = self.dummy_td_1
+        if locked:
+            other.lock_()
+        assert (td + other == 1).all()
+
     @pytest.mark.parametrize("locked", [True, False])
     def test_add_(self, locked):
         td = self.dummy_td_0
@@ -1965,6 +1974,18 @@ class TestPointwiseOps:
             other.lock_()
         assert (td.add_(other) == 1).all()
 
+        td = self.dummy_td_0
+        if locked:
+            td.lock_()
+        td += 1
+        assert (td == 1).all()
+        td = self.dummy_td_0
+        other = self.dummy_td_1
+        if locked:
+            other.lock_()
+        td += other
+        assert (td == 1).all()
+
     @pytest.mark.parametrize("locked", [True, False])
     def test_mul(self, locked):
         td = self.dummy_td_1
@@ -1975,6 +1996,17 @@ class TestPointwiseOps:
         if locked:
             other.lock_()
         assert (td.mul(other) == 0).all()
+
+        td = self.dummy_td_1
+        if locked:
+            td.lock_()
+        td = td * 0
+        assert (td == 0).all()
+        other = self.dummy_td_0
+        if locked:
+            other.lock_()
+        td = td * other
+        assert (td == 0).all()
 
     @pytest.mark.parametrize("locked", [True, False])
     def test_mul_(self, locked):
@@ -1989,6 +2021,18 @@ class TestPointwiseOps:
             other.lock_()
         assert (td.mul_(other) == 0).all()
 
+        td = self.dummy_td_1
+        if locked:
+            td.lock_()
+        td *= 0
+        assert (td == 0).all()
+        td = self.dummy_td_1
+        other = self.dummy_td_0
+        if locked:
+            other.lock_()
+        td *= other
+        assert (td == 0).all()
+
     @pytest.mark.parametrize("locked", [True, False])
     def test_div(self, locked):
         td = self.dummy_td_2
@@ -1999,6 +2043,15 @@ class TestPointwiseOps:
         if locked:
             other.lock_()
         assert (td.div(other) == 1).all()
+
+        td = self.dummy_td_2
+        if locked:
+            td.lock_()
+        assert (td / 2 == 1).all()
+        other = self.dummy_td_2
+        if locked:
+            other.lock_()
+        assert (td / other == 1).all()
 
     @pytest.mark.parametrize("locked", [True, False])
     def test_div_(self, locked):
@@ -2012,6 +2065,63 @@ class TestPointwiseOps:
         if locked:
             other.lock_()
         assert (td.div_(other) == 1).all()
+
+        td = self.dummy_td_2.float()
+        if locked:
+            td.lock_()
+        td /= 2
+        assert (td == 1).all()
+        td = self.dummy_td_2.float()
+        other = self.dummy_td_2.float()
+        if locked:
+            other.lock_()
+        td /= other
+        assert (td == 1).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_pow(self, locked):
+        td = self.dummy_td_2
+        if locked:
+            td.lock_()
+        assert (td.pow(2) == 4).all()
+        other = self.dummy_td_2
+        if locked:
+            other.lock_()
+        assert (td.pow(other) == 4).all()
+
+        td = self.dummy_td_2
+        if locked:
+            td.lock_()
+        assert (td**2 == 4).all()
+        other = self.dummy_td_2
+        if locked:
+            other.lock_()
+        assert (td**other == 4).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_pow_(self, locked):
+        td = self.dummy_td_2.float()
+        if locked:
+            td.lock_()
+        assert (td.pow_(2) == 4).all()
+        assert td.pow_(2) is td
+        td = self.dummy_td_2.float()
+        other = self.dummy_td_2.float()
+        if locked:
+            other.lock_()
+        assert (td.pow_(other) == 4).all()
+
+        td = self.dummy_td_2.float()
+        if locked:
+            td.lock_()
+        td **= 2
+        assert (td == 4).all()
+        td = self.dummy_td_2.float()
+        other = self.dummy_td_2.float()
+        if locked:
+            other.lock_()
+        td **= other
+        assert (td == 4).all()
 
 
 @pytest.mark.parametrize(

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -7698,9 +7698,9 @@ class TestTensorDictMP(TestTensorDictsBase):
         return x.apply(lambda x: x + 1)
 
     @staticmethod
-    def add1_app_error(x):
-        # algerbraic ops are not supported
-        return x + 1
+    def matmul_app_error(x):
+        # non point-wise ops are not supported
+        return x @ 1
 
     @pytest.mark.parametrize(
         "chunksize,num_chunks", [[None, 2], [4, None], [None, None], [2, 2]]
@@ -7713,7 +7713,7 @@ class TestTensorDictMP(TestTensorDictsBase):
             with pytest.raises(
                 RuntimeError, match="Cannot call map on a TensorDictParams object"
             ):
-                td.map(self.add1_app_error, dim=dim, pool=_pool_fixt)
+                td.map(self.matmul_app_error, dim=dim, pool=_pool_fixt)
             return
         if chunksize is not None and num_chunks is not None:
             with pytest.raises(ValueError, match="but not both"):
@@ -7758,10 +7758,10 @@ class TestTensorDictMP(TestTensorDictsBase):
             with pytest.raises(
                 RuntimeError, match="Cannot call map on a TensorDictParams object"
             ):
-                td.map(self.add1_app_error, dim=dim, pool=_pool_fixt)
+                td.map(self.matmul_app_error, dim=dim, pool=_pool_fixt)
             return
         with pytest.raises(TypeError, match="unsupported operand"):
-            td.map(self.add1_app_error, dim=dim, pool=_pool_fixt)
+            td.map(self.matmul_app_error, dim=dim, pool=_pool_fixt)
 
     def test_sharing_locked_td(self, td_name, device):
         td = getattr(self, td_name)(device)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2149,6 +2149,24 @@ class TestPointwiseOps:
         td **= other
         assert (td == 4).all()
 
+    @property
+    def _lazy_td(self):
+        tensordict = LazyStackedTensorDict(
+            TensorDict({"a": -2}), TensorDict({"a": -1, "b": -2}), stack_dim=0
+        )
+        return TensorDict({"super": tensordict})
+
+    def test_lazy_td_pointwise(self):
+        td = self._lazy_td
+        td.abs_()
+        assert (td > 0).all()
+        td = self._lazy_td
+        assert ((td + td) == td * 2).all()
+        td = self._lazy_td
+        td += self._lazy_td
+        assert (td == self._lazy_td * 2).all()
+        assert ((td.abs() ** 2).clamp_max(td) == td).all()
+
 
 @pytest.mark.parametrize(
     "td_name,device",

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1921,6 +1921,94 @@ class TestGeneric:
         t.update({"a": {"d": [[[1]] * 3] * 2}})
 
 
+class TestPointwiseOps:
+    @property
+    def dummy_td_0(self):
+        return TensorDict(
+            {"a": torch.zeros(3, 4), "b": {"c": torch.zeros(3, 5, dtype=torch.int)}}
+        )
+
+    @property
+    def dummy_td_1(self):
+        return self.dummy_td_0.apply(lambda x: x + 1)
+
+    @property
+    def dummy_td_2(self):
+        return self.dummy_td_0.apply(lambda x: x + 2)
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_add(self, locked):
+        td = self.dummy_td_0
+        if locked:
+            td.lock_()
+        assert (td.add(1) == 1).all()
+        other = self.dummy_td_1
+        if locked:
+            other.lock_()
+        assert (td.add(other) == 1).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_add_(self, locked):
+        td = self.dummy_td_0
+        if locked:
+            td.lock_()
+        assert (td.add_(1) == 1).all()
+        assert td.add_(1) is td
+        td = self.dummy_td_0
+        other = self.dummy_td_1
+        if locked:
+            other.lock_()
+        assert (td.add_(other) == 1).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_mul(self, locked):
+        td = self.dummy_td_1
+        if locked:
+            td.lock_()
+        assert (td.mul(0) == 0).all()
+        other = self.dummy_td_0
+        if locked:
+            other.lock_()
+        assert (td.mul(other) == 0).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_mul_(self, locked):
+        td = self.dummy_td_1
+        if locked:
+            td.lock_()
+        assert (td.mul_(0) == 0).all()
+        assert td.mul_(0) is td
+        td = self.dummy_td_1
+        other = self.dummy_td_0
+        if locked:
+            other.lock_()
+        assert (td.mul_(other) == 0).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_div(self, locked):
+        td = self.dummy_td_2
+        if locked:
+            td.lock_()
+        assert (td.div(2) == 1).all()
+        other = self.dummy_td_2
+        if locked:
+            other.lock_()
+        assert (td.div(other) == 1).all()
+
+    @pytest.mark.parametrize("locked", [True, False])
+    def test_div_(self, locked):
+        td = self.dummy_td_2.float()
+        if locked:
+            td.lock_()
+        assert (td.div_(2) == 1).all()
+        assert td.div_(2) is td
+        td = self.dummy_td_2.float()
+        other = self.dummy_td_2.float()
+        if locked:
+            other.lock_()
+        assert (td.div_(other) == 1).all()
+
+
 @pytest.mark.parametrize(
     "td_name,device",
     TestTensorDictsBase.TYPES_DEVICES,

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -377,6 +377,16 @@ class TestGeneric:
         else:
             assert dense_td_stack["lazy"].stack_dim == nested_stack_dim + 1
 
+    def test_dtype(self):
+        td = TensorDict(
+            {("an", "integer"): 1, ("a", "string"): "a", ("the", "float"): 1.0}
+        )
+        assert td.dtype is None
+        td = td.float()
+        assert td.dtype == torch.float
+        td = td.int()
+        assert td.dtype == torch.int
+
     def test_empty(self):
         td = TensorDict(
             {


### PR DESCRIPTION
Test the feature:
```python
from tensordict import TensorDict
from torch.nn import Transformer
import torch
from torch.utils.benchmark import Timer
t = Transformer(device="cuda" if torch.cuda.is_available() else "cpu")

params = TensorDict.from_module(t).apply(lambda t: t.data.clone().fill_(0.0))
other_params = TensorDict.from_module(t).apply(lambda t: t.data.clone().fill_(1.0))

assert (params.add(other_params) == 1).all()

print("\n\nadd")
params.add(other_params)
print("foreach", Timer("params.add(other_params)", globals=globals()).adaptive_autorange())
params.lock_()
other_params.lock_()
params.add(other_params)
print("foreach, locked", Timer("params.add(other_params)", globals=globals()).adaptive_autorange())
params.apply(lambda x, y: x+y, other_params)
print("apply", Timer("params.apply(lambda x, y: x+y, other_params)", globals=globals()).adaptive_autorange())
listval0 = params._values_list(True, True)
listval1 = other_params._values_list(True, True)
torch._foreach_add(listval0, listval1)
print("plain foreach", Timer("torch._foreach_add(listval0, listval1)", globals=globals()).adaptive_autorange())

params.unlock_()
other_params.unlock_()

print("\n\nadd_")
params.add(other_params)
print("foreach", Timer("params.add_(other_params)", globals=globals()).adaptive_autorange())
params.lock_()
other_params.lock_()
params.add(other_params)
print("foreach, locked", Timer("params.add_(other_params)", globals=globals()).adaptive_autorange())
params.apply(lambda x, y: x+y, other_params)
print("apply", Timer("params.apply(lambda x, y: x.add_(y), other_params)", globals=globals()).adaptive_autorange())
listval0 = params._values_list(True, True)
listval1 = other_params._values_list(True, True)
torch._foreach_add_(listval0, listval1)
print("plain foreach", Timer("torch._foreach_add_(listval0, listval1)", globals=globals()).adaptive_autorange())
```


Gives these results:


```
add
foreach <torch.utils.benchmark.utils.common.Measurement object at 0x7f51c7f5ab60>
params.add(other_params)
  Median: 3.62 ms
  IQR:    0.07 ms (3.59 to 3.66)
  4 measurements, 100 runs per measurement, 1 thread
foreach, locked <torch.utils.benchmark.utils.common.Measurement object at 0x7f5169b13e20>
params.add(other_params)
  Median: 1.94 ms
  IQR:    0.12 ms (1.93 to 2.05)
  4 measurements, 100 runs per measurement, 1 thread
apply <torch.utils.benchmark.utils.common.Measurement object at 0x7f5169b11840>
params.apply(lambda x, y: x+y, other_params)
  Median: 4.18 ms
  IQR:    0.02 ms (4.17 to 4.19)
  4 measurements, 100 runs per measurement, 1 thread
plain foreach <torch.utils.benchmark.utils.common.Measurement object at 0x7f5169b12d40>
torch._foreach_add(listval0, listval1)
  Median: 567.85 us
  IQR:    8.00 us (563.76 to 571.76)
  4 measurements, 100 runs per measurement, 1 thread


add_
foreach <torch.utils.benchmark.utils.common.Measurement object at 0x7f51c7f59cc0>
params.add_(other_params)
  Median: 929.06 us
  IQR:    9.48 us (925.40 to 934.88)
  4 measurements, 100 runs per measurement, 1 thread
foreach, locked <torch.utils.benchmark.utils.common.Measurement object at 0x7f5169b11540>
params.add_(other_params)
  Median: 353.06 us
  IQR:    0.10 us (353.00 to 353.10)
  4 measurements, 1000 runs per measurement, 1 thread
apply <torch.utils.benchmark.utils.common.Measurement object at 0x7f5169b13f10>
params.apply(lambda x, y: x.add_(y), other_params)
  Median: 3.34 ms
  IQR:    0.02 ms (3.32 to 3.34)
  4 measurements, 100 runs per measurement, 1 thread
plain foreach <torch.utils.benchmark.utils.common.Measurement object at 0x7f5169b107f0>
torch._foreach_add_(listval0, listval1)
  Median: 353.14 us
  IQR:    0.07 us (353.10 to 353.17)
  4 measurements, 1000 runs per measurement, 1 thread
```

So there is some overhead for add due to the fact that we need to rebuild the tensordict, but if we don't (add_) it's as fast as plain foreach and you can keep the nice structure of your params

cc @fmassa @ahmed-touati @teopir @MateuszGuzek @zou3519 @ezyang @albanD