### PR TITLE
[Perf] Use CUDA event sync instead of torch.cuda.synchronize() in .to()

### DIFF
--- a/benchmarks/common/cpu_transfer_sync_test.py
+++ b/benchmarks/common/cpu_transfer_sync_test.py
@@ -1,0 +1,106 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmark CPU transfer sync strategies for TensorDict.to('cpu').
+
+Three strategies are compared:
+  1. Blocking: non_blocking=False (each tensor.to() blocks individually).
+  2. Global sync: non_blocking=True per tensor, then torch.cuda.synchronize().
+  3. Event sync: non_blocking=True per tensor, then event.record() + event.synchronize().
+
+Strategy (3) is the current default (.to("cpu") with non_blocking=None).
+Strategy (2) was the previous default before the event-based sync change.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tensordict import TensorDict
+from tensordict.base import _sync_cuda_transfer
+from tensordict.utils import logger as tensordict_logger
+
+
+@pytest.fixture
+def td_cuda_many_tensors():
+    """TensorDict on CUDA with many small tensors to stress sync overhead."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    num_keys = 1000
+    shape = (64, 64)
+    td = TensorDict(
+        {
+            str(i): torch.randn(shape, device="cuda", dtype=torch.float32)
+            for i in range(num_keys)
+        },
+        batch_size=[],
+    )
+    tensordict_logger.info(
+        f"td_cuda_many_tensors: {num_keys} keys, shape={shape}, "
+        f"size {td.bytes() / 1024 / 1024:.2f} Mb"
+    )
+    return td
+
+
+def _to_cpu_global_sync(td):
+    """Manual non_blocking + torch.cuda.synchronize() (old behaviour)."""
+    td_cpu = td.to("cpu", non_blocking=True)
+    torch.cuda.synchronize()
+    return td_cpu
+
+
+def _to_cpu_event_sync(td):
+    """Manual non_blocking + event-based sync (new behaviour)."""
+    td_cpu = td.to("cpu", non_blocking=True)
+    _sync_cuda_transfer()
+    return td_cpu
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA device found")
+class TestCpuTransferSync:
+    """Compare blocking, global sync, and event sync .to('cpu')."""
+
+    def test_to_cpu_blocking(self, benchmark, td_cuda_many_tensors):
+        """Each tensor blocks on transfer (non_blocking=False)."""
+        td = td_cuda_many_tensors
+
+        def run():
+            return td.to("cpu", non_blocking=False)
+
+        for _ in range(3):
+            run()
+        benchmark(run)
+
+    def test_to_cpu_global_sync(self, benchmark, td_cuda_many_tensors):
+        """non_blocking copies + torch.cuda.synchronize() (old default)."""
+        td = td_cuda_many_tensors
+
+        def run():
+            return _to_cpu_global_sync(td)
+
+        for _ in range(3):
+            run()
+        benchmark(run)
+
+    def test_to_cpu_event_sync(self, benchmark, td_cuda_many_tensors):
+        """non_blocking copies + event sync (new default)."""
+        td = td_cuda_many_tensors
+
+        def run():
+            return _to_cpu_event_sync(td)
+
+        for _ in range(3):
+            run()
+        benchmark(run)
+
+    def test_to_cpu_default(self, benchmark, td_cuda_many_tensors):
+        """Default .to('cpu') (non_blocking=None, uses event sync internally)."""
+        td = td_cuda_many_tensors
+
+        def run():
+            return td.to("cpu")
+
+        for _ in range(3):
+            run()
+        benchmark(run)


### PR DESCRIPTION
## Summary

- Replace `torch.cuda.synchronize()` with CUDA event-based sync (`event.record()` + `event.synchronize()`) in `TensorDict.to()` when transferring to CPU. This waits only for the queued D2H copies instead of all pending GPU work.
- Applies to both the regular `.to()` path (`_sync_all()`) and the consolidated path (`_to_consolidated()`). Non-CUDA backends (MPS, NPU) are unchanged.

## Benchmark (H200, 1000 keys, 64x64 float32 tensors)

| Strategy | Min | Median | Max | OPS |
|----------|-----|--------|-----|-----|
| **Event sync** (new) | 6.63 ms | 6.70 ms | **7.1 ms** | 149.0 |
| Global sync (old `torch.cuda.synchronize()`) | 6.64 ms | 6.72 ms | 64.3 ms | 140.1 |
| Blocking (`non_blocking=False`) | 13.95 ms | 13.98 ms | 14.1 ms | 71.5 |

Median times are similar for event vs global sync in isolation, but event sync eliminates outlier latency spikes (7 ms max vs 64 ms) caused by accidentally waiting on unrelated GPU work. The benefit is larger in production pipelines with concurrent GPU computation.

## Test plan

- [x] New correctness test: `test_to_cpu_correctness_many_tensors` -- transfers 10,000 tensors from CUDA to CPU across 10 iterations, checks subsample of values. Passed on H200.
- [x] Existing `test_non_blocking` test passes on H200.
- [x] New benchmark: `benchmarks/common/cpu_transfer_sync_test.py` -- compares blocking, global sync, event sync, and default `.to("cpu")`.


Made with [Cursor](https://cursor.com)