### PR TITLE
[BugFix] Fix `pad_sequence` behavior for non-tensor attributes of tensorclass

### DIFF
--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -20,7 +20,14 @@ from tensordict.base import (
     T,
     TensorDictBase,
 )
-from tensordict.utils import _check_keys, _shape, DeviceType, is_non_tensor, unravel_key
+from tensordict.utils import (
+    _check_keys,
+    _shape,
+    DeviceType,
+    is_non_tensor,
+    is_tensorclass,
+    unravel_key,
+)
 
 
 def pad(tensordict: T, pad_size: Sequence[int], value: float = 0.0) -> T:
@@ -149,6 +156,13 @@ def pad_sequence(
     if not list_of_tensordicts:
         raise RuntimeError("list_of_tensordicts cannot be empty")
 
+    if return_mask and is_tensorclass(list_of_tensordicts[0]):
+        raise RuntimeError(
+            "Expected 'return_mask=False' when list_of_tensordicts contains "
+            "tensorclasses, but got 'return_mask=True'. If you want masks, "
+            "plase convert the tensorclasses to TensorDicts first."
+        )
+
     masks_key = "masks"
     if not isinstance(return_mask, bool):
         masks_key = unravel_key(return_mask)
@@ -161,9 +175,10 @@ def pad_sequence(
     list_of_dicts = [{} for _ in range(len(list_of_tensordicts))]
     keys_copy = list(keys)
     for i, td in enumerate(list_of_tensordicts):
+        is_tensorclass_ = is_tensorclass(td)
 
         for key in keys:
-            item = td.get(key)
+            item = td._tensordict.get(key) if is_tensorclass_ else td.get(key)
             list_of_dicts[i][key] = item
             if is_non_tensor(item):
                 continue

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -175,10 +175,11 @@ def pad_sequence(
     list_of_dicts = [{} for _ in range(len(list_of_tensordicts))]
     keys_copy = list(keys)
     for i, td in enumerate(list_of_tensordicts):
-        is_tensorclass_ = is_tensorclass(td)
+        if is_tensorclass(td):
+            td = td._tensordict
 
         for key in keys:
-            item = td._tensordict.get(key) if is_tensorclass_ else td.get(key)
+            item = td.get(key)
             list_of_dicts[i][key] = item
             if is_non_tensor(item):
                 continue

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1501,6 +1501,18 @@ class TestGeneric:
         assert (d["a"] == torch.tensor([[1, 1], [2, 0]])).all()
         assert d["b"] == ["asd", "efg"]
 
+    def test_pad_sequence_tensorclass_nontensor(self):
+        @tensorclass
+        class Sample:
+            a: torch.Tensor
+            b: str
+
+        d1 = Sample(**{"a": torch.tensor([1, 1]), "b": "asd"}, batch_size=[])
+        d2 = Sample(**{"a": torch.tensor([2]), "b": "efg"}, batch_size=[])
+        d = pad_sequence([d1, d2])
+        assert (d.a == torch.tensor([[1, 1], [2, 0]])).all()
+        assert d.b == ["asd", "efg"]
+
     @pytest.mark.parametrize("make_mask", [True, ("bibbidi", "bobbidi", "boo"), False])
     def test_pad_sequence_pad_dim0(self, make_mask):
         pad_dim = 0


### PR DESCRIPTION
## Description

Fix the way `pad_sequence` checks for non-tensor attributes of tensorclasses. Also raise an error if `pad_sequence` is given tensorclasses with `return_mask=True`, since we cannot add the "masks" attribute with `<tensorclass>.set()`.

## Motivation and Context

close #783

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
