### PR TITLE
[Feature] use return_mask as a string in pad_sequence  

### DIFF
--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -97,7 +97,7 @@ def pad_sequence(
             written.
         device (device compatible type, optional): if provded, the device where the
             TensorDict output will be created.
-        return_mask (bool, optional): if ``True``, a "masks" entry will be returned.
+        return_mask (bool, str): if ``True``, a "masks" entry will be returned. If ``return_mask`` is a string, it will be return the masks and be used as the key for the masks entry.
             It contains a tensordict with the same structure as the stacked tensordict where every entry contains the mask of valid values with size ``torch.Size([stack_len, *new_shape])``,
             where `new_shape[pad_dim] = max_seq_length` and the rest of the `new_shape` matches the previous shape of the contained tensors.
 

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -84,7 +84,7 @@ def pad_sequence(
     padding_value: float = 0.0,
     out: T | None = None,
     device: DeviceType | None = None,
-    return_mask: bool | str = False,
+    return_mask: bool | NestedKey = False,
 ) -> T:
     """Pads a list of tensordicts in order for them to be stacked together in a contiguous format.
 
@@ -97,7 +97,7 @@ def pad_sequence(
             written.
         device (device compatible type, optional): if provded, the device where the
             TensorDict output will be created.
-        return_mask (bool, str): if ``True``, a "masks" entry will be returned. If ``return_mask`` is a string, it will be return the masks and be used as the key for the masks entry.
+        return_mask (bool or NestedKey, optional): if ``True``, a "masks" entry will be returned. If ``return_mask`` is a nested key (string or tuple of strings), it will be return the masks and be used as the key for the masks entry.
             It contains a tensordict with the same structure as the stacked tensordict where every entry contains the mask of valid values with size ``torch.Size([stack_len, *new_shape])``,
             where `new_shape[pad_dim] = max_seq_length` and the rest of the `new_shape` matches the previous shape of the contained tensors.
 

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -133,8 +133,8 @@ def pad_sequence(
         raise RuntimeError("list_of_tensordicts cannot be empty")
 
     masks_key = "masks"
-    if isinstance(return_mask, str):
-        masks_key = return_mask
+    if not isinstance(return_mask, bool):
+        masks_key = unravel_key(return_mask)
         return_mask = True
 
     # check that all tensordict match

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1085,7 +1085,7 @@ class TestGeneric:
         assert torch.equal(padded_td["a"], expected_a)
         padded_td._check_batch_size()
 
-    @pytest.mark.parametrize("make_mask", [True, False])
+    @pytest.mark.parametrize("make_mask", [True, "bibbidi-bobbidi-boo", False])
     def test_pad_sequence_pad_dim0(self, make_mask):
         pad_dim = 0
         list_td = [
@@ -1115,22 +1115,25 @@ class TestGeneric:
             [2, 4, 3]
         )  # check the shape of the padded tensor
         assert torch.all(padded_td["b", "c"][0, 2:, :] == 0)  # check the padding
-        if make_mask:
+        if isinstance(make_mask, str) or make_mask:
+            masks_key = "masks"
+            if isinstance(make_mask, str):
+                masks_key = make_mask
             padded_td_without_masks = pad_sequence(
                 list_td, pad_dim=pad_dim, return_mask=False
             )
-            assert "masks" in padded_td.keys()
+            assert masks_key in padded_td.keys()
             assert set(
                 padded_td_without_masks.keys(include_nested=True, leaves_only=True)
-            ) == set(padded_td["masks"].keys(include_nested=True, leaves_only=True))
-            assert not padded_td["masks", "a"].all()
-            assert padded_td["masks", "a"].ndim == pad_dim + 2
-            assert (padded_td["a"][padded_td["masks", "a"]] != 0).all()
-            assert (padded_td["a"][~padded_td["masks", "a"]] == 0).all()
-            assert not padded_td["masks", "b", "c"].all()
-            assert padded_td["masks", "b", "c"].ndim == pad_dim + 2
-            assert (padded_td["b", "c"][padded_td["masks", "b", "c"]] != 0).all()
-            assert (padded_td["b", "c"][~padded_td["masks", "b", "c"]] == 0).all()
+            ) == set(padded_td[masks_key].keys(include_nested=True, leaves_only=True))
+            assert not padded_td[masks_key, "a"].all()
+            assert padded_td[masks_key, "a"].ndim == pad_dim + 2
+            assert (padded_td["a"][padded_td[masks_key, "a"]] != 0).all()
+            assert (padded_td["a"][~padded_td[masks_key, "a"]] == 0).all()
+            assert not padded_td[masks_key, "b", "c"].all()
+            assert padded_td[masks_key, "b", "c"].ndim == pad_dim + 2
+            assert (padded_td["b", "c"][padded_td[masks_key, "b", "c"]] != 0).all()
+            assert (padded_td["b", "c"][~padded_td[masks_key, "b", "c"]] == 0).all()
         else:
             assert "masks" not in padded_td.keys()
 
@@ -1164,22 +1167,25 @@ class TestGeneric:
             [2, 6, 7]
         )  # check the shape of the padded tensor
         assert torch.all(padded_td["b", "c"][0, :, 3:] == 0)  # check the padding
-        if make_mask:
+        if isinstance(make_mask, str) or make_mask:
+            masks_key = "masks"
+            if isinstance(make_mask, str):
+                masks_key = make_mask
             padded_td_without_masks = pad_sequence(
                 list_td, pad_dim=pad_dim, return_mask=False
             )
-            assert "masks" in padded_td.keys()
+            assert masks_key in padded_td.keys()
             assert set(
                 padded_td_without_masks.keys(include_nested=True, leaves_only=True)
-            ) == set(padded_td["masks"].keys(include_nested=True, leaves_only=True))
-            assert not padded_td["masks", "a"].all()
-            assert padded_td["masks", "a"].ndim == pad_dim + 2
-            assert (padded_td["a"][padded_td["masks", "a"]] != 0).all()
-            assert (padded_td["a"][~padded_td["masks", "a"]] == 0).all()
-            assert not padded_td["masks", "b", "c"].all()
-            assert padded_td["masks", "b", "c"].ndim == pad_dim + 2
-            assert (padded_td["b", "c"][padded_td["masks", "b", "c"]] != 0).all()
-            assert (padded_td["b", "c"][~padded_td["masks", "b", "c"]] == 0).all()
+            ) == set(padded_td[masks_key].keys(include_nested=True, leaves_only=True))
+            assert not padded_td[masks_key, "a"].all()
+            assert padded_td[masks_key, "a"].ndim == pad_dim + 2
+            assert (padded_td["a"][padded_td[masks_key, "a"]] != 0).all()
+            assert (padded_td["a"][~padded_td[masks_key, "a"]] == 0).all()
+            assert not padded_td[masks_key, "b", "c"].all()
+            assert padded_td[masks_key, "b", "c"].ndim == pad_dim + 2
+            assert (padded_td["b", "c"][padded_td[masks_key, "b", "c"]] != 0).all()
+            assert (padded_td["b", "c"][~padded_td[masks_key, "b", "c"]] == 0).all()
         else:
             assert "masks" not in padded_td.keys()
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1085,7 +1085,7 @@ class TestGeneric:
         assert torch.equal(padded_td["a"], expected_a)
         padded_td._check_batch_size()
 
-    @pytest.mark.parametrize("make_mask", [True, "bibbidi-bobbidi-boo", False])
+    @pytest.mark.parametrize("make_mask", [True, ("bibbidi", "bobbidi", "boo"), False])
     def test_pad_sequence_pad_dim0(self, make_mask):
         pad_dim = 0
         list_td = [


### PR DESCRIPTION
## Description

This PR augments the ```pad_sequence``` function by allowing the parameter ```return _mask``` to be either a ```bool ``` or ```str```. In case ```return_mask``` is a ```bool```, the function behaves as before, but if ```return_mask``` is a ```str```, then the provided string becomes the key for the padding masks instead of "masks".

Additionally, for debugging purposes, if the TensorDict contains scalar tensors i.e. ```torch.Size([])```, the function raises a runtime error that the method does not support padding scalar tensors. This is consistent with ```torch.nn.utils.rnn.pad_sequence```. In case, we would like to support this we could just unqueeze such tensors. 

## Motivation and Context

In case the user already has some masks within the TensorDict under a key "masks" this will prevent the issue of renaming the masks such that they won't be overwritten by this method.

`close #726`

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
