### PR TITLE
[Bugfix] Fix `TensorDictModuleWrapper` forward

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -1358,7 +1358,7 @@ class TensorDictModuleWrapper(TensorDictModuleBase):
         )
 
     def forward(self, *args: Any, **kwargs: Any) -> TensorDictBase:
-        return self.td_module.forward(*args, **kwargs)
+        return self.td_module(*args, **kwargs)
 
 
 class WrapModule(TensorDictModuleBase):


### PR DESCRIPTION
## Description

Changed `TensorDictModuleWrapper` forward method to directly called the wrapped `td_module`.

## Motivation and Context

Fixes #1414 

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
