### PR TITLE
[BugFix] Check if the current user has write access

### DIFF
--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -1073,7 +1073,6 @@ def _chunk(input, chunks, dim=0):
 def _is_writable(file_path):
     file_path = str(file_path)
     if os.path.exists(file_path):
-        st = os.stat(file_path)
-        return bool(st.st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+        return os.access(file_path, os.W_OK)
     # Assume that the file can be written in the directory
     return True

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -9,7 +9,6 @@ import functools
 
 import mmap
 import os
-import stat
 
 import sys
 import tempfile

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -718,6 +718,7 @@ class TestNestedTensor:
 
 
 class TestReadWrite:
+    @pytest.mark.skipif(os.getuid() == 0, reason="root can write to read-only files")
     def test_read_only(self, tmpdir):
         tmpdir = Path(tmpdir)
         file_path = tmpdir / "elt.mmap"
@@ -747,6 +748,7 @@ class TestReadWrite:
         assert (mmap.reshape(-1) == torch.arange(6)).all()
 
     @pytest.mark.skipif(not HAS_NESTED_TENSOR, reason="Nested tensor incomplete")
+    @pytest.mark.skipif(os.getuid() == 0, reason="root can write to read-only files")
     def test_read_only_nested(self, tmpdir):
         tmpdir = Path(tmpdir)
         file_path = tmpdir / "elt.mmap"


### PR DESCRIPTION
## Description

Currently _is_writable check if any user or group can write to file. In practice, we want to chek if active user can do that. The simple fix should solve the issue, I tested it locally on a problematic file where owner could write to but group not. With the proposed changes, it works.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
