### PR TITLE
[Refactor] Make @tensorclass work properly with pyright

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -370,21 +370,8 @@ class _tensorclass_dec:
         clz.autocast = self.autocast
         return clz
 
-
-@overload
-def tensorclass(autocast: bool = False, frozen: bool = False) -> _tensorclass_dec: ...
-
-
-@overload
-def tensorclass(cls: T) -> T: ...
-
-
-@overload
-def tensorclass(cls: T) -> T: ...
-
-
 @dataclass_transform()
-def tensorclass(*args, **kwargs):
+def tensorclass(cls=None, /, *, autocast: bool = False, frozen: bool = False):
     """A decorator to create :obj:`tensorclass` classes.
 
     ``tensorclass`` classes are specialized :func:`dataclasses.dataclass` instances that
@@ -465,7 +452,16 @@ def tensorclass(*args, **kwargs):
 
 
     """
-    return _tensorclass_dec(*args, **kwargs)
+    def wrap(cls):
+        return _tensorclass_dec(autocast, frozen)(cls)
+
+    # See if we're being called as @tensorclass or @tensorclass().
+    if cls is None:
+        # We're called with parens.
+        return wrap
+
+    # We're called as @tensorclass without parens.
+    return wrap(cls)
 
 
 @dataclass_transform()

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -24,15 +24,7 @@ from copy import copy, deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import indent
-from typing import (
-    Any,
-    Callable,
-    get_type_hints,
-    List,
-    Sequence,
-    Type,
-    TypeVar,
-)
+from typing import Any, Callable, get_type_hints, List, Sequence, Type, TypeVar
 
 import numpy as np
 import orjson as json

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -29,7 +29,6 @@ from typing import (
     Callable,
     get_type_hints,
     List,
-    overload,
     Sequence,
     Type,
     TypeVar,
@@ -370,6 +369,7 @@ class _tensorclass_dec:
         clz.autocast = self.autocast
         return clz
 
+
 @dataclass_transform()
 def tensorclass(cls=None, /, *, autocast: bool = False, frozen: bool = False):
     """A decorator to create :obj:`tensorclass` classes.
@@ -452,6 +452,7 @@ def tensorclass(cls=None, /, *, autocast: bool = False, frozen: bool = False):
 
 
     """
+
     def wrap(cls):
         return _tensorclass_dec(autocast, frozen)(cls)
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context
```python
@tensorclass() # works without typing issues
class MyClass:
    a = torch.Tensor
    b = torch.Tensor
    
@tensorclass # results in pyright typing issues and is arguably more commonly used than @tensorclass() with parentheses
class MyClass:
    a = torch.Tensor
    b = torch.Tensor
```

pyright: error:
```
Argument of type "type[MyClass]" cannot be assigned to parameter "autocast" of type "bool" in function "__new__"
  "type[type]" is not assignable to "type[bool]"Pylance[reportArgumentType](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportArgumentType)
```
## Types of changes

I looked at the `@dataclass` implementation and mimicked the behavior here. I'm no expert in typing.

- typing change


Potential breaking change:
Technically you could have used @tensordict the following:
`@tensordict(<bool_for_autocast_without_using_the_keyword>)`
or
`@tensordict(<bool_for_autocast_without_using_the_keyword>, <bool_for_frozen_without_using_the_keyword>)`

This will break now but I doubt any sane person uses it like that, cs.github.com did not show any such usage when I looked for it.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)

