### PR TITLE
[Performance] Random speedups

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1733,7 +1733,8 @@ class TensorDict(TensorDictBase):
         *,
         validated: bool,
     ):
-        assert validated == True, "Not Implemented for non-validated inputs"
+        if not validated:
+            raise RuntimeError("Not Implemented for non-validated inputs")
         self._tensordict = d
 
     def _set_tuple(
@@ -2450,6 +2451,7 @@ class TensorDict(TensorDictBase):
             return self._tensordict.items()
         elif include_nested and leaves_only:
             is_leaf = _default_is_leaf if is_leaf is None else is_leaf
+
             def fast_iter():
                 for k, val in self._tensordict.items():
                     if not is_leaf(val.__class__):
@@ -2463,6 +2465,7 @@ class TensorDict(TensorDictBase):
                         )
                     else:
                         yield k, val
+
             return fast_iter()
         else:
             return super().items(

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1727,6 +1727,15 @@ class TensorDict(TensorDictBase):
                 ) from err
         return self
 
+    def _set_dict(
+        self,
+        d: dict[str, CompatibleType],
+        *,
+        validated: bool,
+    ):
+        assert validated == True, "Not Implemented for non-validated inputs"
+        self._tensordict = d
+
     def _set_tuple(
         self,
         key: NestedKey,

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -6216,7 +6216,8 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             self.items(include_nested=True, leaves_only=True, is_leaf=is_leaf)
         )
         all_leaves_flat = [
-            separator.join(key) if isinstance(key, tuple) else key for key, _ in all_leaves_items
+            separator.join(key) if isinstance(key, tuple) else key
+            for key, _ in all_leaves_items
         ]
 
         if len(set(all_leaves_flat)) < len(all_leaves_flat):
@@ -6243,9 +6244,10 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         else:
             result = self.empty()
             if hasattr(result, "_set_dict"):
-                result._set_dict({
-                    k: v for (_, v), k in zip(all_leaves_items, all_leaves_flat)
-                }, validated=True)
+                result._set_dict(
+                    {k: v for (_, v), k in zip(all_leaves_items, all_leaves_flat)},
+                    validated=True,
+                )
             else:
                 for (leaf, _), leaf_flat in zip(all_leaves_items, all_leaves_flat):
                     result._set_str(

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -6212,17 +6212,18 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         """
         if is_leaf is None:
             is_leaf = _is_leaf_nontensor
-        all_leaves = list(
-            self.keys(include_nested=True, leaves_only=True, is_leaf=is_leaf)
+        all_leaves_items = list(
+            self.items(include_nested=True, leaves_only=True, is_leaf=is_leaf)
         )
         all_leaves_flat = [
-            separator.join(key) if isinstance(key, tuple) else key for key in all_leaves
+            separator.join(key) if isinstance(key, tuple) else key for key, _ in all_leaves_items
         ]
-        if len(set(all_leaves_flat)) < len(set(all_leaves)):
+
+        if len(set(all_leaves_flat)) < len(all_leaves_flat):
             # find duplicates
             seen = set()
             conflicts = []
-            for leaf, leaf_flat in zip(all_leaves, all_leaves_flat):
+            for (leaf, _), leaf_flat in zip(all_leaves_items, all_leaves_flat):
                 if leaf_flat in seen:
                     conflicts.append(leaf)
                 else:
@@ -6233,7 +6234,7 @@ To temporarily permute a tensordict you can still user permute() as a context ma
         if inplace:
             # we will need to remove the empty tensordicts later on
             root_keys = set(self.keys())
-            for leaf, leaf_flat in zip(all_leaves, all_leaves_flat):
+            for (leaf, _), leaf_flat in zip(all_leaves_items, all_leaves_flat):
                 self.rename_key_(leaf, leaf_flat)
                 if isinstance(leaf, str):
                     root_keys.discard(leaf)
@@ -6241,14 +6242,19 @@ To temporarily permute a tensordict you can still user permute() as a context ma
             return self
         else:
             result = self.empty()
-            for leaf, leaf_flat in zip(all_leaves, all_leaves_flat):
-                result._set_str(
-                    leaf_flat,
-                    self.get(leaf),
-                    validated=True,
-                    inplace=False,
-                    non_blocking=False,
-                )
+            if hasattr(result, "_set_dict"):
+                result._set_dict({
+                    k: v for (_, v), k in zip(all_leaves_items, all_leaves_flat)
+                }, validated=True)
+            else:
+                for (leaf, _), leaf_flat in zip(all_leaves_items, all_leaves_flat):
+                    result._set_str(
+                        leaf_flat,
+                        self.get(leaf),
+                        validated=True,
+                        inplace=False,
+                        non_blocking=False,
+                    )
             # Uncomment if you want key operations to propagate the shared status
             # self._maybe_set_shared_attributes(result)
             if result._is_shared or result._is_memmap:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1016,12 +1016,12 @@ def _unfold_sequence(seq):
 
 
 def _make_cache_key(args, kwargs):
-    """Creats a key for the cache such that memory footprint is minimized."""
+    """Creates a key for the cache such that memory footprint is minimized."""
     # Fast path for the common args
     if not args and not kwargs:
-        key = ((), ())
+        return ((), ())
     elif not kwargs and len(args) == 1 and type(args[0]) is str:
-        key = (args, ())
+        return (args, ())
     else:
         return (
             tuple(_unfold_sequence(args)),

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1017,10 +1017,16 @@ def _unfold_sequence(seq):
 
 def _make_cache_key(args, kwargs):
     """Creats a key for the cache such that memory footprint is minimized."""
-    return (
-        tuple(_unfold_sequence(args)),
-        tuple(_unfold_sequence(sorted(kwargs.items()))),
-    )
+    # Fast path for the common args
+    if not args and not kwargs:
+        key = ((), ())
+    elif not kwargs and len(args) == 1 and type(args[0]) is str:
+        key = (args, ())
+    else:
+        return (
+            tuple(_unfold_sequence(args)),
+            tuple(_unfold_sequence(sorted(kwargs.items()))),
+        )
 
 
 def cache(fun):


### PR DESCRIPTION
This is a proposal for speedup improvements for TensorDict struct by adding fast path for common use cases.
I only tested test/test_tensordict.py locally (the subset that works on main), there is most likely a few things I missed!


Runtime is tested with
```python
from torch.nn import Transformer
from tensordict import TensorDict
import torch.utils.benchmark
t = Transformer()
td = TensorDict.from_module(t)

print(torch.utils.benchmark.Timer("td.flatten_keys()", globals=globals()).adaptive_autorange())
td.lock_()
print(torch.utils.benchmark.Timer("td.flatten_keys()", globals=globals()).adaptive_autorange())
print(torch.utils.benchmark.Timer("""td.flatten_keys(".")""", globals=globals()).adaptive_autorange())
```

Result before:
```
<torch.utils.benchmark.utils.common.Measurement object at 0x7f5c966e6a90>
td.flatten_keys()
  Median: 477.80 us
  IQR:    2.82 us (476.36 to 479.17)
  4 measurements, 1000 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7f5c95c67910>
td.flatten_keys()
  Median: 524.48 ns
  IQR:    3.03 ns (523.41 to 526.44)
  4 measurements, 100000 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7f5c95c677d0>
td.flatten_keys(".")
  Median: 727.95 ns
  IQR:    8.25 ns (724.57 to 732.82)
  4 measurements, 100000 runs per measurement, 1 thread

```

Result after:
```
<torch.utils.benchmark.utils.common.Measurement object at 0x7f1811c61250>
td.flatten_keys()
  Median: 226.33 us
  IQR:    0.10 us (226.25 to 226.34)
  4 measurements, 1000 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7f1810d1b1d0>
td.flatten_keys()
  Median: 159.65 ns
  IQR:    0.13 ns (159.57 to 159.70)
  4 measurements, 1000000 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7f1810d1aa10>
td.flatten_keys(".")
  Median: 216.46 ns
  IQR:    0.56 ns (216.21 to 216.77)
  4 measurements, 1000000 runs per measurement, 1 thread

```