### PR TITLE
[Feature] Support for mixed `TensorDictBase` types in `torch.autograd.grad`

### DIFF
--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -929,15 +929,11 @@ def _grad(
         )
 
     if grad_outputs is not None:
-        tup_grad_outputs = tuple(
-            grad_outputs._values_list(True, True, is_leaf=_NESTED_TENSORS_AS_LISTS)
-        )
+        tup_grad_outputs = tuple(grad_outputs[k] for k in outputs.keys(True, True))
     else:
         tup_grad_outputs = None
 
-    tup_outputs = tuple(
-        outputs._values_list(True, True, is_leaf=_NESTED_TENSORS_AS_LISTS)
-    )
+    tup_outputs = tuple(outputs[k] for k in outputs.keys(True, True))
 
     keys, all_inputs = inputs._items_list(True, True, is_leaf=_NESTED_TENSORS_AS_LISTS)
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -10608,6 +10608,13 @@ class TestLazyStackedTensorDict:
         assert td.batch_size == (2, 4)
         assert td.batch_size == td2.batch_size
 
+    def test_autograd_grad_mixed_types(self):
+        inputs = TensorDict(a=torch.randn(2, 3, requires_grad=True))
+        outputs = inputs + 1
+        grad_outputs = LazyStackedTensorDict(TensorDict(a=torch.ones(3)), TensorDict(a=torch.ones(3)), stack_dim=0)
+        grads = torch.autograd.grad(outputs, inputs, grad_outputs)
+        assert (grads == 1).all()
+
 
 @pytest.mark.skipif(
     not _has_torchsnapshot, reason=f"torchsnapshot not found: err={TORCHSNAPSHOT_ERR}"


### PR DESCRIPTION
## Description

Support:

```py
inputs = TensorDict(a=torch.randn(2, 3, requires_grad=True))
outputs = inputs + 1
grad_outputs = LazyStackedTensorDict(TensorDict(a=torch.ones(3)), TensorDict(a=torch.ones(3)), stack_dim=0)
grads = torch.autograd.grad(outputs, inputs, grad_outputs)
```

## Motivation and Context

- Mentionned in #1417 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
