### PR TITLE
[Refactor] use from_file instead of mmap+from_buffer for readonly files

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1201,7 +1201,13 @@ class TensorDict(TensorDictBase):
         is_shared = self._is_shared
         is_memmap = self._is_memmap
 
-        def empty():
+        def empty(
+            batch_size=batch_size,
+            names=names,
+            device=device,
+            is_shared=is_shared,
+            is_memmap=is_memmap,
+        ):
             result = TensorDict(
                 {}, batch_size=batch_size, names=names, _run_checks=False, device=device
             )

--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -46,7 +46,7 @@ except ImportError:
     from torch.utils._pytree import tree_flatten
 
     def tree_leaves(pytree):
-        """torch 2.0 compatible version of tree_leaves."""
+        """Torch 2.0 compatible version of tree_leaves."""
         return tree_flatten(pytree)[0]
 
 

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -737,18 +737,12 @@ class MemoryMappedTensor(torch.Tensor):
                     "nested tensors. Please upgrade to a more recent "
                     "version."
                 )
-            if writable:
-                tensor = torch.from_file(
-                    str(filename),
-                    shared=True,
-                    dtype=dtype,
-                    size=shape.prod(-1).sum().int(),
-                )
-            else:
-                with open(str(filename), "rb") as f:
-                    mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
-                    tensor = torch.frombuffer(mm, dtype=dtype)
-                    # mm.close()
+            tensor = torch.from_file(
+                str(filename),
+                shared=writable,
+                dtype=dtype,
+                size=shape.prod(-1).sum().int(),
+            )
             tensor = torch._nested_view_from_buffer(
                 tensor,
                 shape,
@@ -757,14 +751,9 @@ class MemoryMappedTensor(torch.Tensor):
         else:
             shape = torch.Size(shape)
             # whether the file already existed
-            if writable:
-                tensor = torch.from_file(
-                    str(filename), shared=True, dtype=dtype, size=shape.numel()
-                )
-            else:
-                with open(str(filename), "rb") as f:
-                    mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
-                    tensor = torch.frombuffer(mm, dtype=dtype)
+            tensor = torch.from_file(
+                str(filename), shared=writable, dtype=dtype, size=shape.numel()
+            )
             tensor = tensor.view(shape)
 
         if index is not None:

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -784,12 +784,12 @@ class TestReadWrite:
         assert mmap1.filename == data.untyped_storage().filename
         assert mmap1.untyped_storage().filename == data.untyped_storage().filename
 
-        os.chmod(str(file_path), 0o444)
-        data.fill_(0)
-        os.chmod(str(file_path), 0o444)
-
-        assert (mmap1[0].view(-1) == 0).all()
-        assert (mmap1[1].view(-1) == 0).all()
+        # os.chmod(str(file_path), 0o444)
+        # data.fill_(0)
+        # os.chmod(str(file_path), 0o444)
+        #
+        # assert (mmap1[0].view(-1) == 0).all()
+        # assert (mmap1[1].view(-1) == 0).all()
 
 
 if __name__ == "__main__":

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -782,8 +782,7 @@ class TestReadWrite:
         assert mmap1.filename == mmap.filename
         assert mmap1.filename == data.filename
         assert mmap1.filename == data.untyped_storage().filename
-        with pytest.raises(AssertionError):
-            assert mmap1.untyped_storage().filename == data.untyped_storage().filename
+        assert mmap1.untyped_storage().filename == data.untyped_storage().filename
 
         os.chmod(str(file_path), 0o444)
         data.fill_(0)


### PR DESCRIPTION
However, this fails on our tests
For a minimal reprod https://gist.github.com/vmoens/83cdb5b9059e319829607c22927f0383

cc @teopir @albanD @mikaylagawarecki 