### PR TITLE
[Feature] implement tensor_split

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -3717,7 +3717,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 for s in split_size:
                     if s == 0:
                         batch_size = list(self._batch_size)
-                        batch_size[self.stack_dim] = 0
+                        batch_size.pop(self.stack_dim)
                         yield LazyStackedTensorDict(
                             batch_size=batch_size,
                             device=self.device,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import math
 import numbers
 import os
 import weakref
@@ -1790,47 +1789,6 @@ class TensorDict(TensorDictBase):
             for split, bsz in _zip_strict(splits, batch_sizes)
         )
         return result
-
-    def tensor_split(self, indices_or_sections: int | list[int], dim=0) -> tuple[TensorDictBase, ...]:
-        assert isinstance(indices_or_sections, int | list)
-
-        batch_size = self.batch_size
-        dim = _maybe_correct_neg_dim(dim, batch_size)
-
-        if self.ndim == 0:
-            msg = "tensor_split: received a rank zero tensor, but expected a tensor of rank one or greater!"
-            raise ValueError(msg)
-
-        # Case 0 -- indices_or_sections is an integer or a scalar tensor n and a is split along dim into n parts of equal-ish length
-        if isinstance(indices_or_sections, int):
-            sections: int = (
-                indices_or_sections  # type: ignore[assignment]
-            )
-
-            if sections <= 0:
-                msg = f"tensor_split: number of sections must be greater than 0, but was {sections}"
-                raise ValueError(msg)
-
-            dim_size = self.shape[dim]
-            min_split_size = math.floor(dim_size / sections)
-            num_splits_one_extra = dim_size % sections
-
-            split_sizes = []
-            for split_idx in range(sections):
-                split_size = (
-                    min_split_size + 1
-                    if (split_idx < num_splits_one_extra)
-                    else min_split_size
-                )
-                split_sizes.append(split_size)
-
-            return tuple(self.split(split_sizes, dim=dim))
-        # Case 1 -- indices_or_sections is a sequence of integers or a 1D tensor describing the splits
-        else:
-            indices = indices_or_sections
-            indices = [0] + list(indices) + [self.shape[dim]]
-            split_sizes = [indices[i + 1] - indices[i] for i in range(len(indices) - 1)]
-            return tuple(self.split(split_sizes, dim=dim))
 
     def chunk(self, chunks: int, dim: int = 0) -> tuple[TensorDictBase, ...]:
         if chunks < 1:

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3421,6 +3421,31 @@ class TensorDictBase(MutableMapping):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def tensor_split(self, indices_or_sections: int | list[int], dim=0) -> tuple[TensorDictBase, ...]:
+        """Splits a tensor into multiple sub-tensors, all of which are views of input,
+        along dimension dim according to the indices or number of sections specified by indices_or_sections.
+
+        Args:
+            indices_or_sections (int or List(int):
+            dim (int, optional): dimension along which to split the tensor. Default: 0
+
+        Examples:
+            >>> td = TensorDict({
+            ...     'x': torch.arange(24).reshape(3, 4, 2),
+            ... }, batch_size=[3, 4])
+            >>> td0, td1 = td.tensor_split(dim=-1, indices_or_sections=2)
+            >>> td0['x']
+            tensor([[[ 0,  1],
+                     [ 2,  3]],
+                    [[ 8,  9],
+                     [10, 11]],
+                    [[16, 17],
+                     [18, 19]]])
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def chunk(self, chunks: int, dim: int = 0) -> tuple[TensorDictBase, ...]:
         """Splits a tensordict into the specified number of chunks, if possible.
 

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -509,6 +509,7 @@ _FALLBACK_METHOD_FROM_TD = [
     "tan_",
     "tanh",
     "tanh_",
+    "tensor_split",
     "to",
     "to_h5",
     "to_lazystack",

--- a/tensordict/tensorclass.pyi
+++ b/tensordict/tensorclass.pyi
@@ -1076,6 +1076,11 @@ class TensorClass:
         is_leaf: Callable[[type], bool] | None = None,
     ) -> T: ...
     def unflatten_keys(self, separator: str = ".", inplace: bool = False) -> T: ...
+    def tensor_split(
+        self,
+        indices_or_sections: int | list[int] | tuple[int, ...] | torch.Tensor,
+        dim: int = 0,
+    ) -> tuple[TensorDictBase, ...]: ...
     def split_keys(
         self,
         *key_sets,

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -1823,6 +1823,27 @@ class TestTensorClass:
         assert split_tcs[0].z == split_tcs[1].z == split_tcs[2].z == z
         assert split_tcs[0].y[0].z == split_tcs[0].y[1].z == split_tcs[0].y[2].z == z
 
+    def test_tensor_split(self):
+        @tensorclass
+        class MyDataNested:
+            X: torch.Tensor
+            z: str
+            y: "MyDataNested" = None
+
+        data_in = MyDataNested(
+            X=torch.ones(3, 6, 5), z="test_tensorclass", batch_size=[3, 6]
+        )
+        data_out = MyDataNested(
+            X=torch.ones(3, 6, 5), z="test_tensorclass", y=data_in, batch_size=[3, 6]
+        )
+
+        data_split = data_out.tensor_split((1, 4, 5), 1)
+        assert len(data_split) == 4
+        assert data_split[0].batch_size == torch.Size([3, 1])
+        assert data_split[1].batch_size == torch.Size([3, 3])
+        assert data_split[2].batch_size == torch.Size([3, 1])
+        assert data_split[2].batch_size == torch.Size([3, 1])
+
     def test_update(self):
         @tensorclass
         class MyDataNested:


### PR DESCRIPTION
## Description

Implement tensor_split for tensordict by following https://docs.pytorch.org/docs/stable/generated/torch.tensor_split.html

## Motivation and Context

- The `tensor_split` function makes sure that the output list after split is equal to the number of chunks specified while the `chunk` function does not.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
