### PR TITLE
[Feature,Performance] `to(device, pin_memory, num_threads)`

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -1574,6 +1574,7 @@ class LazyStackedTensorDict(TensorDictBase):
         executor: ThreadPoolExecutor,
         futures: List[Future],
         local_futures: List,
+        subs_results: Dict[Future, Any] | None = None,
         **constructor_kwargs,
     ) -> None:
         if inplace and any(
@@ -1603,6 +1604,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 executor=executor,
                 futures=futures,
                 local_futures=local_future,
+                subs_results=subs_results,
             )
             results.append(local_out)
         if filter_empty and all(r is None for r in results):

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1052,9 +1052,7 @@ class TensorDict(TensorDictBase):
 
         any_set = set()
 
-        for i, (key, local_future) in enumerate(
-            zip(self.keys(), local_futures, strict=True)
-        ):
+        for i, (key, local_future) in enumerate(zip(self.keys(), local_futures)):
 
             def setter(
                 item_trsf,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -958,7 +958,6 @@ class TensorDict(TensorDictBase):
         futures: List[Future],
         local_futures: List,
     ) -> None:
-        init_idx = len(futures)
         if is_leaf is None:
             is_leaf = _default_is_leaf
         for key, item in self.items():
@@ -1002,7 +1001,6 @@ class TensorDict(TensorDictBase):
                     future = executor.submit(fn, item, *_others)
                 futures.append(future)
                 local_futures.append(future)
-            return (init_idx, len(futures))
 
     def _multithread_rebuild(
         self,
@@ -1054,7 +1052,7 @@ class TensorDict(TensorDictBase):
 
         any_set = set()
 
-        for i, (key, local_future) in enumerate(zip(self.keys(), local_futures)):
+        for i, (key, local_future) in enumerate(zip(self.keys(), local_futures, strict=True)):
 
             def setter(
                 item_trsf,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import numbers
 import os
 from collections import defaultdict
-from concurrent.futures import Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor, wait, as_completed
 from copy import copy
 from numbers import Number
 from pathlib import Path

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1103,13 +1103,13 @@ class TensorDict(TensorDictBase):
                 futures.append(local_future)
             else:
                 if subs_results is not None:
-                    result = subs_results[local_future]
+                    local_result = subs_results[local_future]
                 else:
                     # TODO: check if add_done_callback can safely be used here
                     #  The issue is that it does not raises an exception encountered during the
                     #  execution, resulting in UBs.
-                    result = local_future.result()
-                local_future = executor.submit(setter, item_trsf=result)
+                    local_result = local_future.result()
+                local_future = executor.submit(setter, item_trsf=local_result)
                 futures.append(local_future)
                 local_futures[i] = local_future
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -18,7 +18,7 @@ import warnings
 import weakref
 from collections.abc import MutableMapping
 
-from concurrent.futures import Future, ThreadPoolExecutor, wait, as_completed
+from concurrent.futures import as_completed, Future, ThreadPoolExecutor, wait
 from copy import copy
 from functools import partial, wraps
 from pathlib import Path
@@ -5827,6 +5827,7 @@ class TensorDictBase(MutableMapping):
         executor: ThreadPoolExecutor,
         futures: List[Future],
         local_futures: List,
+        subs_results: Dict[Future, Any] | None = None,
         **constructor_kwargs,
     ) -> None:
         ...

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8420,6 +8420,20 @@ class TensorDictBase(MutableMapping):
                     a dtype, the dtype is gathered from the example leaves.
                     If there are more than one dtype, then no dtype
                     casting is undertook.
+            pin_memory (bool, optional): if ``True``, the tensors are pinned before
+                being sent to device. This will be done asynchronously but can be
+                controlled via the ``num_threads`` argument.
+
+                .. note:: Calling ``tensordict.pin_memory().to("cuda")`` will usually
+                    be much slower than ``tensordict.to("cuda", pin_memory=True)`` as
+                    the pin_memory is called asynchronously in the second case.
+
+            num_threads (int or None, optional): if ``pin_memory=True``, the number
+                of threads to be used for ``pin_memory``. By default, multithreading
+                will be used with ``num_threads=None`` in
+                :meth:`~concurrent.futures.ThreadPoolExecutor(max_workers=None)`, which will
+                result in a high number of threads. ``num_threads=0`` will cancel any
+                multithreading for the `pin_memory()` calls.
 
         Returns:
             a new tensordict instance if the device differs from the tensordict

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8477,7 +8477,11 @@ class TensorDictBase(MutableMapping):
         if device is not None or dtype is not None:
             if pin_memory and num_threads != 0:
                 result = self._multithread_apply_nest(
-                    lambda x: x.pin_memory(), num_threads=num_threads, call_when_done=to, device=device, checked=True,
+                    lambda x: x.pin_memory(),
+                    num_threads=num_threads,
+                    call_when_done=to,
+                    device=device,
+                    checked=True,
                 )
             else:
                 if pin_memory:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8477,7 +8477,7 @@ class TensorDictBase(MutableMapping):
         if device is not None or dtype is not None:
             if pin_memory and num_threads != 0:
                 result = self._multithread_apply_nest(
-                    lambda x: x.pin_memory(), num_threads=num_threads, call_when_done=to
+                    lambda x: x.pin_memory(), num_threads=num_threads, call_when_done=to, device=device, checked=True,
                 )
             else:
                 if pin_memory:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -2420,21 +2420,26 @@ class TensorDictBase(MutableMapping):
         """Calls :meth:`~torch.Tensor.pin_memory` on the stored tensors."""
         ...
 
-    def cpu(self) -> T:
-        """Casts a tensordict to CPU."""
-        return self.to("cpu")
+    def cpu(self, **kwargs) -> T:
+        """Casts a tensordict to CPU.
 
-    def cuda(self, device: int = None) -> T:
+        This function also supports all the keyword arguments of :meth:`~.to`.
+        """
+        return self.to("cpu", **kwargs)
+
+    def cuda(self, device: int = None, **kwargs) -> T:
         """Casts a tensordict to a cuda device (if not already on it).
 
         Args:
             device (int, optional): if provided, the cuda device on which the
                 tensor should be cast.
 
+        This function also supports all the keyword arguments of :meth:`~.to`.
+
         """
         if device is None:
             return self.to(torch.device("cuda"))
-        return self.to(f"cuda:{device}")
+        return self.to(f"cuda:{device}", **kwargs)
 
     @property
     def is_cuda(self):

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8394,7 +8394,6 @@ class TensorDictBase(MutableMapping):
     def to(self: T, *, batch_size: torch.Size) -> T:
         ...
 
-    @abc.abstractmethod
     def to(self, *args, **kwargs) -> T:
         """Maps a TensorDictBase subclass either on another device, dtype or to another TensorDictBase subclass (if permitted).
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -18,7 +18,7 @@ import warnings
 import weakref
 from collections.abc import MutableMapping
 
-from concurrent.futures import Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor, wait, as_completed
 from copy import copy
 from functools import partial, wraps
 from pathlib import Path

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8480,6 +8480,8 @@ class TensorDictBase(MutableMapping):
                     lambda x: x.pin_memory(), num_threads=num_threads, call_when_done=to
                 )
             else:
+                if pin_memory:
+                    result = result.pin_memory()
                 apply_kwargs["device"] = device if device is not None else self.device
                 apply_kwargs["batch_size"] = batch_size
                 result = result._fast_apply(to, propagate_lock=True, **apply_kwargs)

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -12,7 +12,7 @@ import weakref
 from concurrent.futures import Future, ThreadPoolExecutor
 from copy import copy
 from functools import wraps
-from typing import Any, Callable, Iterator, List, OrderedDict, Sequence, Type
+from typing import Any, Callable, Dict, Iterator, List, OrderedDict, Sequence, Type
 
 import torch
 

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -548,6 +548,7 @@ class TensorDictParams(TensorDictBase, nn.Module):
         executor: ThreadPoolExecutor,
         futures: List[Future],
         local_futures: List,
+        subs_results: Dict[Future, Any] | None = None,
         **constructor_kwargs,
     ) -> None:
         ...

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -967,9 +967,15 @@ class PersistentTensorDict(TensorDictBase):
         )
 
     def to(self, *args, **kwargs: Any) -> PersistentTensorDict:
-        device, dtype, non_blocking, convert_to_format, batch_size = _parse_to(
-            *args, **kwargs
-        )
+        (
+            device,
+            dtype,
+            non_blocking,
+            convert_to_format,
+            batch_size,
+            pin_memory,
+            num_threads,
+        ) = _parse_to(*args, **kwargs)
         result = self
         if device is not None and dtype is None and device == self.device:
             return result

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -976,6 +976,9 @@ class PersistentTensorDict(TensorDictBase):
             pin_memory,
             num_threads,
         ) = _parse_to(*args, **kwargs)
+        if pin_memory:
+            raise RuntimeError(f"Cannot call pin_memory {type(self).__name__}.to(). Call "
+                               f"`to_tensordict()` before executing this code.")
         result = self
         if device is not None and dtype is None and device == self.device:
             return result

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -977,8 +977,10 @@ class PersistentTensorDict(TensorDictBase):
             num_threads,
         ) = _parse_to(*args, **kwargs)
         if pin_memory:
-            raise RuntimeError(f"Cannot call pin_memory {type(self).__name__}.to(). Call "
-                               f"`to_tensordict()` before executing this code.")
+            raise RuntimeError(
+                f"Cannot call pin_memory {type(self).__name__}.to(). Call "
+                f"`to_tensordict()` before executing this code."
+            )
         result = self
         if device is not None and dtype is None and device == self.device:
             return result

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -15,10 +15,10 @@ import os
 
 import sys
 import time
-
 import warnings
 from collections import defaultdict, OrderedDict
 from collections.abc import KeysView
+from concurrent.futures import Future
 from copy import copy
 from functools import wraps
 from importlib import import_module

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -18,7 +18,6 @@ import time
 import warnings
 from collections import defaultdict, OrderedDict
 from collections.abc import KeysView
-from concurrent.futures import Future
 from copy import copy
 from functools import wraps
 from importlib import import_module

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1320,6 +1320,8 @@ def _split_tensordict(
 
 def _parse_to(*args, **kwargs):
     batch_size = kwargs.pop("batch_size", None)
+    pin_memory = kwargs.pop("pin_memory", False)
+    num_threads = kwargs.pop("num_threads", None)
     other = kwargs.pop("other", None)
     device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(
         *args, **kwargs
@@ -1333,7 +1335,15 @@ def _parse_to(*args, **kwargs):
             dtype = None
         elif len(dtypes) == 1:
             dtype = list(dtypes)[0]
-    return device, dtype, non_blocking, convert_to_format, batch_size
+    return (
+        device,
+        dtype,
+        non_blocking,
+        convert_to_format,
+        batch_size,
+        pin_memory,
+        num_threads,
+    )
 
 
 class _ErrorInteceptor:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2951,7 +2951,7 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         if device.type == "cuda" and pin_memory:
-            with pytest.raises(RuntimeError, "Only cpu"):
+            with pytest.raises(RuntimeError, match="only dense CPU tensors can be pinned"):
                 td_device = td.to(
                     device_cast, pin_memory=pin_memory, num_threads=num_threads
                 )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2951,6 +2951,7 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         if device.type == "cuda" and device_cast.type == "cpu" and pin_memory:
+            print(device, device_cast)
             with pytest.raises(RuntimeError, match="only dense CPU tensors can be pinned"):
                 td_device = td.to(
                     device_cast, pin_memory=pin_memory, num_threads=num_threads

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2950,6 +2950,13 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_cast_device(self, td_name, device, device_cast, pin_memory, num_threads):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
+        if pin_memory and td_name == "td_h5":
+            with pytest.raises(RuntimeError, match="Cannot call pin_memory PersistentTensorDict.to()"):
+                td_device = td.to(
+                    device_cast, pin_memory=pin_memory, num_threads=num_threads
+                )
+            return
+
         if device.type == "cuda" and device_cast.type == "cpu" and pin_memory:
             with pytest.raises(
                 RuntimeError, match="only dense CPU tensors can be pinned"

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2951,7 +2951,9 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         if device.type == "cuda" and device_cast.type == "cpu" and pin_memory:
-            with pytest.raises(RuntimeError, match="only dense CPU tensors can be pinned"):
+            with pytest.raises(
+                RuntimeError, match="only dense CPU tensors can be pinned"
+            ):
                 td_device = td.to(
                     device_cast, pin_memory=pin_memory, num_threads=num_threads
                 )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2950,7 +2950,7 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_cast_device(self, td_name, device, device_cast, pin_memory, num_threads):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
-        if device.type == "cuda" and pin_memory:
+        if device.type == "cuda" and device_cast.type == "cpu" and pin_memory:
             with pytest.raises(RuntimeError, match="only dense CPU tensors can be pinned"):
                 td_device = td.to(
                     device_cast, pin_memory=pin_memory, num_threads=num_threads

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2943,14 +2943,18 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.cuda.device_count() == 0, reason="No cuda device detected"
     )
     @pytest.mark.parametrize("device_cast", get_available_devices())
-    @pytest.mark.parametrize("pin_memory", [False] if not torch.cuda.is_available() else [False, True])
+    @pytest.mark.parametrize(
+        "pin_memory", [False] if not torch.cuda.is_available() else [False, True]
+    )
     @pytest.mark.parametrize("num_threads", [0, 1, 4, None])
     def test_cast_device(self, td_name, device, device_cast, pin_memory, num_threads):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         if device.type == "cuda" and pin_memory:
             with pytest.raises(RuntimeError, "Only cpu"):
-                td_device = td.to(device_cast, pin_memory=pin_memory, num_threads=num_threads)
+                td_device = td.to(
+                    device_cast, pin_memory=pin_memory, num_threads=num_threads
+                )
             return
         td_device = td.to(device_cast, pin_memory=pin_memory, num_threads=num_threads)
 
@@ -8282,7 +8286,9 @@ class TestNamedDims(TestTensorDictsBase):
             tdbool.names = "All work and no play makes Jack a dull boy"
 
     @pytest.mark.parametrize("device", get_available_devices())
-    @pytest.mark.parametrize("pin_memory", [False] if not torch.cuda.is_available() else [False, True])
+    @pytest.mark.parametrize(
+        "pin_memory", [False] if not torch.cuda.is_available() else [False, True]
+    )
     @pytest.mark.parametrize("num_threads", [0, 1, 4, None])
     def test_to(self, device, pin_memory, num_threads):
         td = TensorDict(

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2951,7 +2951,6 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         if device.type == "cuda" and device_cast.type == "cpu" and pin_memory:
-            print(device, device_cast)
             with pytest.raises(RuntimeError, match="only dense CPU tensors can be pinned"):
                 td_device = td.to(
                     device_cast, pin_memory=pin_memory, num_threads=num_threads

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2951,7 +2951,9 @@ class TestTensorDicts(TestTensorDictsBase):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         if pin_memory and td_name == "td_h5":
-            with pytest.raises(RuntimeError, match="Cannot call pin_memory PersistentTensorDict.to()"):
+            with pytest.raises(
+                RuntimeError, match="Cannot call pin_memory PersistentTensorDict.to()"
+            ):
                 td_device = td.to(
                     device_cast, pin_memory=pin_memory, num_threads=num_threads
                 )


### PR DESCRIPTION
Test:
```python
import torch
from tensordict import TensorDict
from torch.utils.benchmark import Timer
# torch.set_num_threads(16)
import functools

d = {}
sub = d
for _ in range(20):
    for i in range(50):
        sub[str(i)] = torch.rand(2048, 2048)
    sub["nested"] = {}
    sub = sub["nested"]
td = TensorDict(d, batch_size=[])

print(Timer("td.to('cuda')", globals=globals()).adaptive_autorange())
  Median: 1.02 s
print(Timer("td.pin_memmory().to('cuda')", globals=globals()).adaptive_autorange())
#   Median: 1.80 s
print(Timer("td.to('cuda', pin_memory=True)", globals=globals()).adaptive_autorange())
#   Median: 444.79 ms
print(Timer("td.to('cuda', pin_memory=True, num_threads=0)", globals=globals()).adaptive_autorange())
#   Median: 1.82 s
print(Timer("td.to('cuda', pin_memory=True, num_threads=1)", globals=globals()).adaptive_autorange())
#   Median: 1.82 s
print(Timer("td.to('cuda', pin_memory=True, num_threads=16)", globals=globals()).adaptive_autorange())
#   Median: 375.45 ms
```

cc @albanD @mikaylagawarecki @shagunsodhani @dstaay-fb