### PR TITLE
[Feature] Typed MetaData

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -12853,6 +12853,18 @@ class TestNonTensorData:
 
 
 class TestMetaData:
+    def test_typed_metadata(self):
+        d = MetaData[int](0, batch_size=(3,))
+        assert d.data == 0
+        assert isinstance(d, MetaData[int])
+        with pytest.raises(TypeError, match="Expected data of type int, got str"):
+            MetaData[int]("a string")
+        cls = MetaData[int]
+        assert issubclass(cls, MetaData)
+        d = cls(0, batch_size=(3,))
+        assert isinstance(d, MetaData)
+        # Test caching
+        assert isinstance(d, MetaData[int])
 
     def test_expand(self):
         d = MetaData(0, batch_size=(3,))


### PR DESCRIPTION
# Add Type-Safe MetaData with Parametric Types

## Summary

This PR implements type-safe `MetaData` classes using parametric type syntax (e.g., `MetaData[str]`, `MetaData[int]`) with runtime type validation and class caching.

## Changes

### New Features

- **Parametric MetaData Types**: Enable creation of type-specific metadata using bracket notation:
  ```python
  # Valid usage
  metadata = MetaData[str]("hello", batch_size=[3])
  
  # Raises TypeError at runtime
  metadata = MetaData[int]("hello")  # TypeError: Expected data of type int, got str
  ```

- **Runtime Type Validation**: Automatically validates that the `data` field matches the expected type during object initialization.

- **Class Caching**: Implements efficient caching to ensure `MetaData[int]` always returns the same class instance, enabling proper `isinstance` checks and maintaining class identity.

### Implementation Details

#### `_MetaDataMeta` Metaclass Updates

- **Enhanced `__new__` method**: Added initialization of `_typed_class_cache` for storing generated typed classes
- **New `__getitem__` method**: Handles bracket notation and creates/retrieves typed classes from cache
- **Type validation**: Generated classes include automatic type checking in `__post_init__`

#### Key Behavior

1. **Caching**: Multiple calls to `MetaData[int]` return the same class object
2. **Type Safety**: Runtime validation ensures data type consistency
3. **Inheritance**: Generated typed classes properly inherit from base `MetaData`
4. **Error Handling**: Clear error messages for type mismatches

### Test Coverage

Added comprehensive test `test_typed_metadata()` covering:
- ✅ Valid type creation and data access
- ✅ Runtime type validation and error messages  
- ✅ Class identity and inheritance relationships
- ✅ `isinstance` checks working correctly

### Backward Compatibility

- ✅ Existing `MetaData` usage remains unchanged
- ✅ No breaking changes to current API
- ✅ Type specification is purely additive

## Usage Examples

```python
# Basic typed metadata
metadata = MetaData[str]("configuration", batch_size=[10])
assert metadata.data == "configuration"
assert isinstance(metadata, MetaData[str])

# Type validation at runtime
try:
    MetaData[int]("not an int")  # Raises TypeError
except TypeError as e:
    print(e)  # "Expected data of type int, got str"

# Class caching ensures identity
cls1 = MetaData[int]
cls2 = MetaData[int]
assert cls1 is cls2  # Same class object
```

This enhancement provides a more robust and type-safe way to work with metadata while maintaining full backward compatibility with existing code.