### PR TITLE
[BugFix] Flatten with start=end dim

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -7633,9 +7633,9 @@ class TensorDictBase(MutableMapping):
                 raise ValueError(
                     f"Incompatible end_dim {end_dim} for tensordict with shape {self.shape}."
                 )
-        if end_dim <= start_dim:
+        if end_dim < start_dim:
             raise ValueError(
-                "The end dimension must be strictly greater than the start dim."
+                "The end dimension must be greater or equal to the start dim."
             )
 
         def flatten(tensor):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -998,6 +998,12 @@ class TestGeneric:
             2,
         )
 
+    def test_flatten_00(self):
+        td = TensorDict(a=torch.zeros((2,)), batch_size=(2,))
+        td_flat = td.flatten(0, 0)
+        assert td_flat.shape == (2,)
+        assert td_flat["a"].shape == (2,)
+
     def test_fromkeys(self):
         td = TensorDict.fromkeys({"a", "b", "c"})
         assert td["a"] == 0


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
