### PR TITLE
[BugFix] Computation of log prob in composite distribution for TensorDict without batch size

### DIFF
--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -392,17 +392,17 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
         if _requires_sample:
             out_tensors = self._dist_sample(dist, interaction_type=interaction_type())
             if isinstance(out_tensors, TensorDictBase):
-                tensordict_out.update(out_tensors)
                 if self.return_log_prob:
                     kwargs = {}
                     if isinstance(dist, CompositeDistribution):
                         kwargs = {"aggregate_probabilities": False}
-                    log_prob = dist.log_prob(tensordict_out, **kwargs)
-                    if log_prob is not tensordict_out:
+                    log_prob = dist.log_prob(out_tensors, **kwargs)
+                    if log_prob is not out_tensors:
                         # Composite dists return the tensordict_out directly when aggrgate_prob is False
-                        tensordict_out.set(self.log_prob_key, log_prob)
+                        out_tensors.set(self.log_prob_key, log_prob)
                     else:
-                        tensordict_out.rename_key_(dist.log_prob_key, self.log_prob_key)
+                        out_tensors.rename_key_(dist.log_prob_key, self.log_prob_key)
+                tensordict_out.update(out_tensors)
             else:
                 if isinstance(out_tensors, Tensor):
                     out_tensors = (out_tensors,)


### PR DESCRIPTION
## Description

I believe there's a bug in the latest version of the `ProbabilisticTensorDictModule` when calculating the log prob.

## Motivation and Context

The log prob is erroneously flattened according to the sample's ndim. More specifically, the ndim of the batch shape of the root level of the sample tensordict. However, the sample's ndim does not always match the batch shape of the distribution itself!

This is the case, for instance, if there are global keys such as `done` or `terminated`.

For example:

```python
params = TensorDict(
    {
        "agents": TensorDict(
            {
                "params": {
                    "cont": {
                        "loc": torch.randn(3, 4, requires_grad=True),
                        "scale": torch.rand(3, 4, requires_grad=True),
                    },
                    ("nested", "cont"): {
                        "loc": torch.randn(3, 4, requires_grad=True),
                        "scale": torch.rand(3, 4, requires_grad=True),
                    },
                }
            },
            batch_size=3,
        ),
        "done": torch.ones(1),
    }
)
```
In this case the, using the `ProbabilisticTensorDictModule`, the `sample_log_prob` is flattened into a single float instead of having size 3 as expected.

This PR is related to https://github.com/pytorch/tensordict/pull/1054.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
