### PR TITLE
[CI] Fix docs workflow: remove torchvision dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,9 +55,9 @@ jobs:
         conda activate "./env"
 
         # Install PyTorch (CPU version for docs)
-        python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu -U --quiet --root-user-action=ignore
+        python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu -U --quiet --root-user-action=ignore
 
-        # Install tensordict runtime deps explicitly (except torch/torchvision which are handled above),
+        # Install tensordict runtime deps explicitly (except torch which is handled above),
         # then install tensordict without resolving dependencies to avoid any solver changing the
         # PyTorch build (stable vs nightly).
         python -m pip install -U packaging pyvers importlib_metadata --quiet --root-user-action=ignore

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,5 +12,4 @@ sphinxcontrib-htmlhelp
 myst-parser
 docutils
 
-torchvision
 tqdm


### PR DESCRIPTION
## Summary

- Remove `torchvision` from the docs CI pip install and from `docs/requirements.txt`. The nightly CPU torchvision wheel has been 404'ing (e.g. [this run](https://github.com/pytorch/tensordict/actions/runs/21958103107)), and torchvision is not actually needed for the docs build — tensordict doesn't import it and no sphinx-gallery tutorials reference it.

## Test plan

- The docs CI workflow on this PR should pass without torchvision.

Made with [Cursor](https://cursor.com)