### PR TITLE
[BugFix] Fix typo in `OneHotCategorical`

### DIFF
--- a/tensordict/nn/distributions/discrete.py
+++ b/tensordict/nn/distributions/discrete.py
@@ -63,7 +63,7 @@ class OneHotCategorical(D.Categorical):
         else:
             return (self.probs == self.probs.max(-1, True)[0]).to(torch.long)
 
-    determnistic_sample = mode
+    deterministic_sample = mode
 
     def sample(
         self,


### PR DESCRIPTION
## Description

Fix typo in the definition of `OneHotCategorical`.

## Motivation and Context

`deterministic` is spelled wrong.

close #1129 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
