### PR TITLE
[BugFix] Allow context-manager for to_module

### DIFF
--- a/benchmarks/compile/tensordict_nn_test.py
+++ b/benchmarks/compile/tensordict_nn_test.py
@@ -401,14 +401,9 @@ def test_vmap_func_call_runtime_and_backward(mode, plain_decorator, benchmark):
         call_vmap(*args).mean().backward()
 
     x = torch.randn(2, 2, 16)
-    if functional:
-        call_with_backward(x, td)
-        call_with_backward(x, td)
-        benchmark(call_with_backward, x, td)
-    else:
-        call_with_backward(x)
-        call_with_backward(x)
-        benchmark(call_with_backward, x)
+    call_with_backward(x, td)
+    call_with_backward(x, td)
+    benchmark(call_with_backward, x, td)
 
 
 if __name__ == "__main__":

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -329,7 +329,6 @@ class TensorDictParams(TensorDictBase, nn.Module):
         self._reset_params()
         self._is_locked = False
         self._locked_tensordicts = []
-        self.__last_op_queue = None
         self._get_post_hook = []
 
     def register_get_post_hook(self, hook):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -623,25 +623,12 @@ class TestFunctional:
         td_zero = TensorDictParams(td.data.clone())
         td_zero.zero_()
 
-        def call(x, td):
-            with td.to_module(module):
-                return module(x)
-
-        call_compile = torch.compile(call, fullgraph=True, mode=mode)
-        x = torch.randn(2, 3)
-        with pytest.raises(
-            torch._dynamo.exc.Unsupported,
-            match="UserDefinedObjectVariable|Unsupported context manager",
-        ):
-            call_compile(x, td_zero)
         os.environ["TORCHDYNAMO_INLINE_INBUILT_NN_MODULES"] = "0"
         try:
 
             def call(x, td):
-                params = td.to_module(module, return_swap=True)
-                result = module(x)
-                params.to_module(module, return_swap=True, swap_dest=td)
-                return result
+                with td.to_module(module):
+                    return module(x)
 
             call_compile = torch.compile(call, fullgraph=True, mode=mode)
             x = torch.randn(2, 3)
@@ -683,14 +670,8 @@ class TestFunctional:
         td_zero.zero_()
 
         def call(x, td):
-            # TOFIX: `with` needs registering
-            # with td.to_module(module):
-            #     return module(x)
-
-            params = td.to_module(module, return_swap=True)
-            result = module(x)
-            params.to_module(module, return_swap=True, swap_dest=td)
-            return result
+            with td.to_module(module):
+                return module(x)
 
         call_compile = torch.compile(call, fullgraph=True, mode=mode)
         x = torch.randn(2, 3)


### PR DESCRIPTION
Fixes the torch.compile compatibility with functional calls with tensordict using CMs:
```python
def call(x, td):
    with td.to_module(module):
       return module(x)
call_compiled = torch.compile(vmap(call, (None, 0)))
call_compiled(x, td)
```

cc @zou3519 