### PR TITLE
[CI] Failing jobs stop upload in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: wheels
-          pattern: '*wheel*'
+          # pytorch/test-infra uploads artifacts named like: pytorch_tensordict__3.11_cpu_x86_64
+          pattern: 'pytorch_tensordict*'
           merge-multiple: true
 
       - name: List collected wheels


### PR DESCRIPTION
The pytorch/test-infra workflows upload artifacts with names like
'pytorch_tensordict__3.11_cpu_x86_64', not containing 'wheel'.
Update the pattern from '*wheel*' to 'pytorch_tensordict*' to match.
