### PR TITLE
[BugFix] Make min/max tensorclasses be interchangeable with PT equivalent

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -872,7 +872,7 @@ class TensorDictBase(MutableMapping):
         )
         if dim is not NO_DEFAULT and return_indices:
             # Split the tensordict
-            from .return_types import min
+            from torch.return_types import min
 
             values_dict = {}
             indices_dict = {}
@@ -882,8 +882,7 @@ class TensorDictBase(MutableMapping):
                 else:
                     indices_dict[key] = key[:-1]
             return min(
-                *result.split_keys(values_dict, indices_dict),
-                batch_size=result.batch_size,
+                result.split_keys(values_dict, indices_dict)[:2],
             )
         return result
 
@@ -1006,7 +1005,7 @@ class TensorDictBase(MutableMapping):
         )
         if dim is not NO_DEFAULT and return_indices:
             # Split the tensordict
-            from .return_types import max
+            from torch.return_types import max
 
             values_dict = {}
             indices_dict = {}
@@ -1016,8 +1015,7 @@ class TensorDictBase(MutableMapping):
                 else:
                     indices_dict[key] = key[:-1]
             return max(
-                *result.split_keys(values_dict, indices_dict),
-                batch_size=result.batch_size,
+                result.split_keys(values_dict, indices_dict)[:2],
             )
         return result
 
@@ -1110,7 +1108,7 @@ class TensorDictBase(MutableMapping):
             return result
         if dim is not NO_DEFAULT and return_indices:
             # Split the tensordict
-            from .return_types import cummin
+            from torch.return_types import cummin
 
             values_dict = {}
             indices_dict = {}
@@ -1120,8 +1118,7 @@ class TensorDictBase(MutableMapping):
                 else:
                     indices_dict[key] = key[:-1]
             return cummin(
-                *result.split_keys(values_dict, indices_dict),
-                batch_size=result.batch_size,
+                result.split_keys(values_dict, indices_dict)[:2],
             )
         return result
 
@@ -1214,7 +1211,7 @@ class TensorDictBase(MutableMapping):
             return result
         if dim is not NO_DEFAULT and return_indices:
             # Split the tensordict
-            from .return_types import cummax
+            from torch.return_types import cummax
 
             values_dict = {}
             indices_dict = {}
@@ -1224,8 +1221,7 @@ class TensorDictBase(MutableMapping):
                 else:
                     indices_dict[key] = key[:-1]
             return cummax(
-                *result.split_keys(values_dict, indices_dict),
-                batch_size=result.batch_size,
+                result.split_keys(values_dict, indices_dict)[:2],
             )
         return result
 

--- a/tensordict/return_types.py
+++ b/tensordict/return_types.py
@@ -2,74 +2,67 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 
 from tensordict.tensorclass import tensorclass
 from tensordict.tensordict import TensorDict
 
 
-@tensorclass(shadow=True)
+@tensorclass
 class min:
     """A `min` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.min` operations."""
 
-    values: TensorDict
+    vals: TensorDict
     indices: TensorDict
 
-    def __getitem__(self, item):
-        try:
-            return (self.values, self.indices)[item]
-        except IndexError:
-            raise IndexError(
-                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
-                f"__getitem__ method API."
-            )
+    def __post_init__(self):
+        warnings.warn(
+            f"{type(self)}.min is deprecated and will be removed in v0.9. "
+            f"Use torch.return_types.min instead.",
+            category=DeprecationWarning,
+        )
 
 
-@tensorclass(shadow=True)
+@tensorclass
 class max:
     """A `max` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.max` operations."""
 
-    values: TensorDict
+    vals: TensorDict
     indices: TensorDict
 
-    def __getitem__(self, item):
-        try:
-            return (self.values, self.indices)[item]
-        except IndexError:
-            raise IndexError(
-                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
-                f"__getitem__ method API."
-            )
+    def __post_init__(self):
+        warnings.warn(
+            f"{type(self)}.max is deprecated and will be removed in v0.9. "
+            f"Use torch.return_types.max instead.",
+            category=DeprecationWarning,
+        )
 
 
-@tensorclass(shadow=True)
+@tensorclass
 class cummin:
     """A `cummin` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.cummin` operations."""
 
-    values: TensorDict
+    vals: TensorDict
     indices: TensorDict
 
-    def __getitem__(self, item):
-        try:
-            return (self.values, self.indices)[item]
-        except IndexError:
-            raise IndexError(
-                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
-                f"__getitem__ method API."
-            )
+    def __post_init__(self):
+        warnings.warn(
+            f"{type(self)}.cummin is deprecated and will be removed in v0.9. "
+            f"Use torch.return_types.cummin instead.",
+            category=DeprecationWarning,
+        )
 
 
-@tensorclass(shadow=True)
+@tensorclass
 class cummax:
     """A `cummax` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.cummax` operations."""
 
-    values: TensorDict
+    vals: TensorDict
     indices: TensorDict
 
-    def __getitem__(self, item):
-        try:
-            return (self.values, self.indices)[item]
-        except IndexError:
-            raise IndexError(
-                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
-                f"__getitem__ method API."
-            )
+    def __post_init__(self):
+        warnings.warn(
+            f"{type(self)}.cummax is deprecated and will be removed in v0.9. "
+            f"Use torch.return_types.cummax instead.",
+            category=DeprecationWarning,
+        )

--- a/tensordict/return_types.py
+++ b/tensordict/return_types.py
@@ -7,33 +7,69 @@ from tensordict.tensorclass import tensorclass
 from tensordict.tensordict import TensorDict
 
 
-@tensorclass
+@tensorclass(shadow=True)
 class min:
     """A `min` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.min` operations."""
 
-    vals: TensorDict
+    values: TensorDict
     indices: TensorDict
 
+    def __getitem__(self, item):
+        try:
+            return (self.values, self.indices)[item]
+        except IndexError:
+            raise IndexError(
+                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
+                f"__getitem__ method API."
+            )
 
-@tensorclass
+
+@tensorclass(shadow=True)
 class max:
     """A `max` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.max` operations."""
 
-    vals: TensorDict
+    values: TensorDict
     indices: TensorDict
 
+    def __getitem__(self, item):
+        try:
+            return (self.values, self.indices)[item]
+        except IndexError:
+            raise IndexError(
+                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
+                f"__getitem__ method API."
+            )
 
-@tensorclass
+
+@tensorclass(shadow=True)
 class cummin:
     """A `cummin` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.cummin` operations."""
 
-    vals: TensorDict
+    values: TensorDict
     indices: TensorDict
 
+    def __getitem__(self, item):
+        try:
+            return (self.values, self.indices)[item]
+        except IndexError:
+            raise IndexError(
+                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
+                f"__getitem__ method API."
+            )
 
-@tensorclass
+
+@tensorclass(shadow=True)
 class cummax:
     """A `cummax` tensorclass to be used as a result for :meth:`~tensordict.TensorDict.cummax` operations."""
 
-    vals: TensorDict
+    values: TensorDict
     indices: TensorDict
+
+    def __getitem__(self, item):
+        try:
+            return (self.values, self.indices)[item]
+        except IndexError:
+            raise IndexError(
+                f"Indexing a {type(self)} element follows the torch.return_types.{type(self).__name__}'s "
+                f"__getitem__ method API."
+            )

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -5303,7 +5303,10 @@ class TestTensorDicts(TestTensorDictsBase):
         ],
     )
     def test_min_max_cummin_cummax(self, td_name, device, dim, keepdim, return_indices):
-        import tensordict.return_types as return_types
+        def _get_td(v):
+            if not is_tensor_collection(v):
+                return v.values
+            return v
 
         td = getattr(self, td_name)(device)
         # min
@@ -5315,71 +5318,63 @@ class TestTensorDicts(TestTensorDictsBase):
         if not return_indices and dim is not None:
             assert_allclose_td(r, td.amin(dim=dim, keepdim=keepdim))
         if return_indices:
-            assert is_tensorclass(r)
-            assert isinstance(r, return_types.min)
-            assert not r.vals.is_empty()
+            # assert is_tensorclass(r)
+            assert isinstance(r, torch.return_types.min)
+            assert not r.values.is_empty()
             assert not r.indices.is_empty()
-        else:
-            assert not is_tensorclass(r)
         if dim is None:
-            assert r.batch_size == ()
+            assert _get_td(r).batch_size == ()
         elif keepdim:
             s = list(td.batch_size)
             s[dim] = 1
-            assert r.batch_size == tuple(s)
+            assert _get_td(r).batch_size == tuple(s)
         else:
             s = list(td.batch_size)
             s.pop(dim)
-            assert r.batch_size == tuple(s)
+            assert _get_td(r).batch_size == tuple(s)
 
         r = td.max(**kwargs)
         if not return_indices and dim is not None:
             assert_allclose_td(r, td.amax(dim=dim, keepdim=keepdim))
         if return_indices:
-            assert is_tensorclass(r)
-            assert isinstance(r, return_types.max)
-            assert not r.vals.is_empty()
+            # assert is_tensorclass(r)
+            assert isinstance(r, torch.return_types.max)
+            assert not r.values.is_empty()
             assert not r.indices.is_empty()
-        else:
-            assert not is_tensorclass(r)
         if dim is None:
-            assert r.batch_size == ()
+            assert _get_td(r).batch_size == ()
         elif keepdim:
             s = list(td.batch_size)
             s[dim] = 1
-            assert r.batch_size == tuple(s)
+            assert _get_td(r).batch_size == tuple(s)
         else:
             s = list(td.batch_size)
             s.pop(dim)
-            assert r.batch_size == tuple(s)
+            assert _get_td(r).batch_size == tuple(s)
         if dim is None:
             return
         kwargs.pop("keepdim")
         r = td.cummin(**kwargs)
         if return_indices:
-            assert is_tensorclass(r)
-            assert isinstance(r, return_types.cummin)
-            assert not r.vals.is_empty()
+            # assert is_tensorclass(r)
+            assert isinstance(r, torch.return_types.cummin)
+            assert not r.values.is_empty()
             assert not r.indices.is_empty()
-        else:
-            assert not is_tensorclass(r)
         if dim is None:
-            assert r.batch_size == ()
+            assert _get_td(r).batch_size == ()
         else:
-            assert r.batch_size == td.batch_size
+            assert _get_td(r).batch_size == td.batch_size
 
         r = td.cummax(**kwargs)
         if return_indices:
-            assert is_tensorclass(r)
-            assert isinstance(r, return_types.cummax)
-            assert not r.vals.is_empty()
+            # assert is_tensorclass(r)
+            assert isinstance(r, torch.return_types.cummax)
+            assert not r.values.is_empty()
             assert not r.indices.is_empty()
-        else:
-            assert not is_tensorclass(r)
         if dim is None:
-            assert r.batch_size == ()
+            assert _get_td(r).batch_size == ()
         else:
-            assert r.batch_size == td.batch_size
+            assert _get_td(r).batch_size == td.batch_size
 
     @pytest.mark.parametrize("inplace", [False, True])
     def test_named_apply(self, td_name, device, inplace):


### PR DESCRIPTION
We want `torch.min(tensor, dim=dim)` and `torch.min(tensordict, dim=dim)` to be interchangeable.

Currently, `values` is named vals not to conflict with the method with the same name, and indexing works as it does with tensordict.

This means that a piece of code where we do `torch.min(smth, ...)[idx]` will actually index the resulting tensordict, which is susprising.

I therefore suggest we should just use `torch.reduce_types.<type>` instead.