### PR TITLE
[BugFix] Fix compile + vmap

### DIFF
--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -17,7 +17,7 @@ import torch
 import torch.utils._pytree
 
 from tensordict._td import TensorDict
-from tensordict.base import _is_tensor_collection, is_tensor_collection, TensorDictBase
+from tensordict.base import _is_tensor_collection, is_tensor_collection
 
 from tensordict.utils import implement_for
 from torch import nn
@@ -266,7 +266,7 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
             )
 
         # Here:
-        if isinstance(batched_outputs, (TensorDictBase, torch.Tensor)):
+        if isinstance(batched_outputs, torch.Tensor) or is_tensor_collection(batched_outputs):
             # Some weird edge case requires us to spell out the following
             # see test_out_dims_edge_case
             if isinstance(out_dims, int):
@@ -578,7 +578,7 @@ def _make_decorator(module: nn.Module, fun_name: str) -> Callable:
             except TypeError as err:
                 pattern = r".*takes \d+ positional arguments but \d+ were given|got multiple values for argument"
                 pattern = re.compile(pattern)
-                if pattern.search(str(err)) and isinstance(args[-1], TensorDictBase):
+                if pattern.search(str(err)) and is_tensor_collection(args[-1]):
                     # this is raised whenever the module is an nn.Module (not a TensorDictModuleBase)
                     raise TypeError(
                         "It seems you tried to provide the parameters as an argument to the module when the module was not stateless. "

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -266,7 +266,9 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
             )
 
         # Here:
-        if isinstance(batched_outputs, torch.Tensor) or is_tensor_collection(batched_outputs):
+        if isinstance(batched_outputs, torch.Tensor) or is_tensor_collection(
+            batched_outputs
+        ):
             # Some weird edge case requires us to spell out the following
             # see test_out_dims_edge_case
             if isinstance(out_dims, int):

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -106,30 +106,32 @@ _METHOD_FROM_TD = [
 ]
 # Methods to be executed from tensordict, any ref to self means 'self._tensordict'
 _FALLBACK_METHOD_FROM_TD_NOWRAP = [
-    "_check_unlock",
     "_check_dim_name",
+    "_check_unlock",
     "_default_get",
     "_get_at_str",
     "_get_at_tuple",
+    "_get_names_idx",  # no wrap output
     "_get_str",
     "_get_tuple",
     "_has_names",
     "_items_list",
+    "_maybe_names",
     "_multithread_apply_flat",
     "_multithread_rebuild",  # rebuild checks if self is a non tensor
     "_propagate_lock",
     "_propagate_unlock",
     "_values_list",
+    "dim",
     "is_empty",
     "is_memmap",
     "is_shared",
     "items",
     "keys",
-    "_maybe_names",
+    # "ndim",
     "ndimension",
     "numel",
     "values",
-    "_get_names_idx",  # no wrap output
 ]
 
 # Methods to be executed from tensordict, any ref to self means 'self._tensordict'

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -18,6 +18,19 @@ from tensordict.nn import TensorDictModule as Mod, TensorDictSequential as Seq
 TORCH_VERSION = version.parse(torch.__version__).base_version
 
 
+def test_vmap_compile():
+    # Since we monkey patch vmap we need to make sure compile is happy with it
+    def func(x, y):
+        return x + y
+
+    x = torch.randn(3, 4)
+    y = torch.randn(3)
+    funcv = torch.vmap(func, (1, None))
+    funcv(x, y)
+    funcv_c = torch.compile(funcv, fullgraph=True)
+    funcv_c(x, y)
+
+
 @pytest.mark.skipif(TORCH_VERSION < "2.4", reason="requires torch>2.4")
 @pytest.mark.parametrize("mode", [None, "reduce-overhead"])
 class TestTD:


### PR DESCRIPTION
When calling a vmap within a compiled code, things break because of the context manager that we use to exclude TDs from pytree.
We can actually just indicate that TD is a leaf using the `is_leaf` argument where appropriate.
This will only work with torch > 2.4. 