### PR TITLE
[Refactor] `composite_lp_aggregate` to handle log-probs aggregates globally

### DIFF
--- a/docs/source/reference/nn.rst
+++ b/docs/source/reference/nn.rst
@@ -198,6 +198,8 @@ to build distributions from network outputs and get summary statistics or sample
     TensorDictModuleWrapper
     CudaGraphModule
     WrapModule
+    set_composite_lp_aggregate
+    composite_lp_aggregate
 
 Ensembles
 ---------
@@ -249,10 +251,10 @@ Distributions
     :toctree: generated/
     :template: rl_template_noinherit.rst
 
-    NormalParamExtractor
     AddStateIndependentNormalScale
     CompositeDistribution
     Delta
+    NormalParamExtractor
     OneHotCategorical
     TruncatedNormal
 

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2629,6 +2629,8 @@ class TensorDict(TensorDictBase):
         old_key = unravel_key(old_key)
         new_key = unravel_key(new_key)
         if old_key == new_key:
+            if old_key not in self.keys(include_nested=isinstance(old_key, tuple)):
+                raise KeyError(f"Key {old_key} not found in tensordict.")
             return self
         if safe and (new_key in self.keys(include_nested=True)):
             raise KeyError(f"key {new_key} already present in TensorDict.")

--- a/tensordict/nn/__init__.py
+++ b/tensordict/nn/__init__.py
@@ -44,3 +44,4 @@ from tensordict.nn.utils import (
 )
 
 from .cudagraphs import CudaGraphModule
+from .utils import composite_lp_aggregate, set_composite_lp_aggregate

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -27,6 +27,7 @@ from tensordict.nn.distributions.truncated_normal import (
 )
 from tensordict.nn.sequence import TensorDictSequential
 from tensordict.nn.utils import (
+    _composite_lp_aggregate,
     _set_skip_existing_None,
     composite_lp_aggregate,
     set_composite_lp_aggregate,
@@ -445,6 +446,18 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
                 f"unless there is one and only one element in log_prob_keys (got log_prob_keys={self.log_prob_keys}). "
                 f"When composite_lp_aggregate() returns ``False``, try to use {type(self).__name__}.log_prob_keys instead."
             )
+        if _composite_lp_aggregate.get_mode() is None:
+            warnings.warn(
+                f"You are querying the log-probability key of a {type(self).__name__} where the "
+                f"composite_lp_aggregate has not been set. "
+                f"Currently, it is assumed that composite_lp_aggregate() will return True: the log-probs will be aggregated "
+                f"in a {self._log_prob_key} entry. From v0.9, this behaviour will be changed and individual log-probs will "
+                f"be written in `('path', 'to', 'leaf', '<sample_name>_log_prob')`. To prepare for this change, "
+                f"call `set_composite_lp_aggregate(mode: bool).set()` at the beginning of your script. Use mode=True "
+                f"to keep the current behaviour, and mode=False to use per-leaf log-probs.",
+                category=DeprecationWarning,
+            )
+
         return self._log_prob_key
 
     @property

--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -6,11 +6,9 @@
 from __future__ import annotations
 
 import collections
-
 import re
 import warnings
 from collections.abc import MutableSequence
-
 from textwrap import indent
 from typing import Any, Dict, List, OrderedDict, overload
 
@@ -18,24 +16,16 @@ import torch
 
 from tensordict._nestedkey import NestedKey
 from tensordict.base import is_tensor_collection
-
-
 from tensordict.nn.common import dispatch, TensorDictModuleBase
-from tensordict.nn.distributions import Delta, distributions_maps
-
-from tensordict.nn.distributions.composite import CompositeDistribution
 from tensordict.nn.distributions import distributions_maps
-
-from tensordict.nn.distributions.composite import CompositeDistribution
+from tensordict.nn.distributions.composite import _add_suffix, CompositeDistribution
 from tensordict.nn.distributions.continuous import Delta
 from tensordict.nn.distributions.discrete import OneHotCategorical
-
 from tensordict.nn.distributions.truncated_normal import (
     TruncatedNormal,
     TruncatedStandardNormal,
 )
 from tensordict.nn.sequence import TensorDictSequential
-
 from tensordict.nn.utils import (
     _set_skip_existing_None,
     composite_lp_aggregate,
@@ -45,14 +35,7 @@ from tensordict.tensorclass import is_non_tensor
 from tensordict.tensordict import TensorDictBase
 from tensordict.utils import _ContextManager, _zip_strict
 from torch import distributions as D, Tensor
-
 from torch.utils._contextlib import _DecoratorContextManager
-
-from tensordict.nn.distributions.composite import _add_suffix
-from tensordict.base import is_tensor_collection
-from .. import is_tensor_collection
-
-from .distributions.composite import _add_suffix
 
 try:
     from torch.compiler import is_compiling
@@ -431,7 +414,7 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
 
     @property
     def log_prob_key(self):
-        if not composite_lp_aggregate():
+        if not composite_lp_aggregate(nowarn=True):
             if len(self.log_prob_keys) == 1:
                 return self.log_prob_keys[0]
             raise RuntimeError(

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -29,7 +29,7 @@ from tensordict.nn import (
     ProbabilisticTensorDictModule as Prob,
     TensorDictModule,
     TensorDictModule as Mod,
-    TensorDictSequential as Seq, set_composite_lp_aggregate,
+    TensorDictSequential as Seq,
 )
 
 from tensordict.nn.functional_modules import _exclude_td_from_pytree

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -29,7 +29,7 @@ from tensordict.nn import (
     ProbabilisticTensorDictModule as Prob,
     TensorDictModule,
     TensorDictModule as Mod,
-    TensorDictSequential as Seq,
+    TensorDictSequential as Seq, set_composite_lp_aggregate,
 )
 
 from tensordict.nn.functional_modules import _exclude_td_from_pytree

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -27,6 +27,7 @@ from tensordict.nn import (
     CudaGraphModule,
     InteractionType,
     ProbabilisticTensorDictModule as Prob,
+    set_composite_lp_aggregate,
     TensorDictModule,
     TensorDictModule as Mod,
     TensorDictSequential as Seq,
@@ -665,6 +666,7 @@ class TestNN:
         mod_compile = torch.compile(mod, fullgraph=_v2_5, mode=mode)
         torch.testing.assert_close(mod(x=x, y=y), mod_compile(x=x, y=y))
 
+    @set_composite_lp_aggregate(False)
     def test_prob_module_with_kwargs(self, mode):
         kwargs = TensorDictParams(
             TensorDict(scale=1.0, validate_args=NonTensorData(False)), no_convert=True

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2685,13 +2685,6 @@ class TestCompositeDist:
     @pytest.mark.parametrize("mode", [None, True, False])
     def test_set_composite_lp_aggregate_build_and_get(self, mode):
         d = torch.distributions
-        params = TensorDict(
-            {
-                "cont": {"loc": torch.randn(3, 4), "scale": torch.rand(3, 4)},
-                ("nested", "disc"): {"logits": torch.randn(3, 10)},
-            },
-            [3],
-        )
         dist_maker = functools.partial(
             CompositeDistribution,
             distribution_map={"cont": d.Normal, ("nested", "disc"): d.Categorical},

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2696,20 +2696,41 @@ class TestCompositeDist:
                 distribution_class=dist_maker,
                 return_log_prob=True,
             )
-        with set_composite_lp_aggregate(True):
-            assert p.out_keys == ["cont", ("nested", "disc"), "sample_log_prob"]
-            assert p.log_prob_key == "sample_log_prob"
-            assert p.log_prob_keys == ["sample_log_prob"]
-        with set_composite_lp_aggregate(False):
-            assert p.out_keys == [
-                "cont",
-                ("nested", "disc"),
-                "cont_log_prob",
-                ("nested", "disc_log_prob"),
-            ]
-            with pytest.raises(RuntimeError):
-                p.log_prob_key
-            assert p.log_prob_keys == ["cont_log_prob", ("nested", "disc_log_prob")]
+            if composite_lp_aggregate(nowarn=True):
+                assert p.log_prob_key == "sample_log_prob"
+            else:
+                assert p.log_prob_keys == ["cont_log_prob", ("nested", "disc_log_prob")]
+
+        if mode in (True, None):
+            with set_composite_lp_aggregate(True):
+                assert p.out_keys == ["cont", ("nested", "disc"), "sample_log_prob"]
+                assert p.log_prob_key == "sample_log_prob"
+                assert p.log_prob_keys == ["sample_log_prob"]
+            with set_composite_lp_aggregate(False):
+                with pytest.raises(RuntimeError):
+                    p.out_keys
+                with pytest.raises(RuntimeError):
+                    p.log_prob_key
+                with pytest.raises(RuntimeError):
+                    p.log_prob_keys
+        else:
+            with set_composite_lp_aggregate(False):
+                assert p.out_keys == [
+                    "cont",
+                    ("nested", "disc"),
+                    "cont_log_prob",
+                    ("nested", "disc_log_prob"),
+                ]
+                with pytest.raises(RuntimeError):
+                    p.log_prob_key
+                assert p.log_prob_keys == ["cont_log_prob", ("nested", "disc_log_prob")]
+            with set_composite_lp_aggregate(True):
+                with pytest.raises(RuntimeError):
+                    p.out_keys
+                with pytest.raises(RuntimeError):
+                    p.log_prob_key
+                with pytest.raises(RuntimeError):
+                    p.log_prob_keys
 
     @set_composite_lp_aggregate(False)
     def test_from_distributions(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2697,7 +2697,12 @@ class TestCompositeDist:
                 return_log_prob=True,
             )
             if composite_lp_aggregate(nowarn=True):
-                assert p.log_prob_key == "sample_log_prob"
+                with (
+                    pytest.warns(DeprecationWarning)
+                    if mode is None
+                    else contextlib.nullcontext()
+                ):
+                    assert p.log_prob_key == "sample_log_prob"
             else:
                 assert p.log_prob_keys == ["cont_log_prob", ("nested", "disc_log_prob")]
 


### PR DESCRIPTION
I propose a global flag `composite_lp_aggregate` to handle the issue of the aggregation of log-probs.

So far, we have dealt with this using kwargs everywhere (in `ProbabilisticTDModule`, `ProbabilisticTDSequential`, `CompositeDistribution` and subclasses). The hierarchy of these classes and what to do when args conflict isn't easy to handle. It's also confusing for users, who I suspect will usually want to work with either collapsed or non-collapsed log-probs.

A global flag (set to True for now and False in the future) will make things easier to handle. 
Globally, the v0.6.2 behaviour will not be changed all users who rely on it will be informed about the upcoming change through a warning that will tell them to set the global var to `False` to accommodate upcoming changes. If they set it to `True`, nothing will change for them but that also means that bugs will not be solved (we won't maintain the `True` behaviour).

When `composite_lp_aggregate() == True`, we'll have `aggregate_probabilities=True`, `include_sum=True` and `inplace=True` by default everywhere. When `composite_lp_aggregate() == False`, all of these will be set to False, meaning that any call to `whatever.log_prob(tensordict)` will return another tensordict containing the leaf log-probs.
