### PR TITLE
[CI] Fix benchmark workflows: remove torchvision, align CUDA versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -76,7 +76,7 @@ jobs:
           source .venv/local/bin/activate
           echo "=== uv version ==="
           uv --version
-          uv pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
+          uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
           uv pip install "pybind11[global]" "setuptools" "wheel" "ninja"
           uv pip install pytest pytest-benchmark
           # Do not resolve runtime dependencies here: we want to keep the PyTorch build (nightly)

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: bash -l {0}
     container:
-      image: nvidia/cuda:12.3.0-runtime-ubuntu22.04
+      image: nvidia/cuda:12.8.0-runtime-ubuntu22.04
       options: --gpus all
     steps:
       - name: Who triggered this?
@@ -65,10 +65,13 @@ jobs:
           source .venv/local/bin/activate
           echo "=== uv version ==="
           uv --version
-          uv pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126
+          uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
           uv pip install "pybind11[global]" "setuptools" "wheel" "ninja"
           uv pip install pytest pytest-benchmark
+          # Do not resolve runtime dependencies here: we want to keep the PyTorch build (nightly)
+          # that was explicitly installed above, and avoid any solver replacing it.
           uv pip install -e . --no-deps
+          uv run --active python -c "import torch; print(torch.__version__)"
           ${{ matrix.device == 'CPU' && 'export CUDA_VISIBLE_DEVICES=' || '' }}
       - name: check GPU presence
         if: matrix.device == 'GPU'


### PR DESCRIPTION
## Summary
- Both benchmark workflows (Continuous Benchmark and Continuous Benchmark PR) fail during setup because they install `torchvision` nightly which is frequently unavailable (HTTP 404)
- No benchmark in the suite actually requires torchvision (only `benchmarks/distributed/dataloading.py` uses it, and distributed benchmarks are not run in CI)
- The PR workflow was also using a stale CUDA container (12.3.0) and PyTorch index (cu126) vs the main workflow's 12.8.0/cu128

## Changes
- Remove `torchvision` from `uv pip install` in both `benchmarks.yml` and `benchmarks_pr.yml`
- Align PR workflow CUDA container image to `nvidia/cuda:12.8.0-runtime-ubuntu22.04`
- Align PR workflow PyTorch index to `cu128`
- Add `--no-deps` comment and torch version print to PR workflow for consistency

## Test plan
- [x] CI will validate this fix by running the benchmark workflows on this PR itself


Made with [Cursor](https://cursor.com)