### PR TITLE
[CI] Fix release workflow: remove invalid job-level permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,9 +207,6 @@ jobs:
     uses: ./.github/workflows/build-wheels-linux.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
-    permissions:
-      id-token: write
-      contents: read
 
   build-windows:
     name: Build Windows Wheels
@@ -218,9 +215,6 @@ jobs:
     uses: ./.github/workflows/build-wheels-windows.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
-    permissions:
-      id-token: write
-      contents: read
 
   build-macos:
     name: Build macOS Wheels
@@ -229,9 +223,6 @@ jobs:
     uses: ./.github/workflows/build-wheels-m1.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
-    permissions:
-      id-token: write
-      contents: read
 
   build-aarch64:
     name: Build Aarch64 Linux Wheels
@@ -240,9 +231,6 @@ jobs:
     uses: ./.github/workflows/build-wheels-aarch64-linux.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
-    permissions:
-      id-token: write
-      contents: read
 
   # =============================================================================
   # COLLECT WHEELS


### PR DESCRIPTION
## Summary

Fixes the release workflow by removing invalid `permissions:` blocks from reusable workflow jobs.

When using `uses:` to call reusable workflows, `permissions:` cannot be specified at the job level - this causes GitHub Actions to reject the workflow file entirely. Permissions are inherited from the workflow level or from the called workflow itself.

The `build-wheels-*.yml` workflows already declare their own permissions at workflow level, so these job-level declarations were both invalid and redundant.

## Test Plan

- [x] Workflow file will be validated by GitHub Actions on push