### PR TITLE
[CI] Skip benchmark upload for nightly orchestrator runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,11 @@ on:
       - "*"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      skip-upload:
+        description: 'Skip benchmark upload to gh-pages'
+        type: boolean
+        default: false
 
 permissions:
   deployments: write
@@ -111,7 +116,7 @@ jobs:
       # Upload benchmark results for main branch, manual dispatch, or PRs with 'benchmarks/upload' label
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
-        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload')) }}
+        if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload'))) }}
         with:
           name: ${{ matrix.device }}-benchmark-results
           path: benchmarks/output.json
@@ -121,7 +126,7 @@ jobs:
     name: Upload benchmark results
     runs-on: ubuntu-latest
     needs: benchmark
-    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload')) }}
+    if: ${{ !inputs.skip-upload && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmarks/upload'))) }}
     steps:
       - name: Show upload trigger reason
         run: |

--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -47,6 +47,8 @@ jobs:
 
   benchmarks:
     uses: ./.github/workflows/benchmarks.yml
+    with:
+      skip-upload: true
     secrets: inherit
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

- Adds a `skip-upload` input (boolean, default `false`) to the `benchmarks.yml` `workflow_call` trigger
- The nightly orchestrator passes `skip-upload: true` when calling benchmarks, so nightly runs execute benchmarks but never upload results to gh-pages
- Direct triggers (push to main, manual `workflow_dispatch` on benchmarks itself, PR with `benchmarks/upload` label) are unaffected and continue to upload as before

## Test plan

- [ ] Verify nightly orchestrator runs benchmarks but skips the upload job
- [ ] Verify push to main still uploads benchmark results
- [ ] Verify direct `workflow_dispatch` on benchmarks.yml still uploads


Made with [Cursor](https://cursor.com)