### PR TITLE
[Feature] Add init value option to AddStateIndependentNormalScale

### DIFF
--- a/tensordict/nn/distributions/continuous.py
+++ b/tensordict/nn/distributions/continuous.py
@@ -106,6 +106,8 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         make_param (bool, optional): whether the scale should be a parameter (``True``)
             or a buffer (``False``).
             Defaults to ``True``.
+        init_value (float, optional): Initial value of state independent scale.
+            Defaults to 0.0.
 
     Examples:
         >>> from torch import nn
@@ -136,6 +138,7 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         scale_lb: Number = 1e-4,
         device: torch.device | None = None,
         make_param: bool = True,
+        init_value: float = 0.0,
     ) -> None:
 
         super().__init__()
@@ -148,11 +151,11 @@ class AddStateIndependentNormalScale(torch.nn.Module):
         self.scale_mapping = scale_mapping
         if make_param:
             self.state_independent_scale = torch.nn.Parameter(
-                torch.zeros(scale_shape, device=device)
+                torch.ones(scale_shape, device=device) * init_value
             )
         else:
             self.state_independent_scale = torch.nn.Buffer(
-                torch.zeros(scale_shape, device=device)
+                torch.ones(scale_shape, device=device) * init_value
             )
 
     def forward(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3740,6 +3740,20 @@ class TestAddStateIndependentNormalScale:
         assert scale.shape == (4, 2, num_outputs)
         assert (scale > 0).all()
 
+    def test_add_scale_init_value(self, num_outputs=4):
+        module = nn.Linear(3, num_outputs)
+        init_value = 1.0
+        module_normal = AddStateIndependentNormalScale(
+            num_outputs,
+            scale_mapping="relu",
+            init_value=init_value,
+        )
+        tensor = torch.randn(3)
+        loc, scale = module_normal(module(tensor))
+        assert loc.shape == (num_outputs,)
+        assert scale.shape == (num_outputs,)
+        assert (scale == init_value).all()
+
 
 class TestStateDict:
     @pytest.mark.parametrize("detach", [True, False])


### PR DESCRIPTION
## Description

When using `AddStateIndependentNormalScale` (in our case specifically with scale_mapping `relu`) we'd like the option of initializing the scale to any value based on our configurations. I added the option of taking in an initial value. Since it's set to 0.0 for default, it should be the same as initializing to `torch.zeros`.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
