### PR TITLE
[BugFix] Fix error catching of context-manager support in compile

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -264,6 +264,10 @@ class TensorDictBase(MutableMapping):
             is_shared_str = indent(f"is_shared={self.is_shared()}", 4 * " ")
             string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
         except AttributeError:
+            # When using torch.compile, an exception may be raised with a tensordict object
+            #  that has no attribute (no _tensordict or no _batch_size).
+            #  To get the proper erro message and not an attribute error raised during __repr__,
+            #  we simply default to '...' when trying to print the TD content.
             string = "..."
         return f"{type(self).__name__}(\n{string})"
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -256,12 +256,15 @@ class TensorDictBase(MutableMapping):
         ...
 
     def __repr__(self) -> str:
-        fields = _td_fields(self)
-        field_str = indent(f"fields={{{fields}}}", 4 * " ")
-        batch_size_str = indent(f"batch_size={self.batch_size}", 4 * " ")
-        device_str = indent(f"device={self.device}", 4 * " ")
-        is_shared_str = indent(f"is_shared={self.is_shared()}", 4 * " ")
-        string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
+        try:
+            fields = _td_fields(self)
+            field_str = indent(f"fields={{{fields}}}", 4 * " ")
+            batch_size_str = indent(f"batch_size={self.batch_size}", 4 * " ")
+            device_str = indent(f"device={self.device}", 4 * " ")
+            is_shared_str = indent(f"is_shared={self.is_shared()}", 4 * " ")
+            string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
+        except AttributeError:
+            string = "..."
         return f"{type(self).__name__}(\n{string})"
 
     def __iter__(self) -> Generator:

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -630,7 +630,8 @@ class TestFunctional:
         call_compile = torch.compile(call, fullgraph=True, mode=mode)
         x = torch.randn(2, 3)
         with pytest.raises(
-            torch._dynamo.exc.Unsupported, match="UserDefinedObjectVariable|Unsupported context manager"
+            torch._dynamo.exc.Unsupported,
+            match="UserDefinedObjectVariable|Unsupported context manager",
         ):
             call_compile(x, td_zero)
         os.environ["TORCHDYNAMO_INLINE_INBUILT_NN_MODULES"] = "0"

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -630,7 +630,7 @@ class TestFunctional:
         call_compile = torch.compile(call, fullgraph=True, mode=mode)
         x = torch.randn(2, 3)
         with pytest.raises(
-            torch._dynamo.exc.Unsupported, match="UserDefinedObjectVariable"
+            torch._dynamo.exc.Unsupported, match="UserDefinedObjectVariable|Unsupported context manager"
         ):
             call_compile(x, td_zero)
         os.environ["TORCHDYNAMO_INLINE_INBUILT_NN_MODULES"] = "0"


### PR DESCRIPTION
dynamo ctx_manager attempts to print an incomplete version of the object
In this case, the `TensorDict` instance lacks a `_tensordict` and `_batch_size` attribute (which should never be the case in eager mode), and the error that should result from `unimplemented` is never raised because the `__repr__` of the tensordict in `self.cm_obj` never returns.

@anijain2305 in the following code snippet, it could be wise to either print only the type of `self.cm_obj` or decorate this in a `try/except` such that the `__repr__` of self.cm_obj doesn't hide the real error.

```
  File "/Users/vmoens/venv/rl/lib/python3.11/site-packages/torch/_dynamo/variables/ctx_manager.py", line 154, in enter
    f"Unsupported context manager {self.cm_obj}'s __enter__ function",
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```