### PR TITLE
[Refactor] Remove non-ascii characters from code base

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -529,10 +529,10 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `mean` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
-            dtype (torch.dtype, optional) – the desired data type of returned tensor.
+            dtype (torch.dtype, optional): the desired data type of returned tensor.
                 If specified, the input tensor is casted to dtype before the operation is performed.
                 This is useful for preventing data type overflows. Default: ``None``.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
@@ -567,10 +567,10 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `mean` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
-            dtype (torch.dtype, optional) – the desired data type of returned tensor.
+            dtype (torch.dtype, optional): the desired data type of returned tensor.
                 If specified, the input tensor is casted to dtype before the operation is performed.
                 This is useful for preventing data type overflows. Default: ``None``.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
@@ -602,10 +602,10 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `prod` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
-            dtype (torch.dtype, optional) – the desired data type of returned tensor.
+            dtype (torch.dtype, optional): the desired data type of returned tensor.
                 If specified, the input tensor is casted to dtype before the operation is performed.
                 This is useful for preventing data type overflows. Default: ``None``.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
@@ -646,10 +646,10 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `sum` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
-            dtype (torch.dtype, optional) – the desired data type of returned tensor.
+            dtype (torch.dtype, optional): the desired data type of returned tensor.
                 If specified, the input tensor is casted to dtype before the operation is performed.
                 This is useful for preventing data type overflows. Default: ``None``.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
@@ -681,10 +681,10 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `sum` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
-            dtype (torch.dtype, optional) – the desired data type of returned tensor.
+            dtype (torch.dtype, optional): the desired data type of returned tensor.
                 If specified, the input tensor is casted to dtype before the operation is performed.
                 This is useful for preventing data type overflows. Default: ``None``.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
@@ -716,11 +716,11 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `std` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
             correction (int): difference between the sample size and sample degrees of freedom.
-                Defaults to Bessel’s correction, correction=1.
+                Defaults to Bessel's correction, correction=1.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
                 and a single reduced tensor will be returned.
                 Defaults to ``False``.
@@ -750,11 +750,11 @@ class TensorDictBase(MutableMapping):
                 If integer or tuple of integers, `var` is called upon the dimension specified if
                 and only if this dimension is compatible with the tensordict
                 shape.
-            keepdim (bool) – whether the output tensor has dim retained or not.
+            keepdim (bool): whether the output tensor has dim retained or not.
 
         Keyword Args:
             correction (int): difference between the sample size and sample degrees of freedom.
-                Defaults to Bessel’s correction, correction=1.
+                Defaults to Bessel's correction, correction=1.
             reduce (bool, optional): if ``True``, the reduciton will occur across all TensorDict values
                 and a single reduced tensor will be returned.
                 Defaults to ``False``.
@@ -2611,7 +2611,7 @@ class TensorDictBase(MutableMapping):
     def refine_names(self, *names) -> T:
         """Refines the dimension names of self according to names.
 
-        Refining is a special case of renaming that “lifts” unnamed dimensions.
+        Refining is a special case of renaming that "lifts" unnamed dimensions.
         A None dim can be refined to have any name; a named dim can only be
         refined to have the same name.
 
@@ -9970,7 +9970,7 @@ class TensorDictBase(MutableMapping):
         return any(v.requires_grad for v in self.values())
 
     def requires_grad_(self, requires_grad=True) -> T:
-        """Change if autograd should record operations on this tensor: sets this tensor’s requires_grad attribute in-place.
+        """Change if autograd should record operations on this tensor: sets this tensor's requires_grad attribute in-place.
 
         Returns this tensordict.
 

--- a/tutorials/dummy.py
+++ b/tutorials/dummy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-The early bird gets the worm – which is what he deserves
+The early bird gets the worm - which is what he deserves
 ========================================================
 """
 

--- a/tutorials/sphinx_tuto/tensorclass_fashion.py
+++ b/tutorials/sphinx_tuto/tensorclass_fashion.py
@@ -49,7 +49,7 @@ test_data = datasets.FashionMNIST(
 # structure of the data you want to store is fixed and predictable.
 #
 # As well as specifying the contents, we can also encapsulate related
-# logic as custom methods when defining the class. In this case we’ll
+# logic as custom methods when defining the class. In this case we'll
 # write a ``from_dataset`` classmethod that takes a dataset as input and
 # creates a tensorclass containing the data from the dataset. We create
 # memory-mapped tensors to hold the data. This will allow us to
@@ -89,7 +89,7 @@ test_data_tc = FashionMNISTData.from_dataset(test_data, device=device)
 # DataLoaders
 # ----------------
 #
-# We’ll create DataLoaders from the ``torchvision``-provided Datasets, as
+# We'll create DataLoaders from the ``torchvision``-provided Datasets, as
 # well as from our memory-mapped TensorDicts.
 #
 # Since ``TensorDict`` implements ``__len__`` and ``__getitem__`` (and

--- a/tutorials/sphinx_tuto/tensorclass_imagenet.py
+++ b/tutorials/sphinx_tuto/tensorclass_imagenet.py
@@ -19,7 +19,7 @@ Batched data loading with tensorclasses
 # storage and on-device batched transformation, we obtain a 10x speedup in data-loading
 # over regular torch + torchvision pipelines.
 #
-# We’ll use the same subset of imagenet used in `this transfer learning
+# We'll use the same subset of imagenet used in `this transfer learning
 # tutorial <https://pytorch.org/tutorials/beginner/transfer_learning_tutorial.html>`__,
 # though we also give results of our experiments running the same code on ImageNet.
 #
@@ -105,8 +105,8 @@ if __name__ == "__main__":
     # sphinx_gallery_end_ignore
 
     ##############################################################################
-    # We’ll also create a dataset of the raw training data that simply resizes
-    # the image to a common size and converts to tensor. We’ll use this to
+    # We'll also create a dataset of the raw training data that simply resizes
+    # the image to a common size and converts to tensor. We'll use this to
     # load the data into memory-mapped tensors. The random transformations
     # need to be different each time we iterate through the data, so they
     # cannot be pre-computed. We also do not scale the data yet so that we can set the

--- a/tutorials/sphinx_tuto/tensordict_memory.py
+++ b/tutorials/sphinx_tuto/tensordict_memory.py
@@ -154,7 +154,7 @@ print(mm_tensordict["a"].contiguous())
 #    ├── a.memmap
 #    ├── a.meta.pt
 #    ├── b
-#    │   ├── c.memmap
-#    │   ├── c.meta.pt
-#    │   └── meta.pt
+#    │ ├── c.memmap
+#    │ ├── c.meta.pt
+#    │ └── meta.pt
 #    └── meta.pt


### PR DESCRIPTION
The only remaining non ascii-characters are in the turorials, which should not be a problem for compiled jobs:
In `tensordict_memory.py`:
```
  tensordict
  ├── a.memmap
  ├── b
  │   ├── c.memmap
  │   └── meta.json
  └── meta.json
```