### PR TITLE
[BugFix] ONNX Export Syntax in Tests and Add Optional Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tests = [
 h5 = ["h5py>=3.8"]
 dev = ["pybind11", "ninja"]
 typecheck = ["mypy>=1.0.0"]
+onnx = ["onnx", "onnxscript", "onnxruntime"]
 
 [tool.setuptools]
 include-package-data = false

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -950,9 +950,7 @@ class TestONNXExport:
         x = torch.randn(3)
         y = torch.randn(3)
         torch_input = {"x": x, "y": y}
-        onnx_program = torch.onnx.dynamo_export(tdm, **torch_input)
-
-        onnx_input = onnx_program.adapt_torch_inputs_to_onnx(**torch_input)
+        onnx_program = torch.onnx.export(tdm, kwargs=torch_input, dynamo=True)
 
         path = Path(tmpdir) / "file.onnx"
         onnx_program.save(str(path))
@@ -969,9 +967,7 @@ class TestONNXExport:
                 else tensor.cpu().numpy()
             )
 
-        onnxruntime_input = {
-            k.name: to_numpy(v) for k, v in zip(ort_session.get_inputs(), onnx_input)
-        }
+        onnxruntime_input = {k: to_numpy(v) for k, v in torch_input.items()}
 
         onnxruntime_outputs = ort_session.run(None, onnxruntime_input)
         torch.testing.assert_close(
@@ -986,10 +982,8 @@ class TestONNXExport:
         x = torch.randn(3)
         y = torch.randn(3)
         torch_input = {"x": x, "y": y}
-        torch.onnx.dynamo_export(tdm, x=x, y=y)
-        onnx_program = torch.onnx.dynamo_export(tdm, **torch_input)
-
-        onnx_input = onnx_program.adapt_torch_inputs_to_onnx(**torch_input)
+        torch.onnx.export(tdm, kwargs=torch_input, dynamo=True)
+        onnx_program = torch.onnx.export(tdm, kwargs=torch_input, dynamo=True)
 
         path = Path(tmpdir) / "file.onnx"
         onnx_program.save(str(path))
@@ -1006,9 +1000,7 @@ class TestONNXExport:
                 else tensor.cpu().numpy()
             )
 
-        onnxruntime_input = {
-            k.name: to_numpy(v) for k, v in zip(ort_session.get_inputs(), onnx_input)
-        }
+        onnxruntime_input = {k: to_numpy(v) for k, v in torch_input.items()}
 
         onnxruntime_outputs = ort_session.run(None, onnxruntime_input)
         torch.testing.assert_close(


### PR DESCRIPTION
## Description

This PR fixes the ONNX export tests in `test/test_compile.py` by updating the syntax to use the current `torch.onnx.export()` API instead of the deprecated `torch.onnx.dynamo_export()` method. Additionally, it adds the necessary optional dependencies (`onnx`, `onnxscript`, `onnxruntime`) to `pyproject.toml` to enable running these tests.

## Motivation and Context

The ONNX export tests were using outdated API syntax (`torch.onnx.dynamo_export()` and `adapt_torch_inputs_to_onnx()`), which has been replaced in newer PyTorch versions. This change updates the tests to use the current recommended API (`torch.onnx.export()` with `dynamo=True` flag) and simplifies the input handling by directly using the torch input dictionary.

The change also adds an `onnx` optional dependency group in `pyproject.toml`, making it easier for developers to install the required dependencies for running ONNX-related tests.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
