### PR TITLE
[BugFix] make device arg in TensorDict constructor respect cuda current device

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -268,8 +268,13 @@ class TensorDict(TensorDictBase):
                 sub_non_blocking = non_blocking
             device = torch.device(device)
             # Auto-index the device
-            if device.type not in ("cpu", "meta") and device.index is None:
-                device = torch.device(device.type, index=0)
+            if device.index is None:
+                if device.type == "cuda":
+                    device = torch.device(
+                        device.type, index=torch.cuda.current_device()
+                    )
+                elif device.type not in ("cpu", "meta"):
+                    device = torch.device(device.type, index=0)
             if device.type == "cuda":
                 # CUDA does its sync by itself
                 call_sync = False


### PR DESCRIPTION
## Description

The `device` argument in `TensorDict` constructor didn't respect `torch.cuda.current_device`. After setting the global cuda device to 1, `TensorDict(..., device='cuda')` still uses device 0. This PR fixed this issue using cuda current device index by default.
```python
import torch
from tensordict import TensorDict

torch.cuda.set_device(1)

td = TensorDict(dict(x=torch.zeros(1))).to(device='cuda')
print(td.device)    # prints cuda:1
td = TensorDict(dict(x=torch.zeros(1)), device='cuda')
print(td.device)    # prints cuda:0, which is unexpected
```

## Motivation and Context

As above.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
