### PR TITLE
[BugFix] Change is_diff check to use is_diff.any()

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2579,7 +2579,7 @@ class TensorDict(TensorDictBase):
                     ignore_lock=True,
                 )
             is_diff = dest[idx].tolist() != value.tolist()
-            if is_diff:
+            if is_diff.any():
                 dest_val = dest.maybe_to_stack()
                 dest_val[idx] = value
                 if dest_val is not dest:


### PR DESCRIPTION
## Description

Previous implementation using list of boolean values resulted in ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

I assume using any() instead of all() is the intended behavior.

## Motivation and Context
Why is this change required? ValueError when setting td.set_at_()
close #1476

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

Not sure how this logical error should be tested. Please help