### PR TITLE
[BugFix,CI] Fix storage filename tests

### DIFF
--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -782,7 +782,7 @@ class TestReadWrite:
         assert mmap1.filename == mmap.filename
         assert mmap1.filename == data.filename
         assert mmap1.filename == data.untyped_storage().filename
-        assert mmap1.untyped_storage().filename == data.untyped_storage().filename
+        # assert mmap1.untyped_storage().filename == data.untyped_storage().filename
 
         # os.chmod(str(file_path), 0o444)
         # data.fill_(0)


### PR DESCRIPTION
Interestingly apply silicon runners are the only machines that don't have root permission in the CI, and hence are the only one that run the `TestReadWrite` test.

All file-stored storages used to have a `filename` associated but we deprecated this since there was not guarantee that a change in a non-writable file would be reflected on the corresponding opened tensor (making the filename useless and misleading).
This PR fixes that test.

cc @mikaylagawarecki 