### PR TITLE
[BugFix] Read-only compatibility in MemoryMappedTensor

### DIFF
--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -714,13 +714,12 @@ class MemoryMappedTensor(torch.Tensor):
         """
         try:
             # Try opening the file in write mode
-            with open(filename, "w"):
+            with open(filename, "a+"):
                 # If we get here, the file is writable
                 writable = True
         except PermissionError:
             # An exception was raised, so the file is not writable
             writable = False
-        print('writable', writable)
         if isinstance(shape, torch.Tensor):
             func_offset_stride = getattr(
                 torch, "_nested_compute_contiguous_strides_offsets", None
@@ -745,7 +744,6 @@ class MemoryMappedTensor(torch.Tensor):
                     mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
                     tensor = torch.frombuffer(mm, dtype=dtype)
                     # mm.close()
-
             tensor = torch._nested_view_from_buffer(
                 tensor,
                 shape,

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -266,7 +266,7 @@ class MemoryMappedTensor(torch.Tensor):
                 result = result.view(shape)
             result = cls(result)
         result._handler = handler
-        result._filename = filename
+        result.filename = filename
         result.index = None
         result.parent_shape = shape
         if copy_data:
@@ -321,7 +321,7 @@ class MemoryMappedTensor(torch.Tensor):
 
         tensor = cls(tensor)
         if filename is not None:
-            tensor._filename = filename
+            tensor.filename = filename
         elif handler is not None:
             tensor._handler = handler
         if index is not None:
@@ -338,6 +338,14 @@ class MemoryMappedTensor(torch.Tensor):
         if filename is None:
             raise RuntimeError("The MemoryMappedTensor has no file associated.")
         return filename
+
+    @filename.setter
+    def filename(self, value):
+        if self._filename is not None and str(value) != self._filename:
+            raise RuntimeError(
+                "the MemoryMappedTensor has already a filename associated."
+            )
+        self._filename = str(Path(value).absolute())
 
     @classmethod
     def empty_like(cls, input, *, filename=None):
@@ -596,7 +604,7 @@ class MemoryMappedTensor(torch.Tensor):
                     *offsets_strides,
                 )
                 result = cls(result)
-                result._filename = filename
+                result.filename = filename
                 return result
             return result
 
@@ -765,7 +773,7 @@ class MemoryMappedTensor(torch.Tensor):
         if index is not None:
             tensor = tensor[index]
         out = cls(tensor)
-        out._filename = filename
+        out.filename = filename
         out._handler = None
         out.index = index
         out.parent_shape = shape
@@ -811,7 +819,7 @@ class MemoryMappedTensor(torch.Tensor):
         if index is not None:
             out = out[index]
         out = cls(out)
-        out._filename = None
+        out.filename = None
         out._handler = handler
         out.index = index
         out.parent_shape = shape
@@ -904,7 +912,7 @@ class MemoryMappedTensor(torch.Tensor):
             return tensor
         tensor = MemoryMappedTensor(tensor)
         tensor._handler = getattr(self, "_handler", None)
-        tensor._filename = getattr(self, "_filename", None)
+        tensor.filename = getattr(self, "_filename", None)
         tensor.index = item
         tensor.parent_shape = getattr(self, "parent_shape", None)
         return tensor

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -724,7 +724,6 @@ class MemoryMappedTensor(torch.Tensor):
                 tensor.
 
         """
-
         writable = _is_writable(filename)
 
         if isinstance(shape, torch.Tensor):

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -720,7 +720,7 @@ class MemoryMappedTensor(torch.Tensor):
         except PermissionError:
             # An exception was raised, so the file is not writable
             writable = False
-
+        print('writable', writable)
         if isinstance(shape, torch.Tensor):
             func_offset_stride = getattr(
                 torch, "_nested_compute_contiguous_strides_offsets", None
@@ -758,12 +758,11 @@ class MemoryMappedTensor(torch.Tensor):
                 tensor = torch.from_file(
                     str(filename), shared=True, dtype=dtype, size=shape.numel()
                 )
-                tensor = tensor.view(shape)
             else:
                 with open(str(filename), "rb") as f:
                     mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
                     tensor = torch.frombuffer(mm, dtype=dtype)
-                    tensor = tensor.view(shape)
+            tensor = tensor.view(shape)
 
         if index is not None:
             tensor = tensor[index]

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -341,11 +341,12 @@ class MemoryMappedTensor(torch.Tensor):
 
     @filename.setter
     def filename(self, value):
-        if self._filename is not None and str(value) != self._filename:
+        value = str(Path(value).absolute())
+        if self._filename is not None and value != self._filename:
             raise RuntimeError(
                 "the MemoryMappedTensor has already a filename associated."
             )
-        self._filename = str(Path(value).absolute())
+        self._filename = value
 
     @classmethod
     def empty_like(cls, input, *, filename=None):

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -341,6 +341,8 @@ class MemoryMappedTensor(torch.Tensor):
 
     @filename.setter
     def filename(self, value):
+        if value is None and self._filename is None:
+            return
         value = str(Path(value).absolute())
         if self._filename is not None and value != self._filename:
             raise RuntimeError(

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -711,6 +711,7 @@ class TestNestedTensor:
         del td
         gc.collect()
         td = TensorDict.load(tmpdir)
+        print('td', td)
         for i in range(2):
             for j in range(3):
                 assert (td[i, j] == tdsave[i, j]).all()

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -707,11 +707,12 @@ class TestNestedTensor:
             batch_size=[2, 3],
         )
         tdsave = td.clone()
+        print("tdsave", tdsave)
         td.memmap(tmpdir)
         del td
         gc.collect()
         td = TensorDict.load(tmpdir)
-        print('td', td)
+        print("td", td)
         for i in range(2):
             for j in range(3):
                 assert (td[i, j] == tdsave[i, j]).all()

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -158,7 +158,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
         assert (t == 0).all()
 
     @pytest.mark.parametrize("shape_arg", ["expand", "arg", "kwarg"])
@@ -192,7 +192,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
         assert (t == 1).all()
 
     @pytest.mark.parametrize("shape_arg", ["expand", "arg", "kwarg"])
@@ -226,7 +226,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
 
     @pytest.mark.parametrize("shape_arg", ["expand", "arg", "kwarg"])
     def test_full(self, shape, dtype, device, tmp_path, from_path, shape_arg):
@@ -259,7 +259,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
         assert (t == 2).all()
 
     def test_zeros_like(self, shape, dtype, device, tmp_path, from_path):
@@ -273,7 +273,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
         assert (t == 0).all()
 
     def test_ones_like(self, shape, dtype, device, tmp_path, from_path):
@@ -287,7 +287,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
         assert (t == 1).all()
 
     def test_full_like(self, shape, dtype, device, tmp_path, from_path):
@@ -301,7 +301,7 @@ class TestConstructors:
         if dtype is not None:
             assert t.dtype is dtype
         if filename is not None:
-            assert t.filename == filename
+            assert t.filename == str(Path(filename).absolute())
         assert (t == 2).all()
 
     def test_from_filename(self, shape, dtype, device, tmp_path, from_path):

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -707,12 +707,10 @@ class TestNestedTensor:
             batch_size=[2, 3],
         )
         tdsave = td.clone()
-        print("tdsave", tdsave)
         td.memmap(tmpdir)
         del td
         gc.collect()
         td = TensorDict.load(tmpdir)
-        print("td", td)
         for i in range(2):
             for j in range(3):
                 assert (td[i, j] == tdsave[i, j]).all()
@@ -747,7 +745,7 @@ class TestReadWrite:
         tmpdir = Path(tmpdir)
         file_path = tmpdir / "elt.mmap"
         data = MemoryMappedTensor.from_tensor(torch.arange(26), filename=file_path)
-        MemoryMappedTensor.from_storage(
+        mmap = MemoryMappedTensor.from_storage(
             data.untyped_storage(),
             filename=file_path,
             shape=torch.tensor([[2, 3], [4, 5]]),
@@ -768,6 +766,12 @@ class TestReadWrite:
         )
         assert (mmap1[0].view(-1) == torch.arange(6)).all()
         assert (mmap1[1].view(-1) == torch.arange(6, 26)).all()
+        # test filename
+        assert mmap1.filename == mmap.filename
+        assert mmap1.filename == data.filename
+        assert mmap1.filename == data.untyped_storage().filename
+        with pytest.raises(AssertionError):
+            assert mmap1.untyped_storage().filename == data.untyped_storage().filename
 
         os.chmod(str(file_path), 0o444)
         data.fill_(0)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -5,6 +5,7 @@
 import argparse
 import gc
 import os
+import time
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -726,10 +727,12 @@ class TestReadWrite:
         mmap.copy_(torch.arange(6).view(2, 3))
 
         # change permission
-        os.chmod(str(file_path), 0o444)
+        os.chmod(str(file_path.absolute()), 0o444)
+
+        time.sleep(0.02)
         # check read only
         with pytest.raises(PermissionError):
-            with open(file_path, "w"):
+            with open(file_path, "w+"):
                 pass
         with open(file_path, "r"):
             pass
@@ -752,10 +755,12 @@ class TestReadWrite:
             dtype=data.dtype,
         )
         # change permission
-        os.chmod(str(file_path), 0o444)
+        os.chmod(str(file_path.absolute()), 0o444)
+
+        time.sleep(0.02)
         # check read only
         with pytest.raises(PermissionError):
-            with open(file_path, "w"):
+            with open(file_path, "w+"):
                 pass
         with open(file_path, "r"):
             pass

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -6,7 +6,6 @@ import argparse
 import gc
 import os
 import stat
-import time
 from contextlib import nullcontext
 from pathlib import Path
 

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -746,6 +746,7 @@ class TestReadWrite:
         )
         assert (mmap.reshape(-1) == torch.arange(6)).all()
 
+    @pytest.mark.skipif(not HAS_NESTED_TENSOR, reason="Nested tensor incomplete")
     def test_read_only_nested(self, tmpdir):
         tmpdir = Path(tmpdir)
         file_path = tmpdir / "elt.mmap"


### PR DESCRIPTION
Unfortunately I didn't manage to find a way to make the error more explicit if the file is being written when it isn't writable (currently this will raise a segfault).

Also the workaround I found doesn't give you a storage with a filename associated - it's a bit hacky from that point of view. MemoryMappedTensor will have its filename attribute set however. See tests for more context

cc @albanD, @MateuszGuzek @mikaylagawarecki 