### PR TITLE
[BugFix] Add check for split_size in TensorDict.split

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -471,6 +471,7 @@ class TensorDict(TensorDictBase):
         return destination
 
     def is_empty(self):
+
         for item in self._tensordict.values():
             # we need to check if item is empty
             if _is_tensor_collection(type(item)):
@@ -1147,7 +1148,8 @@ class TensorDict(TensorDictBase):
             is_leaf = _default_is_leaf
         for key, item in self.items():
             if (
-                not call_on_nested and not is_leaf(type(item))
+                not call_on_nested 
+                and not is_leaf(type(item))
                 # and not is_non_tensor(item)
             ):
                 if default is not NO_DEFAULT:
@@ -1268,6 +1270,7 @@ class TensorDict(TensorDictBase):
                 result._tensordict[key] = item_trsf
 
         else:
+
             local_inplace = BEST_ATTEMPT_INPLACE if inplace else False
 
             def setter(
@@ -1292,6 +1295,7 @@ class TensorDict(TensorDictBase):
         for i, (key, local_future) in enumerate(
             _zip_strict(self.keys(), local_futures)
         ):
+
             if isinstance(local_future, list):
                 # We can't make this a future as it could cause deadlocks:
                 #  If we put a future over the root and this triggers another
@@ -1412,7 +1416,8 @@ class TensorDict(TensorDictBase):
 
         for key, item in self.items():
             if (
-                not call_on_nested and not is_leaf(type(item))
+                not call_on_nested 
+                and not is_leaf(type(item))
                 # and not is_non_tensor(item)
             ):
                 if default is not NO_DEFAULT:

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import itertools
 import numbers
 import os
 import weakref

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2744,6 +2744,14 @@ class TestGeneric:
             td.split(1, 2)
         with pytest.raises(IndexError, match="Incompatible dim"):
             td.split(1, -3)
+        with pytest.raises(
+            RuntimeError, match="split_size must be a positive integer, but got 0."
+        ):
+            td.split(0, -1)
+        with pytest.raises(
+            RuntimeError, match="split_size must be a positive integer, but got -1."
+        ):
+            td.split(-1, -1)
 
     def test_split_with_negative_dim(self):
         td = TensorDict(


### PR DESCRIPTION
## Description

Refactored code in TensorDict.split to add the check ```split_size > 0```; otherwise, raise a RuntimeError.

## Motivation and Context

close #1368, fail fast when ```split_size <= 0```.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
