### PR TITLE
[BugFix] Fix select strict=False for torch.compile compatibility

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -45,6 +45,7 @@ from tensordict.base import (
     _maybe_broadcast_other,
     _NESTED_TENSORS_AS_LISTS,
     _register_tensor_class,
+    _UNSET,
     BEST_ATTEMPT_INPLACE,
     CompatibleType,
     is_tensor_collection,
@@ -3394,8 +3395,8 @@ class TensorDict(TensorDictBase):
                 else:
                     key, subkey = key[0], key[1:]
 
-                val = self._get_str(key, default=None if not strict else NO_DEFAULT)
-                if val is None:
+                val = self._get_str(key, default=_UNSET if not strict else NO_DEFAULT)
+                if val is _UNSET:
                     continue
                 source[key] = val
                 if len(subkey):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -295,6 +295,24 @@ class TestTD:
         result_c = pop_missing_c(data.clone())
         assert result_c is None
 
+    def test_select_strict_false(self, mode):
+        def select_keys(td: TensorDict):
+            return td.select("a", "missing_key", strict=False)
+
+        select_keys_c = torch.compile(select_keys, fullgraph=True, mode=mode)
+
+        # Test select with strict=False
+        data = TensorDict({"a": torch.tensor(1), "b": torch.tensor(2)})
+        result = select_keys(data)
+        assert "a" in result.keys()
+        assert "missing_key" not in result.keys()
+        assert "b" not in result.keys()
+
+        result_c = select_keys_c(data)
+        assert "a" in result_c.keys()
+        assert "missing_key" not in result_c.keys()
+        assert "b" not in result_c.keys()
+
     def test_names(self, mode):
         import torch._dynamo.exc
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1503
* #1502
* __->__ #1501

Use _UNSET sentinel instead of None in _select method to detect missing
keys without relying on try/except. This also fixes a potential bug where
actual None values could be incorrectly skipped.