### PR TITLE
[Refactor] Make all leaves in tensorclass part of `_tensordict`, except for NonTensorData

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2319,16 +2319,7 @@ class TensorDict(TensorDictBase):
             raise RuntimeError(
                 "memmap and shared memory are mutually exclusive features."
             )
-        dest = (
-            self
-            if inplace
-            else TensorDict(
-                {},
-                batch_size=self.batch_size,
-                names=self.names if self._has_names() else None,
-                device=torch.device("cpu"),
-            )
-        )
+        dest = self if inplace else self.empty(device=torch.device("cpu"))
 
         # We must set these attributes before memmapping because we need the metadata
         # to match the tensordict content.

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -818,6 +818,7 @@ def _memmap_(
         td = self._tensordict.empty()
         td._is_memmap = True
         td._is_locked = True
+        td._memmap_prefix = prefix
         if inplace:
             self.__dict__["_tensordict"] = td
     if not inplace:
@@ -2712,6 +2713,7 @@ class NonTensorStack(LazyStackedTensorDict):
         # The only thing remaining to do is share the data between processes
         results = []
         for i, td in enumerate(self.tensordicts):
+            td: NonTensorData
             results.append(
                 td._memmap_(
                     prefix=(prefix / str(i)) if prefix is not None else None,

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1475,7 +1475,8 @@ def assert_allclose_td(
                 continue
             assert_allclose_td(input1, input2, rtol=rtol, atol=atol)
             continue
-
+        elif not isinstance(input1, torch.Tensor):
+            continue
         mse = (input1.to(torch.float) - input2.to(torch.float)).pow(2).sum()
         mse = mse.div(input1.numel()).sqrt().item()
 

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -167,6 +167,7 @@ class TestTensorClass:
             {
                 "X": X,
                 "y": y,
+                "z": z,
             },
             batch_size=[3, 4],
         )
@@ -428,6 +429,7 @@ class TestTensorClass:
             ),
             batch_size=[3],
         )
+        assert not a._non_tensordict
         b = MyClass2(
             torch.zeros(3),
             "z0",
@@ -439,7 +441,11 @@ class TestTensorClass:
             ),
             batch_size=[3],
         )
-        c = TensorDict({"x": torch.zeros(3), "y": {"x": torch.ones(3)}}, batch_size=[3])
+        assert not b._non_tensordict
+        c = TensorDict(
+            {"x": torch.zeros(3), "z": "z0", "y": {"x": torch.ones(3), "z": "z1"}},
+            batch_size=[3],
+        )
 
         assert (a == a.clone()).all()
         assert (a != 1.0).any()
@@ -776,9 +782,9 @@ class TestTensorClass:
         data2 = MyDataNested(X=X, y=data_nest2, z=z, batch_size=batch_size)
         assert (data == data2).all()
         assert (data == data2).X.all()
-        assert (data == data2).z is None
+        assert (data == data2).z.all()
         assert (data == data2).y.X.all()
-        assert (data == data2).y.z is None
+        assert (data == data2).y.z.all()
 
     @pytest.mark.parametrize("any_to_td", [True, False])
     def test_nested_heterogeneous(self, any_to_td):
@@ -840,9 +846,9 @@ class TestTensorClass:
         data2 = MyDataNested(X=X + 1, y=data_nest2, z=z, batch_size=batch_size)
         assert (data != data2).any()
         assert (data != data2).X.all()
-        assert (data != data2).z is None
+        assert (data != data2).z.all()
         assert not (data != data2).y.X.any()
-        assert (data != data2).y.z is None
+        assert not (data != data2).y.z.any()
 
     def test_permute(
         self,
@@ -1031,10 +1037,9 @@ class TestTensorClass:
 
         data.set("v", "test")
         assert data.v == "test"
-        assert "v" not in data._tensordict.keys()
-        assert "v" in data._non_tensordict.keys()
+        assert "v" in data._tensordict.keys()
 
-        with pytest.raises(RuntimeError, match="Cannot update an existing"):
+        with pytest.raises(ValueError, match="Failed to update 'v'"):
             data.set("v", vorig, inplace=True)
 
         # ensure optional fields are writable
@@ -1112,8 +1117,8 @@ class TestTensorClass:
 
         data.v = "test"
         assert data.v == "test"
-        assert "v" not in data._tensordict.keys()
-        assert "v" in data._non_tensordict.keys()
+        assert "v" in data._tensordict.keys()
+        assert "v" not in data._non_tensordict.keys()
 
         # ensure optional fields are writable
         data.k = torch.zeros(3, 4, 5)
@@ -1165,11 +1170,9 @@ class TestTensorClass:
         # Negative testcase for non-tensor data
         z = "test_bluff"
         data2 = MyData(X=x, y=y, z=z, batch_size=batch_size)
-        with pytest.warns(
-            UserWarning,
-            match="Meta data at 'z' may or may not be equal, this may result in undefined behaviours",
-        ):
-            data[1] = data2[1]
+        data[1] = data2[1]
+        assert (data[1] == data2[1]).all()
+        assert data[1].z == ["test_bluff"] * data[1].numel()
 
         # Validating nested test cases
         @tensorclass
@@ -1193,11 +1196,8 @@ class TestTensorClass:
 
         # Negative Scenario
         data3 = MyDataNested(X=X2, y=data_nest2, z=["e", "f"], batch_size=batch_size)
-        with pytest.warns(
-            UserWarning,
-            match="Meta data at 'z' may or may not be equal, this may result in undefined behaviours",
-        ):
-            data[:2] = data3[:2]
+        data[:2] = data3[:2]
+        assert data[:2].z == data3[:2]._get_str("z", None).tolist()
 
     @pytest.mark.parametrize(
         "broadcast_type",
@@ -1479,7 +1479,12 @@ class TestTensorClass:
         if lazy_legacy() or lazy:
             assert isinstance(stacked_tc._tensordict, LazyStackedTensorDict)
             assert isinstance(stacked_tc.y._tensordict, LazyStackedTensorDict)
-        assert stacked_tc.z == stacked_tc.y.z == z
+        zlist = z
+        if lazy:
+            for d in range(stacked_tc.ndim - 1, -1, -1):
+                zlist = [zlist] * stacked_tc.batch_size[d]
+        assert stacked_tc.z == stacked_tc.y.z
+        assert stacked_tc.z == zlist
 
         # Testing negative scenarios
         y = torch.zeros(3, 4, 5, dtype=torch.bool)
@@ -2005,7 +2010,7 @@ class TestAutoCasting:
         )
         assert isinstance(obj.tensor, torch.Tensor)
         assert isinstance(obj.integer, int)
-        assert isinstance(obj.string, str)
+        assert isinstance(obj.string, str), type(obj.string)
         assert isinstance(obj.floating, float)
         assert isinstance(obj.numpy_array, np.ndarray)
         assert isinstance(obj.anything, torch.Tensor)
@@ -2222,7 +2227,8 @@ class TestVMAP:
 
         data_bis = torch.vmap(assert_is_data)(data)
         assert isinstance(data_bis, VmappableClass)
-        assert "non_tensor" not in data_bis._tensordict
+        assert "non_tensor" in data_bis._tensordict
+        assert "non_tensor" not in data_bis._non_tensordict
         assert (data_bis == data).all()
         assert data_bis.non_tensor == "a string!"
 

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -19,6 +19,7 @@ from typing import Any, Optional, Tuple, Union
 
 import numpy as np
 import pytest
+import tensordict.utils
 import torch
 
 try:
@@ -2265,6 +2266,21 @@ class TestVMAP:
         assert "non_tensor" not in data_bis._non_tensordict
         assert (data_bis == data).all()
         assert data_bis.non_tensor == "a string!"
+
+
+class TestSerialization:
+    def test_save_load(self, tmpdir):
+        myc = MyData(
+            X=torch.rand(2, 3, 4),
+            y=torch.rand(2, 3, 4, 5),
+            z="test_tensorclass",
+            batch_size=[2, 3],
+        )
+        myc.save(tmpdir)
+        tensordict.utils.print_directory_tree(tmpdir)
+        myc_load = TensorDict.load(tmpdir)
+        assert myc_load.z == "test_tensorclass"
+        assert (myc == myc_load).all()
 
 
 class TestPointWise:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -3047,8 +3047,6 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_equal(self, td_name, device):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
-        print(td)
-        print(td.to_tensordict())
         assert (td == td.to_tensordict()).all()
         td0 = td.to_tensordict().zero_()
         assert (td != td0).any()


### PR DESCRIPTION
This is bc-breaking in the following ways:
1. non-tensor data are proper leaves in the tensorclass
```python
data = MyData(X=X, y=y, z="a string", batch_size=batch_size)
assert "z" in data.keys() # used to break
```

2. non-tensor data will be compared if a tensorclass is compared to another tc / td
```python
# Previously
z = "a striing!"
tensordict = TensorDict(
            {
                "X": X,
                "y": y,
            },
            batch_size=[3, 4],
)
data = MyData(X=X, y=y, z=z, batch_size=batch_size)
assert (tensordict == data).all()
# Now z needs to be part of the tensordict as it won't be ignored during comparison
tensordict = TensorDict(
            {
                "X": X,
                "y": y,
            },
            batch_size=[3, 4],
)
```
3. Non-tensor data following comparison is not None
```python
data0 = MyData(X=X, y=y, z="a string", batch_size=batch_size)
data1 = MyData(X=X, y=y, z="another string", batch_size=batch_size)
(data0 == data1).z # used to be None, now a TD with boolean values
```
4. when setting non-tensor values in-place will now return a `ValueError`, not `RuntimeError`
5. This now works BUT it will convert any `NonTensorData` in `data` in a `NonTensorStack` (since values depend on their location in the batch):
```python
data0 = MyData(X=X, y=y, z="a string", batch_size=batch_size)
data1 = MyData(X=X, y=y, z="another string", batch_size=batch_size)
data0[:2] = data1[:2]
data0.z # used to be a string, bc ignored by __setitem__, now a list
```

