### PR TITLE
[CI] Fix status collector: disable uv cache to avoid symlink loop

### DIFF
--- a/.github/workflows/nightly_status_collector.yml
+++ b/.github/workflows/nightly_status_collector.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Collect nightly status
         env:


### PR DESCRIPTION
## Summary

- The nightly status collector was failing at the "Install uv" step with: `ELOOP: too many symbolic links encountered, stat '/home/runner/work/tensordict/tensordict/0.9/0.10'`
- Root cause: the gh-pages checkout (for existing `history.json`) contains symlink loops in the versioned docs directories (e.g., `0.9` -> `0.10`). The `setup-uv` action's cache glob scan (`**/uv.lock`) traverses these and crashes.
- Fix: set `enable-cache: false`. This is a one-shot script that installs a single dependency (`requests`) -- caching provides no benefit here.

## Test plan

- [ ] Merge and trigger `nightly_status_collector.yml` manually via workflow_dispatch
- [ ] Verify the collector completes and deploys dashboard to https://pytorch.github.io/tensordict/nightly-status/


Made with [Cursor](https://cursor.com)