### PR TITLE
[CI] Fix dashboard job permissions for repository_dispatch

### DIFF
--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -62,6 +62,8 @@ jobs:
   update-status-dashboard:
     name: Update Status Dashboard
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
       - test-linux
       - test-macos


### PR DESCRIPTION
## Summary

- The `update-status-dashboard` job in the nightly orchestrator was failing with "Resource not accessible by integration" when trying to fire `repository_dispatch`
- Root cause: the job had no `permissions:` block, and since other jobs in the workflow explicitly declare permissions, GitHub drops undeclared jobs to minimal read-only defaults
- Fix: add `contents: write` to the `update-status-dashboard` job, which is required by `peter-evans/repository-dispatch` to create dispatch events

## Test plan

- [ ] Merge, trigger nightly orchestrator manually, verify the status collector workflow is triggered after completion
- [ ] Verify dashboard deploys to https://pytorch.github.io/tensordict/nightly-status/


Made with [Cursor](https://cursor.com)