### PR TITLE
[Feature,Quality] Raise ValueError if split_size is zero

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1798,8 +1798,14 @@ class TensorDict(TensorDictBase):
         dim = _maybe_correct_neg_dim(dim, batch_size)
         max_size = batch_size[dim]
         if isinstance(split_size, int):
-            if split_size == 0:
-                raise ValueError('TensorDict.split: split_size cannot be 0.')
+            if split_size <= 0:
+                raise ValueError(
+                    f"TensorDict.split: split_size must be positive, got {split_size}."
+                )
+            if split_size > max_size:
+                raise ValueError(
+                    f"TensorDict.split: split_size ({split_size}) exceeds dimension size ({max_size})."
+                )
             segments = _create_segments_from_int(split_size, max_size)
             splits = [end - start for start, end in segments]
             splits = {k: v.split(splits, dim) for k, v in self.items()}


### PR DESCRIPTION
Add validation to prevent split_size from being zero.

## Description

Add validation to prevent split_size from being zero, which then causes CPU OOM.

## Motivation and Context

Why is this change required? What problem does it solve?
verl gets CPU OOM killed when `ppo_micro_batch_size < world_size` in `data.batch.split(ppo_micro_batch_size//world_size)`. That is, when TensorDict.split gets an 0 int input.

Fixes #1479.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
