### PR TITLE
[BugFix] Method _is_list_tensor_compatible missing return value

### DIFF
--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -2803,7 +2803,7 @@ def _is_list_tensor_compatible(t) -> Tuple[bool, tuple | None, type | None]:
             if len(sizes) > 1:
                 return False, None, None
             continue
-        return False, None
+        return False, None, None
     else:
         if len(dtypes):
             dtype = list(dtypes)[0]


### PR DESCRIPTION
## Description

The method `_is_list_tensor_compatible` seems to be missing a return value in one of the return statements.

The function is supposed to return a tuple with three elements `(bool, tuple|None, type|None)`, but one return statement only returns two values.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
