### PR TITLE
[CI] Add dry-run and smoke-test modes to nightly orchestrator

### DIFF
--- a/.github/workflows/nightly_orchestrator.yml
+++ b/.github/workflows/nightly_orchestrator.yml
@@ -4,13 +4,58 @@ on:
   schedule:
     - cron: '0 6 * * *' # 6AM UTC daily
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Run mode: full (run tests + deploy dashboard), dry-run (run tests, skip dashboard deploy), smoke-test (skip tests, validate CI plumbing only)'
+        type: choice
+        options:
+          - full
+          - dry-run
+          - smoke-test
+        default: full
 
 concurrency:
   group: nightly-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
+  # =============================================================================
+  # Resolve the effective mode (schedule always uses "full")
+  # =============================================================================
+  config:
+    name: Configure
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.resolve.outputs.mode }}
+      run_tests: ${{ steps.resolve.outputs.run_tests }}
+      deploy_dashboard: ${{ steps.resolve.outputs.deploy_dashboard }}
+    steps:
+      - name: Resolve mode
+        id: resolve
+        run: |
+          MODE="${{ inputs.mode || 'full' }}"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$MODE" = "smoke-test" ]; then
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
+            echo "deploy_dashboard=true" >> "$GITHUB_OUTPUT"
+          elif [ "$MODE" = "dry-run" ]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "deploy_dashboard=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "deploy_dashboard=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "### Nightly Orchestrator Configuration" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Mode**: $MODE" >> "$GITHUB_STEP_SUMMARY"
+
+  # =============================================================================
+  # Test workflows (skipped in smoke-test mode)
+  # =============================================================================
   test-linux:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-linux.yml
     secrets: inherit
     permissions:
@@ -18,6 +63,8 @@ jobs:
       contents: read
 
   test-macos:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-macos.yml
     secrets: inherit
     permissions:
@@ -25,6 +72,8 @@ jobs:
       contents: read
 
   test-rl-gpu:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/test-rl-gpu.yml
     secrets: inherit
     permissions:
@@ -32,6 +81,8 @@ jobs:
       contents: read
 
   lint:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/lint.yml
     secrets: inherit
     permissions:
@@ -39,6 +90,8 @@ jobs:
       contents: read
 
   docs:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/docs.yml
     secrets: inherit
     permissions:
@@ -46,6 +99,8 @@ jobs:
       contents: write
 
   benchmarks:
+    needs: config
+    if: needs.config.outputs.run_tests == 'true'
     uses: ./.github/workflows/benchmarks.yml
     with:
       skip-upload: true
@@ -65,13 +120,14 @@ jobs:
     permissions:
       contents: write
     needs:
+      - config
       - test-linux
       - test-macos
       - test-rl-gpu
       - lint
       - docs
       - benchmarks
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: always()
     steps:
       - name: Trigger status collector
         uses: peter-evans/repository-dispatch@v4
@@ -80,5 +136,6 @@ jobs:
           client-payload: |
             {
               "run_id": "${{ github.run_id }}",
-              "triggered_at": "${{ github.event.repository.updated_at }}"
+              "triggered_at": "${{ github.event.repository.updated_at }}",
+              "deploy": ${{ needs.config.outputs.deploy_dashboard }}
             }

--- a/.github/workflows/nightly_status_collector.yml
+++ b/.github/workflows/nightly_status_collector.yml
@@ -18,6 +18,10 @@ on:
         description: 'Force recollection even if data already exists'
         type: boolean
         default: false
+      skip-deploy:
+        description: 'Collect status but skip deploying to gh-pages (dry-run)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,7 +30,29 @@ permissions:
 jobs:
   collect-status:
     runs-on: ubuntu-latest
+    outputs:
+      should-deploy: ${{ steps.resolve-deploy.outputs.deploy }}
     steps:
+      - name: Resolve deploy flag
+        id: resolve-deploy
+        run: |
+          # repository_dispatch: read from client payload
+          # workflow_dispatch: read from inputs
+          # schedule: always deploy
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            DEPLOY="${{ github.event.client_payload.deploy }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.skip-deploy }}" = "true" ]; then
+              DEPLOY="false"
+            else
+              DEPLOY="true"
+            fi
+          else
+            DEPLOY="true"
+          fi
+          echo "deploy=${DEPLOY:-true}" >> "$GITHUB_OUTPUT"
+          echo "Deploy dashboard: ${DEPLOY:-true}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -40,7 +66,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Collect nightly status
         env:
@@ -80,6 +106,7 @@ jobs:
           cp .github/nightly-dashboard/index.html nightly-status/
 
       - name: Deploy nightly-status to GitHub Pages
+        if: steps.resolve-deploy.outputs.deploy == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -87,6 +114,20 @@ jobs:
           destination_dir: nightly-status
           keep_files: true
           commit_message: 'Update nightly status dashboard'
+
+      - name: Dry-run summary
+        if: steps.resolve-deploy.outputs.deploy != 'true'
+        run: |
+          echo "### Dry-run: skipped dashboard deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "Collected status data is available in the workflow artifacts below." >> "$GITHUB_STEP_SUMMARY"
+          cat nightly-status/history.json | head -50 >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload collected data (artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-status-data
+          path: nightly-status/
+          retention-days: 7
 
   notify-if-degraded:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `mode` dropdown to the nightly orchestrator's manual dispatch with three options:

| Mode | Tests | Collect Status | Deploy Dashboard |
|------|-------|---------------|-----------------|
| **full** (default, schedule) | Yes | Yes | Yes |
| **dry-run** | Yes | Yes | No (artifact only) |
| **smoke-test** | No | Yes | Yes |

- **dry-run**: useful for running the full nightly suite without touching the live dashboard (e.g., testing on a branch). Collected data is uploaded as a workflow artifact.
- **smoke-test**: skips all test workflows, only exercises the dashboard collection + deploy pipeline. Use this to validate the CI plumbing end-to-end without waiting for real tests.

Also includes:
- Fix for the uv cache symlink loop (`enable-cache: false`) that was causing the collector to crash (#1560)
- `skip-deploy` input on the status collector for direct manual invocation
- Always uploads collected status data as a workflow artifact for inspection

## Test plan

- [ ] Trigger orchestrator with mode=smoke-test, verify tests are skipped and dashboard deploys
- [ ] Trigger orchestrator with mode=dry-run, verify tests run but dashboard is NOT deployed
- [ ] Verify scheduled runs (mode defaults to full) still work as before


Made with [Cursor](https://cursor.com)