### PR TITLE
[Quality] Simplify error handling in TensorDictSequential execution

### DIFF
--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -620,15 +620,9 @@ class TensorDictSequential(TensorDictModule):
 
         if not len(kwargs):
             for module in self._module_iter():
-                try:
-                    tensordict_exec = self._run_module(
-                        module, tensordict_exec, **kwargs
-                    )
-                except Exception as e:
-                    module_num_or_key = self._get_module_num_or_key(module)
-                    raise RuntimeError(
-                        f"Failed while executing module '{module_num_or_key}'. Scroll up for more info."
-                    ) from e
+                tensordict_exec = self._run_module(
+                    module, tensordict_exec, **kwargs
+                )
         else:
             raise RuntimeError(
                 f"TensorDictSequential does not support keyword arguments other than 'tensordict_out' or in_keys: {self.in_keys}. Got {kwargs.keys()} instead."

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -620,9 +620,7 @@ class TensorDictSequential(TensorDictModule):
 
         if not len(kwargs):
             for module in self._module_iter():
-                tensordict_exec = self._run_module(
-                    module, tensordict_exec, **kwargs
-                )
+                tensordict_exec = self._run_module(module, tensordict_exec, **kwargs)
         else:
             raise RuntimeError(
                 f"TensorDictSequential does not support keyword arguments other than 'tensordict_out' or in_keys: {self.in_keys}. Got {kwargs.keys()} instead."


### PR DESCRIPTION
## Description

Remove an unnecessary try-except in the forward pass of `tensordict.nn.sequential`.

## Motivation and Context

As raised in close #1327, there is an unnecessary try-except in the [forward call](https://github.com/pytorch/tensordict/blob/b5568a99e7bc0d5b3e50d941d71a1a5af007024b/tensordict/nn/sequence.py#L627) of tensordict.nn.sequential:

```
for module in self._module_iter():
    try:
        tensordict_exec = self._run_module(
            module, tensordict_exec, **kwargs
        )
    except Exception as e:
        module_num_or_key = self._get_module_num_or_key(module)
        raise RuntimeError(
            f"Failed while executing module '{module_num_or_key}'. Scroll up for more info."
        ) from e
```

This can be frustrating when trying to use PDB to debug, because you would prefer to be dropped into the location of the initial exception so you can inspect variables. There also does not appear to be a need for this try-except, because it simply parrots the original exception.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
