### PR TITLE
Add `_check_dim_name`  to `tensorclass`

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -460,6 +460,8 @@ def _tensorclass(cls: T) -> T:
         cls.update_ = _update_
     if not hasattr(cls, "update_at_"):
         cls.update_at_ = _update_at_
+    if not hasattr(cls, "_check_dim_name"):
+        cls._check_dim_name = _check_dim_name
     for method_name in _METHOD_FROM_TD:
         if not hasattr(cls, method_name):
             setattr(cls, method_name, getattr(TensorDict, method_name))
@@ -1093,6 +1095,10 @@ def _update_at_(
     )
     self._non_tensordict.update(non_tensordict)
     return self
+
+
+def _check_dim_name(self, name):
+    return self._tensordict._check_dim_name(name)
 
 
 def _wrap_classmethod(td_cls, cls, func):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -8171,6 +8171,25 @@ class TestNamedDims(TestTensorDictsBase):
         tdr = td.refine_names("a", ..., "d")
         assert tdr.names == ["a", None, "c", "d"]
 
+    @pytest.mark.filterwarnings("error")
+    def test_refine_names_nontensor(self):
+        td = NonTensorStack(
+            NonTensorData("test0", batch_size=[1, 2, 3]),
+            NonTensorData("test1", batch_size=[1, 2, 3]),
+        )
+        tdr = td.refine_names(None, None, None, "d")
+        assert tdr.names == [None, None, None, "d"]
+        tdr = tdr.refine_names(None, None, "c", "d")
+        assert tdr.names == [None, None, "c", "d"]
+        with pytest.raises(
+            RuntimeError, match="refine_names: cannot coerce TensorDict"
+        ):
+            tdr.refine_names(None, None, "d", "d")
+        tdr = td.refine_names(..., "d")
+        assert tdr.names == [None, None, "c", "d"]
+        tdr = td.refine_names("a", ..., "d")
+        assert tdr.names == ["a", None, "c", "d"]
+
     def test_rename(self):
         td = TensorDict({}, batch_size=[3, 4, 5, 6], names=None)
         td.names = ["a", None, None, "d"]


### PR DESCRIPTION
## Description

Add `_check_dim_name` method to `tensorclass` to prevent warning that the fallback method is not compilable.

## Motivation and Context

close #852

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
