### PR TITLE
[BugFix] `tensordict.stack` forces all names to `None`  when no match

### DIFF
--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -678,10 +678,10 @@ def _stack(
             # Add names if all tensordicts have the same `names`
             names = list_of_tensordicts[0]._maybe_names()
             if names is not None:
-                if all(td._maybe_names() == names for td in list_of_tensordicts[:1]):
+                if all(td._maybe_names() == names for td in list_of_tensordicts[1:]):
                     names.insert(dim, None)
-            else:
-                names = None
+                else:
+                    names = None
 
             result = clz._new_unsafe(
                 out,

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2793,6 +2793,12 @@ class TestGeneric:
         td2 = torch.stack([td, td], dim=-1)
         assert td2.names == ["first", "second", None]
 
+        # Mess with the names
+        td_copy = td.clone()
+        td_copy.names = ["first", "third"]
+        td2 = torch.stack([td, td_copy], dim=0)
+        assert td2.names == [None, None, None]
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_record_stream(self):
         s0 = torch.cuda.Stream(0)


### PR DESCRIPTION
## Description

Fix a bug in `stack` when names are not matching -- now returns `None` in that case.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
