### PR TITLE
[Feature] Allow to specify log_prob_key in CompositeDistribution

### DIFF
--- a/tensordict/nn/distributions/composite.py
+++ b/tensordict/nn/distributions/composite.py
@@ -32,6 +32,8 @@ class CompositeDistribution(d.Distribution):
             will be used.
         extra_kwargs (Dict[NestedKey, Dict]): a possibly incomplete dictionary of
             extra keyword arguments for the distributions to be built.
+        log_prob_key (NestedKey, optional): key where to write the log_prob if return_log_prob = True.
+            Defaults to `'sample_log_prob'`.
 
     .. note:: In this distribution class, the batch-size of the input tensordict containing the params
         (``params``) is indicative of the batch_shape of the distribution. For instance,
@@ -71,6 +73,7 @@ class CompositeDistribution(d.Distribution):
         *,
         name_map: dict | None = None,
         extra_kwargs=None,
+        log_prob_key: NestedKey = "sample_log_prob",
     ):
         self._batch_shape = params.shape
         if extra_kwargs is None:
@@ -101,6 +104,7 @@ class CompositeDistribution(d.Distribution):
             dist = dist_class(**dist_params, **kwargs)
             dists[write_name] = dist
         self.dists = dists
+        self.log_prob_key = log_prob_key
 
     def sample(self, shape=None) -> TensorDictBase:
         if shape is None:
@@ -152,7 +156,7 @@ class CompositeDistribution(d.Distribution):
             while lp.ndim > sample.ndim:
                 lp = lp.sum(-1)
             slp = slp + lp
-        d["sample_log_prob"] = slp
+        d[self.log_prob_key] = slp
         sample.update(d)
         return sample
 

--- a/tensordict/nn/distributions/composite.py
+++ b/tensordict/nn/distributions/composite.py
@@ -32,7 +32,7 @@ class CompositeDistribution(d.Distribution):
             will be used.
         extra_kwargs (Dict[NestedKey, Dict]): a possibly incomplete dictionary of
             extra keyword arguments for the distributions to be built.
-        log_prob_key (NestedKey, optional): key where to write the log_prob if return_log_prob = True.
+        log_prob_key (NestedKey, optional): key where to write the log_prob.
             Defaults to `'sample_log_prob'`.
 
     .. note:: In this distribution class, the batch-size of the input tensordict containing the params


### PR DESCRIPTION
## Description

This PR allows to change the output key used for the `sample_log_prob` in `CompositeDistribution`'s, which is now hardcoded to `sample_log_prob`.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
