### PR TITLE
[Deprecation] Remove deprecated features scheduled for v0.11

### DIFF
--- a/tensordict/_contextlib.py
+++ b/tensordict/_contextlib.py
@@ -14,7 +14,6 @@ import contextlib
 import functools
 import inspect
 import sys
-import warnings
 from typing import Any, Callable, cast, TypeVar
 
 import numpy as np
@@ -143,15 +142,13 @@ class _DecoratorContextManager:
 
     def __call__(self, orig_func: F) -> F:
         if inspect.isclass(orig_func):
-            warnings.warn(
-                "Decorating classes is deprecated and will be disabled in "
-                "future versions. You should only decorate functions or methods. "
+            raise RuntimeError(
+                "Decorating classes is no longer supported. "
+                "You should only decorate functions or methods. "
                 "To preserve the current behavior of class decoration, you can "
                 "directly decorate the `__init__` method and nothing else."
             )
-            func = cast(F, lambda *args, **kwargs: orig_func(*args, **kwargs))
-        else:
-            func = orig_func
+        func = orig_func
 
         return cast(F, context_decorator(self.clone, func))
 

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 from typing import Any, Callable, Dict, Mapping, Sequence
 
 import torch
@@ -102,7 +100,6 @@ def pad_sequence(
     pad_dim: int = 0,
     padding_value: float = 0.0,
     out: T | None = None,
-    device: DeviceType | None = None,
     return_mask: bool | NestedKey = False,
 ) -> T:
     """Pads a list of tensordicts in order for them to be stacked together in a contiguous format.
@@ -140,12 +137,6 @@ def pad_sequence(
             device=None,
             is_shared=False)
     """
-    if device is not None:
-        warnings.warn(
-            "The device argument is ignored by this function and will be removed in v0.5. To cast your"
-            " result to a different device, call `tensordict.to(device)` instead."
-        )
-
     if not len(list_of_tensordicts):
         raise RuntimeError("list_of_tensordicts cannot be empty")
 

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -825,8 +825,10 @@ class MemoryMappedTensor(torch.Tensor):
 
     @property
     def _tensor(self):
-        # for bc-compatibility with MemmapTensor, to be deprecated in v0.4
-        return self
+        raise RuntimeError(
+            "_tensor property has been removed. MemoryMappedTensor is now a tensor subclass "
+            "and can be used directly without accessing _tensor."
+        )
 
     def __setstate__(self, state):
         if "filename" in state:

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1575,10 +1575,9 @@ def _expand_index(index, batch_size):
 
 def _renamed_inplace_method(fn):
     def wrapper(*args, **kwargs):
-        warnings.warn(
-            f"{fn.__name__.rstrip('_')} has been deprecated, use {fn.__name__} instead"
+        raise RuntimeError(
+            f"{fn.__name__.rstrip('_')} has been removed, use {fn.__name__} instead"
         )
-        return fn(*args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
## Summary

This PR addresses deprecation warnings that were scheduled for v0.11 or earlier versions:

- **`pad_sequence` device parameter** (deprecated in v0.5): Removed the `device` parameter entirely since it was never used and was scheduled for removal
- **`MemoryMappedTensor._tensor` property** (deprecated in v0.4): Now raises RuntimeError explaining that MemoryMappedTensor is a tensor subclass and can be used directly
- **Class decoration on context managers**: Converted warning to RuntimeError - decorating classes with context managers like `set_lazy_legacy` is no longer supported
- **Deprecated non-underscore methods**: `lock`, `unlock`, `rename_key` (without trailing underscore) on LazyStackedTensorDict and related classes now raise RuntimeError. Users should use `lock_`, `unlock_`, `rename_key_` instead

## Changes

| File | Change |
|------|--------|
| `tensordict/functional.py` | Removed `device` parameter from `pad_sequence` |
| `tensordict/memmap.py` | `_tensor` property now raises RuntimeError |
| `tensordict/_contextlib.py` | Class decoration now raises RuntimeError |
| `tensordict/utils.py` | `_renamed_inplace_method` now raises RuntimeError |

## Test plan

- [x] All existing tests pass
- [x] `pad_sequence` tests pass without `device` parameter
- [x] Deprecated methods correctly raise RuntimeError
- [x] Class decoration correctly raises RuntimeError
- [x] `lock_`/`unlock_`/`rename_key_` (with underscore) continue to work