### PR TITLE
[Feature] Load tensordicts on device, incl. meta

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2051,13 +2051,17 @@ class LazyStackedTensorDict(TensorDictBase):
         return results
 
     @classmethod
-    def _load_memmap(cls, prefix: str, metadata: dict) -> LazyStackedTensorDict:
+    def _load_memmap(
+        cls, prefix: str, metadata: dict, **kwargs
+    ) -> LazyStackedTensorDict:
         tensordicts = []
         i = 0
         while (prefix / str(i)).exists():
-            tensordicts.append(TensorDict.load_memmap(prefix / str(i)))
+            tensordicts.append(
+                TensorDict.load_memmap(prefix / str(i), **kwargs, non_blocking=False)
+            )
             i += 1
-        return cls(*tensordicts, stack_dim=metadata["stack_dim"])
+        return cls(*tensordicts, stack_dim=metadata["stack_dim"], **kwargs)
 
     def expand(self, *args: int, inplace: bool = False) -> T:
         if len(args) == 1 and isinstance(args[0], Sequence):
@@ -2990,13 +2994,13 @@ class _CustomOpTensorDict(TensorDictBase):
         return dest
 
     @classmethod
-    def _load_memmap(cls, prefix: str, metadata: dict) -> _CustomOpTensorDict:
+    def _load_memmap(cls, prefix: str, metadata: dict, **kwargs) -> _CustomOpTensorDict:
         custom_op = metadata.pop("custom_op")
         inv_op = metadata.pop("inv_op")
         custom_op_kwargs = metadata.pop("custom_op_kwargs")
         inv_op_kwargs = metadata.pop("inv_op_kwargs")
 
-        source = TensorDict.load_memmap(prefix / "_source")
+        source = TensorDict.load_memmap(prefix / "_source", **kwargs, non_blocking=True)
 
         return cls(
             source,

--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2052,13 +2052,15 @@ class LazyStackedTensorDict(TensorDictBase):
 
     @classmethod
     def _load_memmap(
-        cls, prefix: str, metadata: dict, **kwargs
+        cls, prefix: str, metadata: dict, device: torch.device | None = None, **kwargs
     ) -> LazyStackedTensorDict:
         tensordicts = []
         i = 0
         while (prefix / str(i)).exists():
             tensordicts.append(
-                TensorDict.load_memmap(prefix / str(i), **kwargs, non_blocking=False)
+                TensorDict.load_memmap(
+                    prefix / str(i), device=device, **kwargs, non_blocking=True
+                )
             )
             i += 1
         return cls(*tensordicts, stack_dim=metadata["stack_dim"], **kwargs)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2255,7 +2255,9 @@ class TensorDict(TensorDictBase):
             ):
                 # invalid dict means
                 continue
-            if device is None or device != torch.device("meta"):
+            if (
+                device is None or device != torch.device("meta")
+            ) and not torch._guards.active_fake_mode():
                 tensor = MemoryMappedTensor.from_filename(
                     dtype=_STRDTYPE2DTYPE[dtype],
                     shape=torch.Size(entry_metadata["shape"]),
@@ -2266,7 +2268,7 @@ class TensorDict(TensorDictBase):
             else:
                 tensor = torch.zeros(
                     torch.Size(entry_metadata["shape"]),
-                    device=torch.device("meta"),
+                    device=device,
                     dtype=_STRDTYPE2DTYPE[dtype],
                 )
             out._set_str(

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2222,14 +2222,20 @@ class TensorDict(TensorDictBase):
         return dest
 
     @classmethod
-    def _load_memmap(cls, prefix: str, metadata: dict) -> T:
+    def _load_memmap(
+        cls, prefix: str, metadata: dict, device: torch.device | None = None
+    ) -> T:
         if metadata["device"] == "None":
             metadata["device"] = None
         else:
             metadata["device"] = torch.device(metadata["device"])
         metadata["shape"] = torch.Size(metadata["shape"])
 
-        out = cls({}, batch_size=metadata.pop("shape"), device=metadata.pop("device"))
+        out = cls(
+            {},
+            batch_size=metadata.pop("shape"),
+            device=metadata.pop("device") if device is None else device,
+        )
 
         paths = set()
         for key, entry_metadata in metadata.items():
@@ -2249,13 +2255,23 @@ class TensorDict(TensorDictBase):
             ):
                 # invalid dict means
                 continue
-            out._set_str(
-                key,
-                MemoryMappedTensor.from_filename(
+            if device is None or device != torch.device("meta"):
+                tensor = MemoryMappedTensor.from_filename(
                     dtype=_STRDTYPE2DTYPE[dtype],
                     shape=torch.Size(entry_metadata["shape"]),
                     filename=str(prefix / f"{key}.memmap"),
-                ),
+                )
+                if device is not None:
+                    tensor = tensor.to(device, non_blocking=True)
+            else:
+                tensor = torch.zeros(
+                    torch.Size(entry_metadata["shape"]),
+                    device=torch.device("meta"),
+                    dtype=_STRDTYPE2DTYPE[dtype],
+                )
+            out._set_str(
+                key,
+                tensor,
                 validated=True,
                 inplace=False,
                 non_blocking=False,
@@ -2264,7 +2280,9 @@ class TensorDict(TensorDictBase):
         for path in prefix.iterdir():
             if path.is_dir() and path.parts[-1] in paths:
                 key = path.parts[len(prefix.parts) :]
-                out.set(key, TensorDict.load_memmap(path))
+                out.set(
+                    key, TensorDict.load_memmap(path, device=device, non_blocking=True)
+                )
         return out
 
     def to(self, *args, **kwargs: Any) -> T:
@@ -3323,10 +3341,13 @@ class _SubTensorDict(TensorDictBase):
         return result
 
     @classmethod
-    def _load_memmap(cls, prefix: Path, metadata: dict):
+    def _load_memmap(
+        cls, prefix: Path, metadata: dict, device: torch.device | None = None
+    ):
         index = metadata["index"]
         return _SubTensorDict(
-            TensorDict.load_memmap(prefix / "_source"), _str_to_index(index)
+            TensorDict.load_memmap(prefix / "_source", device=device),
+            _str_to_index(index),
         )
 
     def share_memory_(self) -> T:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2608,7 +2608,9 @@ class TensorDictBase(MutableMapping):
 
     @classmethod
     @abc.abstractmethod
-    def _load_memmap(cls, prefix: Path, metadata: dict):
+    def _load_memmap(
+        cls, prefix: Path, metadata: dict, device: torch.device | None = None
+    ):
         ...
 
     # Key functionality: set, get, set_, set_at_, update, update_

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2578,6 +2578,43 @@ class TensorDictBase(MutableMapping):
             >>> nested = TensorDict.load_memmap("./saved_td/nested")
             >>> assert nested["e"] == 0
 
+        A tensordict can also be loaded on "meta" device or, alternatively,
+        as a fake tensor:
+            >>> import tempfile
+            >>> td = TensorDict({"a": torch.zeros(()), "b": {"c": torch.zeros(())}})
+            >>> with tempfile.TemporaryDirectory() as path:
+            ...     td.save(path)
+            ...     td_load = TensorDict.load_memmap(path, device="meta")
+            ...     print("meta:", td_load)
+            ...     from torch._subclasses import FakeTensorMode
+            ...     with FakeTensorMode():
+            ...         td_load = TensorDict.load_memmap(path)
+            ...         print("fake:", td_load)
+            meta: TensorDict(
+                fields={
+                    a: Tensor(shape=torch.Size([]), device=meta, dtype=torch.float32, is_shared=False),
+                    b: TensorDict(
+                        fields={
+                            c: Tensor(shape=torch.Size([]), device=meta, dtype=torch.float32, is_shared=False)},
+                        batch_size=torch.Size([]),
+                        device=meta,
+                        is_shared=False)},
+                batch_size=torch.Size([]),
+                device=meta,
+                is_shared=False)
+            fake: TensorDict(
+                fields={
+                    a: FakeTensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                    b: TensorDict(
+                        fields={
+                            c: FakeTensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False)},
+                        batch_size=torch.Size([]),
+                        device=cpu,
+                        is_shared=False)},
+                batch_size=torch.Size([]),
+                device=cpu,
+                is_shared=False)
+
         """
         prefix = Path(prefix)
 

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -609,13 +609,13 @@ def _share_memory_(self):
     return self
 
 
-def _load_memmap(cls, prefix: Path, metadata: dict):
+def _load_memmap(cls, prefix: Path, metadata: dict, **kwargs):
     non_tensordict = copy(metadata)
     del non_tensordict["_type"]
     if os.path.exists(prefix / "other.pickle"):
         with open(prefix / "other.pickle", "rb") as pickle_file:
             non_tensordict.update(pickle.load(pickle_file))
-    td = TensorDict.load_memmap(prefix / "_tensordict")
+    td = TensorDict.load_memmap(prefix / "_tensordict", **kwargs, non_blocking=False)
     return cls._from_tensordict(td, non_tensordict)
 
 
@@ -2390,7 +2390,9 @@ class NonTensorStack(LazyStackedTensorDict):
         return results
 
     @classmethod
-    def _load_memmap(cls, prefix: str, metadata: dict) -> LazyStackedTensorDict:
+    def _load_memmap(
+        cls, prefix: str, metadata: dict, **kwargs
+    ) -> LazyStackedTensorDict:
         data = metadata.get("data", None)
         if data is not None:
             if isinstance(data, str):
@@ -2400,7 +2402,7 @@ class NonTensorStack(LazyStackedTensorDict):
             if device is not None:
                 device = torch.device(device)
             return cls._from_list(data, device=device)
-        return super()._load_memmap(prefix=prefix, metadata=metadata)
+        return super()._load_memmap(prefix=prefix, metadata=metadata, **kwargs)
 
     @classmethod
     def _from_list(cls, datalist: List, device: torch.device):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1015,6 +1015,7 @@ class TestGeneric:
             pytest.skip("no device to test")
         device_state_dict = TensorDict.load(tmpdir, device=device)
         assert (device_state_dict == 0).all()
+
         def assert_device(item):
             assert item.device == torch.device(device)
             if is_tensor_collection(item):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -29,7 +29,7 @@ from _utils_internal import (
     prod,
     TestTensorDictsBase,
 )
-from torch._subclasses import FakeTensorMode, FakeTensor
+from torch._subclasses import FakeTensor, FakeTensorMode
 
 try:
     from functorch import dim as ftdim
@@ -1026,8 +1026,10 @@ class TestGeneric:
 
         with FakeTensorMode():
             fake_state_dict = TensorDict.load(tmpdir)
+
             def assert_fake(tensor):
                 assert isinstance(tensor, FakeTensor)
+
             fake_state_dict.apply(assert_fake)
 
     def test_load_state_dict_incomplete(self):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1008,9 +1008,9 @@ class TestGeneric:
         meta_state_dict.apply(check_meta, filter_empty=True)
 
         if torch.cuda.is_available():
-            device = "cuda"
+            device = "cuda:0"
         elif torch.backends.mps.is_available():
-            device = "mps"
+            device = "mps:0"
         else:
             pytest.skip("no device to test")
         device_state_dict = TensorDict.load(tmpdir, device=device)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -991,6 +991,37 @@ class TestGeneric:
         assert leaves == set()
         assert leaves_nested == {("a", "b", "c")}
 
+    def test_load_device(self, tmpdir):
+        t = nn.Transformer(
+            d_model=64, nhead=4, num_encoder_layers=3, dim_feedforward=128
+        )
+
+        state_dict = TensorDict.from_module(t)
+        state_dict.data.zero_()
+
+        state_dict.save(tmpdir)
+        meta_state_dict = TensorDict.load(tmpdir, device="meta")
+
+        def check_meta(tensor):
+            assert tensor.device == torch.device("meta")
+
+        meta_state_dict.apply(check_meta, filter_empty=True)
+
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            pytest.skip("no device to test")
+        device_state_dict = TensorDict.load(tmpdir, device=device)
+        assert (device_state_dict == 0).all()
+        def assert_device(item):
+            assert item.device == torch.device(device)
+            if is_tensor_collection(item):
+                item.apply(assert_device, filter_empty=True, call_on_nested=True)
+
+        device_state_dict.apply(assert_device, filter_empty=True, call_on_nested=True)
+
     def test_load_state_dict_incomplete(self):
         data = TensorDict({"a": {"b": {"c": {}}}, "d": 1}, [])
         sd = TensorDict({"d": 0}, []).state_dict()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -29,6 +29,7 @@ from _utils_internal import (
     prod,
     TestTensorDictsBase,
 )
+from torch._subclasses import FakeTensorMode, FakeTensor
 
 try:
     from functorch import dim as ftdim
@@ -1022,6 +1023,12 @@ class TestGeneric:
                 item.apply(assert_device, filter_empty=True, call_on_nested=True)
 
         device_state_dict.apply(assert_device, filter_empty=True, call_on_nested=True)
+
+        with FakeTensorMode():
+            fake_state_dict = TensorDict.load(tmpdir)
+            def assert_fake(tensor):
+                assert isinstance(tensor, FakeTensor)
+            fake_state_dict.apply(assert_fake)
 
     def test_load_state_dict_incomplete(self):
         data = TensorDict({"a": {"b": {"c": {}}}, "d": 1}, [])


### PR DESCRIPTION
Allows to load (asynchronously) a tensordict on device, or on "meta" (ie creating a meta-tensordict without reading any data except metadata)


Test the feature:
```python
import tempfile

from tensordict import TensorDict, is_tensor_collection
from torch.nn import Transformer
import torch

with tempfile.TemporaryDirectory() as tmpdir:
    t = Transformer(
        d_model=64, nhead=4, num_encoder_layers=3, dim_feedforward=128
    )

    state_dict = TensorDict.from_module(t)
    state_dict.data.zero_()

    state_dict.save(tmpdir)
    meta_state_dict = TensorDict.load(tmpdir, device="meta")


    def check_meta(tensor):
        assert tensor.device == torch.device("meta")


    meta_state_dict.apply(check_meta, filter_empty=True)

    if torch.cuda.is_available():
        device = "cuda:0"
    elif torch.backends.mps.is_available():
        device = "mps:0"
    device_state_dict = TensorDict.load(tmpdir, device=device)
    assert (device_state_dict == 0).all()


    def assert_device(item):
        assert item.device == torch.device(device), (device, item.device)
        if is_tensor_collection(item):
            item.apply(assert_device, filter_empty=True, call_on_nested=True)

    device_state_dict.apply(assert_device, filter_empty=True, call_on_nested=True)

```