### PR TITLE
[BugFix] calling pad with immutable sequence

### DIFF
--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -74,7 +74,7 @@ def pad(tensordict: T, pad_size: Sequence[int], value: float = 0.0) -> T:
     for i in range(len(pad_size)):
         new_batch_size[i // 2] += pad_size[i]
 
-    reverse_pad = pad_size[::-1]
+    reverse_pad = list(pad_size[::-1])
     for i in range(0, len(reverse_pad), 2):
         reverse_pad[i], reverse_pad[i + 1] = reverse_pad[i + 1], reverse_pad[i]
 


### PR DESCRIPTION
## Description

Allow `functional.pad` to take a tuple for `pad_size`.

## Motivation and Context

I recently tried to use `pad` with a tuple for `pad_size`, but it didn't work as expected.

Close #1074

- [X] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
