### PR TITLE
[Doc,BugFix] Fix default argument in doc for `AddStateIndependentNormalScale`

### DIFF
--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -98,7 +98,7 @@ class AddStateIndependentNormalScale(torch.nn.Module):
 
     Keyword Args:
         scale_mapping (str, optional): positive mapping function to be used with the std.
-            Defaults to ``"biased_softplus_1.0"`` (i.e. softplus map with bias such that fn(0.0) = 1.0)
+            Defaults to ``"exp"``,
             choices: ``"softplus"``, ``"exp"``, ``"relu"``, ``"biased_softplus_1"``.
         scale_lb (Number, optional): The minimum value that the variance can take.
             Defaults to ``1e-4``.


### PR DESCRIPTION
## Description

The doc for `AddStateIndependentNormalScale` indicates of `biased_softplus_1` as the default for the `scale_mapping`, while it is `exp`.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
