### PR TITLE
[Setup] Parametrize PyTorch version with env variable for local builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ def write_version_file(version):
 
 
 def _get_pytorch_version(is_nightly, is_local):
-    # if "PYTORCH_VERSION" in os.environ:
-    #     return f"torch=={os.environ['PYTORCH_VERSION']}"
+    if "PYTORCH_VERSION" in os.environ:
+         return f"torch=={os.environ['PYTORCH_VERSION']}"
     if is_nightly:
         return "torch>=2.7.0.dev"
     if is_local:

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def write_version_file(version):
 
 def _get_pytorch_version(is_nightly, is_local):
     if "PYTORCH_VERSION" in os.environ:
-         return f"torch=={os.environ['PYTORCH_VERSION']}"
+        return f"torch=={os.environ['PYTORCH_VERSION']}"
     if is_nightly:
         return "torch>=2.7.0.dev"
     if is_local:


### PR DESCRIPTION
## Description

Describe your changes in detail.

Sometimes it's needed to install tensordict with a PyTorch version than are poorly parsed by python's dependency resolver. For instance, Nvidia's [NVCR containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags) come with PyTorch versions that don't follow semver guidelines (are missing a dash after patch). This leads to pip install a version of PyTorch from PyPI. It wold be helpful to be able to specify the needed version inside an environment variable.

## Motivation and Context

`close #1244`

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
