### PR TITLE
[Feature] remove distutils dependency and enable 3.12 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,7 @@ def _main(argv):
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Development Status :: 4 - Beta",
         ],
     )

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -426,7 +426,7 @@ class TensorDictBase(MutableMapping):
         *,
         dtype: torch.dtype | None = None,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the mean value of all elements in the input tensordit.
+        """Returns the mean value of all elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless
@@ -455,7 +455,7 @@ class TensorDictBase(MutableMapping):
         *,
         dtype: torch.dtype | None = None,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the mean of all non-NaN elements in the input tensordit.
+        """Returns the mean of all non-NaN elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless
@@ -484,7 +484,7 @@ class TensorDictBase(MutableMapping):
         *,
         dtype: torch.dtype | None = None,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the produce of values of all elements in the input tensordit.
+        """Returns the produce of values of all elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless
@@ -519,7 +519,7 @@ class TensorDictBase(MutableMapping):
         *,
         dtype: torch.dtype | None = None,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the sum value of all elements in the input tensordit.
+        """Returns the sum value of all elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless
@@ -548,7 +548,7 @@ class TensorDictBase(MutableMapping):
         *,
         dtype: torch.dtype | None = None,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the sum of all non-NaN elements in the input tensordit.
+        """Returns the sum of all non-NaN elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless
@@ -577,7 +577,7 @@ class TensorDictBase(MutableMapping):
         *,
         correction: int = 1,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the standard deviation value of all elements in the input tensordit.
+        """Returns the standard deviation value of all elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless
@@ -608,7 +608,7 @@ class TensorDictBase(MutableMapping):
         *,
         correction: int = 1,
     ) -> bool | TensorDictBase:  # noqa: D417
-        """Returns the variance value of all elements in the input tensordit.
+        """Returns the variance value of all elements in the input tensordict.
 
         Args:
             dim (int, tuple of int, optional): if ``None``, returns a dimensionless

--- a/tensordict/nn/distributions/composite.py
+++ b/tensordict/nn/distributions/composite.py
@@ -109,7 +109,7 @@ class CompositeDistribution(d.Distribution):
         )
 
     def log_prob(self, sample: TensorDictBase) -> TensorDictBase:
-        """Writes a ``<sample>_log_prob entry`` for each sample in the input tensordit, along with a ``"sample_log_prob"`` entry with the summed log-prob."""
+        """Writes a ``<sample>_log_prob entry`` for each sample in the input tensordict, along with a ``"sample_log_prob"`` entry with the summed log-prob."""
         slp = 0.0
         d = {}
         for name, dist in self.dists.items():

--- a/tensordict/nn/utils.py
+++ b/tensordict/nn/utils.py
@@ -11,8 +11,8 @@ import os
 from typing import Any, Callable
 
 import torch
-from torch import nn
 from tensordict.utils import strtobool
+from torch import nn
 
 AUTO_MAKE_FUNCTIONAL = strtobool(os.environ.get("AUTO_MAKE_FUNCTIONAL", "False"))
 

--- a/tensordict/nn/utils.py
+++ b/tensordict/nn/utils.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import functools
 import inspect
 import os
-from distutils.util import strtobool
 from typing import Any, Callable
 
 import torch
 from torch import nn
+from tensordict.utils import strtobool
 
 AUTO_MAKE_FUNCTIONAL = strtobool(os.environ.get("AUTO_MAKE_FUNCTIONAL", "False"))
 

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -161,9 +161,9 @@ def strtobool(val):
     'val' is anything else.
     """
     val = val.lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ("n", "no", "f", "false", "off", "0"):
         return 0
     else:
         raise ValueError(f"invalid truth value {val!r}")

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -19,7 +19,6 @@ import warnings
 from collections import defaultdict, OrderedDict
 from collections.abc import KeysView
 from copy import copy
-from distutils.util import strtobool
 from functools import wraps
 from importlib import import_module
 from numbers import Number
@@ -152,6 +151,22 @@ console_handler.setLevel(logging.INFO)
 formatter = logging.Formatter("%(asctime)s [%(name)s][%(levelname)s] %(message)s")
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 def _sub_index(tensor: Tensor, idx: IndexType) -> Tensor:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1385,7 +1385,7 @@ def _get_leaf_tensordict(
     tensordict: T, key: tuple[str, ...], hook: Callable = None
 ) -> tuple[TensorDictBase, str]:
     # utility function for traversing nested tensordicts
-    # hook should return the default value for tensordit.get(key)
+    # hook should return the default value for tensordict.get(key)
     while len(key) > 1:
         if hook is not None:
             tensordict = hook(tensordict, key)

--- a/tutorials/sphinx_tuto/tensorclass_imagenet.py
+++ b/tutorials/sphinx_tuto/tensorclass_imagenet.py
@@ -31,7 +31,6 @@ Batched data loading with tensorclasses
 #
 import os
 import time
-from distutils.util import strtobool
 from pathlib import Path
 
 import torch
@@ -40,6 +39,7 @@ import tqdm
 
 from tensordict import MemoryMappedTensor
 from tensordict.prototype import tensorclass
+from tensordict.utils import strtobool
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 


### PR DESCRIPTION
## Description

The current use of deprecated `distutils` is fairly limited and is the last reason for `tensordict` being incompatible with python 3.12.
This PR brings [distutils' implementation of `strtobool`](https://github.com/pypa/distutils/blob/4549de12976703a135c0b9db71e5aaa3ba0f34a6/distutils/util.py#L334) to `tensordict/utils.py`.

Note: Although `distutils` is not anymore required as a runtime dependency and `tensordict` now being compatible with python 3.12, there remains a reference to `distutils.command.clean` in [setup.py](https://github.com/pytorch/tensordict/blob/7e8cba9b2e620471132cd3184f5458d1ffb91009/setup.py#L85-L99).

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
