### PR TITLE
[BugFix] Fix del_ in LazyStackedTensorDict for torch.compile compatibility

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2890,9 +2890,7 @@ class LazyStackedTensorDict(TensorDictBase):
                     td.del_(key, **kwargs)
                     is_deleted = True
         if not is_deleted:
-            raise KeyError(
-                f"Key {key} not found in any of the stacked tensordicts."
-            )
+            raise KeyError(f"Key {key} not found in any of the stacked tensordicts.")
         return self
 
     def pop(self, key: NestedKey, default: Any = NO_DEFAULT) -> CompatibleType:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #1503
* #1502
* #1501

Replace try/except pattern with check-before-delete pattern using
key existence check before deletion, making it compatible with
torch.compile fullgraph mode.