### PR TITLE
[Doc] Fix typo in pad_sequence docstring example

### DIFF
--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -127,11 +127,11 @@ def pad_sequence(
         >>> print(padded_td)
         TensorDict(
             fields={
-                a: Tensor(shape=torch.Size([2, 4, 8]), device=cpu, dtype=torch.float32, is_shared=False),
-                b: Tensor(shape=torch.Size([2, 5, 8]), device=cpu, dtype=torch.float32, is_shared=False),
+                a: Tensor(shape=torch.Size([2, 5, 8]), device=cpu, dtype=torch.float32, is_shared=False),
+                b: Tensor(shape=torch.Size([2, 6, 8]), device=cpu, dtype=torch.float32, is_shared=False),
                 masks: TensorDict(
                     fields={
-                        a: Tensor(shape=torch.Size([2, 4]), device=cpu, dtype=torch.bool, is_shared=False),
+                        a: Tensor(shape=torch.Size([2, 5]), device=cpu, dtype=torch.bool, is_shared=False),
                         b: Tensor(shape=torch.Size([2, 6]), device=cpu, dtype=torch.bool, is_shared=False)},
                     batch_size=torch.Size([2]),
                     device=None,


### PR DESCRIPTION
## Description

The output dimensions of the following docstring example are incorrect:
```
list_td = [
    TensorDict({"a": torch.zeros((3, 8)), "b": torch.zeros((6, 8))}, batch_size=[]),
    TensorDict({"a": torch.zeros((5, 8)), "b": torch.zeros((6, 8))}, batch_size=[]),
]
```
I ran the above line to verify, and updated the example accordingly.

## Types of changes

- [x] Documentation (update in the documentation)
