### PR TITLE
[Feature] Multithreaded apply

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
           - flake8-comprehensions==3.10.1
           - torchfix==0.0.2
           - flake8-print==5.0.0
+#          - flake8-unused-arguments==0.0.13
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.1.1

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -9,9 +9,10 @@ import inspect
 import numbers
 import re
 import weakref
+from concurrent.futures import Future, ThreadPoolExecutor
 from copy import copy
 from functools import wraps
-from typing import Any, Callable, Iterator, OrderedDict, Sequence, Type
+from typing import Any, Callable, Iterator, List, OrderedDict, Sequence, Type
 
 import torch
 
@@ -514,6 +515,41 @@ class TensorDictParams(TensorDictBase, nn.Module):
 
     @_unlock_and_set(inplace=True)
     def _apply_nest(*args, **kwargs):
+        ...
+
+    @_fallback
+    def _multithread_apply_flat(
+        self,
+        fn: Callable,
+        *others: T,
+        call_on_nested: bool = False,
+        default: Any = NO_DEFAULT,
+        named: bool = False,
+        nested_keys: bool = False,
+        prefix: tuple = (),
+        is_leaf: Callable = None,
+        executor: ThreadPoolExecutor,
+        futures: List[Future],
+        local_futures: List,
+    ) -> None:
+        ...
+
+    @_fallback
+    def _multithread_rebuild(
+        self,
+        *,
+        batch_size: Sequence[int] | None = None,
+        device: torch.device | None = NO_DEFAULT,
+        names: Sequence[str] | None = None,
+        inplace: bool = False,
+        checked: bool = False,
+        out: TensorDictBase | None = None,
+        filter_empty: bool = False,
+        executor: ThreadPoolExecutor,
+        futures: List[Future],
+        local_futures: List,
+        **constructor_kwargs,
+    ) -> None:
         ...
 
     @_get_post_hook

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -1318,6 +1318,9 @@ class PersistentTensorDict(TensorDictBase):
 
     _cast_reduction = TensorDict._cast_reduction
     _apply_nest = TensorDict._apply_nest
+    _multithread_apply_flat = TensorDict._multithread_apply_flat
+    _multithread_rebuild = TensorDict._multithread_rebuild
+
     _check_device = TensorDict._check_device
     _check_is_shared = TensorDict._check_is_shared
     _convert_to_tensordict = TensorDict._convert_to_tensordict

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -104,6 +104,7 @@ _METHOD_FROM_TD = [
     "numel",
     "replace",
     "_has_names",
+    "_multithread_rebuild",  # rebuild checks if self is a non tensor
 ]
 # Methods to be executed from tensordict, any ref to self means 'self._tensordict'
 _FALLBACK_METHOD_FROM_TD = [
@@ -120,6 +121,7 @@ _FALLBACK_METHOD_FROM_TD = [
     "__truediv__",
     "_add_batch_dim",
     "_apply_nest",
+    "_multithread_apply_flat",
     "_check_unlock",
     "_erase_names",  # TODO: must be specialized
     "_exclude",  # TODO: must be specialized
@@ -467,9 +469,6 @@ def _tensorclass(cls: T) -> T:
                 method_name,
                 _wrap_td_method(method_name, copy_non_tensor=True),
             )
-
-    if not hasattr(cls, "_apply_nest"):
-        cls._apply_nest = TensorDict._apply_nest
 
     if not hasattr(cls, "filter_non_tensor_data"):
         cls.filter_non_tensor_data = _filter_non_tensor_data


### PR DESCRIPTION
multithreaded apply should only be used internally as there is a non-negligeable set of operations that can lead to deadlocks. 
As of now, it is __not__ made to speed up the tensordict operations (reduce TD overhead) but speed up the execution of any function passed to `apply` that can benefit from being executed asynchronously over the leaves.

Some benchmarks:
```python
import torch
from tensordict import TensorDict
from torch.utils.benchmark import Timer
# torch.set_num_threads(16)
import functools

d = {}
sub = d
for _ in range(20):
    for i in range(50):
        sub[str(i)] = torch.rand(2048, 2048)
    sub["nested"] = {}
    sub = sub["nested"]
td = TensorDict(d, batch_size=[])

assert (td._multithread_apply_nest(lambda x: x, num_threads=16) == td).all()

func = lambda x: x.pin_memory()
print(Timer("td._fast_apply(func)", globals=globals()).adaptive_autorange())
print(Timer("td._multithread_apply_nest(func, checked=True, num_threads=4)", globals=globals()).adaptive_autorange())
print(Timer("td._multithread_apply_nest(func, checked=True, num_threads=8)", globals=globals()).adaptive_autorange())
print(Timer("td._multithread_apply_nest(func, checked=True, num_threads=16)", globals=globals()).adaptive_autorange())
```

Results:
```
td._fast_apply(func)
  Median: 1.74 s
  IQR:    0.02 s (1.73 to 1.75)
  4 measurements, 1 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc456a92530>
td._multithread_apply_nest(func, checked=True, num_threads=4)
  Median: 498.21 ms
  IQR:    80.43 ms (455.67 to 536.10)
  20 measurements, 1 runs per measurement, 1 thread
  WARNING: Interquartile range is 16.1% of the median measurement.
           This could indicate system fluctuation.
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc3537e44c0>
td._multithread_apply_nest(func, checked=True, num_threads=8)
  Median: 303.86 ms
  IQR:    24.10 ms (295.45 to 319.54)
  4 measurements, 1 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc35377da80>
td._multithread_apply_nest(func, checked=True, num_threads=16)
  Median: 220.13 ms
  IQR:    13.43 ms (214.42 to 227.85)
  4 measurements, 1 runs per measurement, 1 thread
```

```python
print(Timer("td._fast_apply(func).to('cuda')", globals=globals()).adaptive_autorange())
print(Timer("td._multithread_apply_nest(func, checked=True, num_threads=4).to('cuda')", globals=globals()).adaptive_autorange())
print(Timer("td._multithread_apply_nest(func, checked=True, num_threads=8).to('cuda')", globals=globals()).adaptive_autorange())
print(Timer("td._multithread_apply_nest(func, checked=True, num_threads=16).to('cuda')", globals=globals()).adaptive_autorange())
```

Results

```
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc35377fc10>
td._fast_apply(func).to('cuda')
  Median: 1.73 s
  IQR:    0.02 s (1.72 to 1.73)
  4 measurements, 1 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc3541dbe50>
td._multithread_apply_nest(func, checked=True, num_threads=4).to('cuda')
  Median: 864.55 ms
  IQR:    80.37 ms (817.05 to 897.42)
  9 measurements, 1 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc35413cc10>
td._multithread_apply_nest(func, checked=True, num_threads=8).to('cuda')
  Median: 680.82 ms
  IQR:    19.13 ms (679.74 to 698.87)
  5 measurements, 1 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc3541a4400>
td._multithread_apply_nest(func, checked=True, num_threads=16).to('cuda')
  Median: 608.28 ms
  IQR:    12.52 ms (603.43 to 615.95)
  4 measurements, 1 runs per measurement, 1 thread
```