### PR TITLE
[Benchmark] Add Redis benchmarks, optimize reads with covering-range strategy

### DIFF
--- a/benchmarks/storage/bench_redis.py
+++ b/benchmarks/storage/bench_redis.py
@@ -1,0 +1,276 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark RedisTensorDict vs local TensorDict for common operations.
+
+Measures key-based get/set, key/value iteration, and indexed read/write
+(int, slice, fancy) for both backends.
+
+Run with:
+    python benchmarks/storage/bench_redis.py
+"""
+
+import importlib
+import time
+
+import torch
+
+from tensordict import TensorDict
+
+_has_redis_pkg = importlib.util.find_spec("redis", None) is not None
+
+
+def _redis_available():
+    if not _has_redis_pkg:
+        return False
+    import redis
+
+    try:
+        r = redis.Redis(host="localhost", port=6379, db=0, socket_connect_timeout=2)
+        r.ping()
+        r.close()
+        return True
+    except (redis.ConnectionError, redis.exceptions.ConnectionError, OSError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+N = 10_000  # batch size
+N_KEYS = 5  # number of leaf keys
+FEAT = 64  # feature dim per key
+WARMUP = 2
+ROUNDS = 10
+
+IDX_INT = 42
+IDX_SLICE = slice(100, 356)  # 256 rows, step=1
+IDX_STEP = slice(0, N, 3)  # every 3rd row
+IDX_FANCY = torch.randint(0, N, (256,))
+IDX_BOOL = torch.zeros(N, dtype=torch.bool)
+IDX_BOOL[torch.randint(0, N, (256,))] = True
+
+
+def _make_local_td():
+    d = {f"key_{i}": torch.randn(N, FEAT) for i in range(N_KEYS)}
+    return TensorDict(d, batch_size=[N])
+
+
+def _make_redis_td():
+    from tensordict.redis import RedisTensorDict
+
+    td = RedisTensorDict(batch_size=[N], db=14)
+    for i in range(N_KEYS):
+        td[f"key_{i}"] = torch.randn(N, FEAT)
+    return td
+
+
+def _timeit(fn, warmup=WARMUP, rounds=ROUNDS):
+    for _ in range(warmup):
+        fn()
+    times = []
+    for _ in range(rounds):
+        t0 = time.perf_counter()
+        fn()
+        t1 = time.perf_counter()
+        times.append(t1 - t0)
+    mean = sum(times) / len(times)
+    std = (sum((t - mean) ** 2 for t in times) / len(times)) ** 0.5
+    return mean, std
+
+
+# ---------------------------------------------------------------------------
+# Benchmark definitions -- each returns (mean_s, std_s)
+# ---------------------------------------------------------------------------
+
+
+def bench_get_single_key(td):
+    return _timeit(lambda: td["key_0"])
+
+
+def bench_set_single_key(td):
+    v = torch.randn(N, FEAT)
+    return _timeit(lambda: td.__setitem__("key_0", v))
+
+
+def bench_keys_iter(td):
+    return _timeit(lambda: list(td.keys()))
+
+
+def bench_values_iter(td):
+    return _timeit(lambda: list(td.values()))
+
+
+def bench_items_iter(td):
+    return _timeit(lambda: list(td.items()))
+
+
+def bench_read_int(td):
+    return _timeit(lambda: td[IDX_INT])
+
+
+def bench_read_slice(td):
+    return _timeit(lambda: td[IDX_SLICE])
+
+
+def bench_read_step(td):
+    return _timeit(lambda: td[IDX_STEP])
+
+
+def bench_read_fancy(td):
+    return _timeit(lambda: td[IDX_FANCY])
+
+
+def bench_read_bool(td):
+    return _timeit(lambda: td[IDX_BOOL])
+
+
+def bench_write_int(td):
+    sub = TensorDict({f"key_{i}": torch.randn(FEAT) for i in range(N_KEYS)}, [])
+
+    def _write():
+        td[IDX_INT] = sub
+
+    return _timeit(_write)
+
+
+def bench_write_slice(td):
+    n = len(range(*IDX_SLICE.indices(N)))
+    sub = TensorDict(
+        {f"key_{i}": torch.randn(n, FEAT) for i in range(N_KEYS)}, [n]
+    )
+
+    def _write():
+        td[IDX_SLICE] = sub
+
+    return _timeit(_write)
+
+
+def bench_write_step(td):
+    n = len(range(*IDX_STEP.indices(N)))
+    sub = TensorDict(
+        {f"key_{i}": torch.randn(n, FEAT) for i in range(N_KEYS)}, [n]
+    )
+
+    def _write():
+        td[IDX_STEP] = sub
+
+    return _timeit(_write)
+
+
+def bench_write_fancy(td):
+    n = IDX_FANCY.numel()
+    sub = TensorDict(
+        {f"key_{i}": torch.randn(n, FEAT) for i in range(N_KEYS)}, [n]
+    )
+
+    def _write():
+        td[IDX_FANCY] = sub
+
+    return _timeit(_write)
+
+
+def bench_write_bool(td):
+    n = int(IDX_BOOL.sum().item())
+    sub = TensorDict(
+        {f"key_{i}": torch.randn(n, FEAT) for i in range(N_KEYS)}, [n]
+    )
+
+    def _write():
+        td[IDX_BOOL] = sub
+
+    return _timeit(_write)
+
+
+def bench_to_tensordict(td):
+    return _timeit(lambda: td.to_tensordict())
+
+
+def bench_index_to_td_int(td):
+    return _timeit(lambda: td[IDX_INT].to_tensordict())
+
+
+def bench_index_to_td_slice(td):
+    return _timeit(lambda: td[IDX_SLICE].to_tensordict())
+
+
+def bench_index_to_td_fancy(td):
+    return _timeit(lambda: td[IDX_FANCY].to_tensordict())
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+BENCHMARKS = [
+    ("get single key", bench_get_single_key),
+    ("set single key", bench_set_single_key),
+    ("keys() iteration", bench_keys_iter),
+    ("values() iteration", bench_values_iter),
+    ("items() iteration", bench_items_iter),
+    ("read td[int]", bench_read_int),
+    ("read td[slice]", bench_read_slice),
+    ("read td[::3]", bench_read_step),
+    ("read td[fancy]", bench_read_fancy),
+    ("read td[bool]", bench_read_bool),
+    ("write td[int]=v", bench_write_int),
+    ("write td[slice]=v", bench_write_slice),
+    ("write td[::3]=v", bench_write_step),
+    ("write td[fancy]=v", bench_write_fancy),
+    ("write td[bool]=v", bench_write_bool),
+    ("to_tensordict()", bench_to_tensordict),
+    ("td[int].to_tensordict()", bench_index_to_td_int),
+    ("td[slice].to_tensordict()", bench_index_to_td_slice),
+    ("td[fancy].to_tensordict()", bench_index_to_td_fancy),
+]
+
+
+def _fmt(mean, std):
+    if mean < 1e-3:
+        return f"{mean * 1e6:8.1f} us +/- {std * 1e6:6.1f} us"
+    if mean < 1:
+        return f"{mean * 1e3:8.2f} ms +/- {std * 1e3:6.2f} ms"
+    return f"{mean:8.3f}  s +/- {std:6.3f}  s"
+
+
+def main():
+    if not _redis_available():
+        print("ERROR: Redis server not reachable on localhost:6379. Start it first.")
+        return
+
+    print("=" * 90)
+    print(
+        f"  RedisTensorDict vs TensorDict benchmark"
+        f"  (N={N}, keys={N_KEYS}, feat={FEAT})"
+    )
+    print(f"  warmup={WARMUP}, rounds={ROUNDS}")
+    print("=" * 90)
+
+    local_td = _make_local_td()
+    redis_td = _make_redis_td()
+
+    header = f"{'Operation':<25s} | {'TensorDict':>28s} | {'RedisTensorDict':>28s} | {'Ratio':>8s}"
+    print(header)
+    print("-" * len(header))
+
+    for name, bench_fn in BENCHMARKS:
+        m_local, s_local = bench_fn(local_td)
+        m_redis, s_redis = bench_fn(redis_td)
+        ratio = m_redis / m_local if m_local > 0 else float("inf")
+        print(
+            f"{name:<25s} | {_fmt(m_local, s_local):>28s} | "
+            f"{_fmt(m_redis, s_redis):>28s} | {ratio:>7.1f}x"
+        )
+
+    print("-" * len(header))
+    print()
+
+    redis_td.clear_redis()
+    redis_td.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tensordict/redis.py
+++ b/tensordict/redis.py
@@ -32,6 +32,7 @@ from tensordict.base import (
 )
 from tensordict.utils import (
     _as_context_manager,
+    _getitem_batch_size,
     _KEY_ERROR,
     _LOCK_ERROR,
     erase_cache,
@@ -67,9 +68,9 @@ def _tensor_to_bytes(tensor: torch.Tensor) -> bytes:
     """Serialize a tensor to raw bytes.
 
     The tensor is made contiguous and moved to CPU before serialization.
+    Uses NumPy's buffer protocol for fast zero-overhead memcpy.
     """
-    tensor = tensor.detach().contiguous().cpu()
-    return bytes(tensor.untyped_storage())
+    return tensor.detach().contiguous().cpu().numpy().tobytes()
 
 
 def _bytes_to_tensor(
@@ -123,12 +124,14 @@ def _compute_byte_ranges(
         pos = idx % shape[0]
         return [(pos * row_size, row_size)]
 
-    if isinstance(idx, slice):
-        positions = range(*idx.indices(shape[0]))
+    if isinstance(idx, (slice, range)):
+        positions = range(*idx.indices(shape[0])) if isinstance(idx, slice) else idx
+        if len(positions) == 0:
+            return []
+        # Contiguous with step 1: return a single range
+        if positions.step == 1:
+            return [(positions[0] * row_size, len(positions) * row_size)]
         return [(p * row_size, row_size) for p in positions]
-
-    if isinstance(idx, range):
-        return [(p * row_size, row_size) for p in idx]
 
     if isinstance(idx, list):
         return [(int(p) * row_size, row_size) for p in idx]
@@ -185,6 +188,73 @@ def _getitem_result_shape(
 
     # Fallback
     return list(torch.zeros(shape)[idx].shape)
+
+
+def _compute_covering_range(
+    shape: list[int],
+    dtype: torch.dtype,
+    idx,
+) -> tuple[int, int, object] | None:
+    """Compute a single covering byte range for indexed reads.
+
+    Returns ``(byte_offset, byte_length, local_idx)`` or ``None``.
+    - **byte_offset / byte_length**: a single contiguous GETRANGE span.
+    - **local_idx**: ``None`` when the fetched bytes are already the result
+      (int index, step-1 slice), or an index to apply on the covering tensor's
+      first dimension to extract the requested rows.
+
+    This always emits at most **one** GETRANGE per key regardless of index type.
+    """
+    # Unwrap 1-element tuples
+    if isinstance(idx, tuple):
+        if len(idx) == 1:
+            idx = idx[0]
+        else:
+            return None
+
+    if idx is Ellipsis:
+        idx = slice(None)
+
+    elem_size = torch.tensor([], dtype=dtype).element_size()
+    row_size = elem_size
+    for s in shape[1:]:
+        row_size *= s
+
+    if isinstance(idx, int):
+        pos = idx % shape[0]
+        return (pos * row_size, row_size, None)
+
+    if isinstance(idx, (slice, range)):
+        positions = range(*idx.indices(shape[0])) if isinstance(idx, slice) else idx
+        if len(positions) == 0:
+            return (0, 0, None)
+        start = positions[0]
+        stop = positions[-1] + 1  # make exclusive
+        covering_rows = stop - start
+        if positions.step == 1:
+            return (start * row_size, covering_rows * row_size, None)
+        # Step > 1: fetch covering range, stride locally
+        local_idx = slice(None, None, positions.step)
+        return (start * row_size, covering_rows * row_size, local_idx)
+
+    if isinstance(idx, list):
+        idx = torch.tensor(idx)
+
+    if isinstance(idx, torch.Tensor):
+        if idx.dtype == torch.bool:
+            positions = idx.nonzero(as_tuple=False).squeeze(-1)
+        else:
+            positions = idx.reshape(-1)
+        if positions.numel() == 0:
+            return (0, 0, None)
+        min_pos = int(positions.min().item())
+        max_pos = int(positions.max().item())
+        covering_rows = max_pos - min_pos + 1
+        # Shift indices relative to covering range start
+        local_idx = positions - min_pos
+        return (min_pos * row_size, covering_rows * row_size, local_idx)
+
+    return None
 
 
 class _RedisTDKeysView(_TensorDictKeysView):
@@ -633,47 +703,61 @@ class RedisTensorDict(TensorDictBase):
     async def _abatch_get_at(
         self, key_paths: list[str], idx
     ) -> dict[str, torch.Tensor]:
-        """Batch-fetch slices of multiple tensors using ``GETRANGE``.
+        """Batch-fetch indexed slices of multiple tensors.
 
-        Falls back to full ``GET`` for key-paths whose index cannot be
-        decomposed into byte ranges.
+        Uses :func:`_compute_covering_range` so that every key emits **at most
+        one** ``GETRANGE`` command, regardless of whether the index is an int,
+        slice-with-step, tensor, or boolean mask.  A local post-index is
+        applied when the covering range is larger than the result.
+
+        Falls back to full ``GET`` + local indexing for unsupported index types.
         """
         if not key_paths:
             return {}
 
         meta_map = await self._aget_metadata_batch(key_paths)
 
-        # Build GETRANGE pipeline
         pipe = self._client.pipeline()
-        # Each entry: (key_path, shape, dtype, n_ranges)
-        range_plan: list[tuple[str, list[int], torch.dtype, int]] = []
+        # (key_path, covering_shape, dtype, local_idx, has_data)
+        plan: list[tuple[str, list[int], torch.dtype, object, bool]] = []
         fallback_kps: list[str] = []
 
         for kp in key_paths:
             shape, dtype = meta_map[kp]
-            ranges = _compute_byte_ranges(shape, dtype, idx)
-            if ranges is None:
+            cr = _compute_covering_range(shape, dtype, idx)
+            if cr is None:
                 fallback_kps.append(kp)
                 continue
-            for byte_offset, byte_length in ranges:
+            byte_offset, byte_length, local_idx = cr
+            elem_size = torch.tensor([], dtype=dtype).element_size()
+            rest = shape[1:]
+            row_bytes = elem_size * (int(torch.tensor(rest).prod().item()) if rest else 1)
+            covering_rows = byte_length // row_bytes if row_bytes > 0 else 0
+            covering_shape = [covering_rows] + rest
+            has_data = byte_length > 0
+            if has_data:
                 pipe.getrange(
                     self._data_key(kp),
                     byte_offset,
                     byte_offset + byte_length - 1,
                 )
-            range_plan.append((kp, shape, dtype, len(ranges)))
+            plan.append((kp, covering_shape, dtype, local_idx, has_data))
 
-        results_flat = await pipe.execute() if range_plan else []
+        raw_results = await pipe.execute() if any(p[4] for p in plan) else []
 
-        # Reassemble tensors from byte chunks
         result: dict[str, torch.Tensor] = {}
-        flat_idx = 0
-        for kp, shape, dtype, n_ranges in range_plan:
-            chunks = results_flat[flat_idx:flat_idx + n_ranges]
-            flat_idx += n_ranges
-            data = b"".join(chunks)
-            result_shape = _getitem_result_shape(shape, idx)
-            tensor = _bytes_to_tensor(data, result_shape, dtype)
+        ri = 0
+        for kp, covering_shape, dtype, local_idx, has_data in plan:
+            result_shape = _getitem_result_shape(meta_map[kp][0], idx)
+            if not has_data:
+                result[kp] = torch.empty(result_shape, dtype=dtype)
+                continue
+            data = raw_results[ri]
+            ri += 1
+            tensor = _bytes_to_tensor(data, covering_shape, dtype)
+            if local_idx is not None:
+                tensor = tensor[local_idx]
+            tensor = tensor.reshape(result_shape)
             if self._device is not None:
                 tensor = tensor.to(self._device)
             result[kp] = tensor
@@ -686,14 +770,155 @@ class RedisTensorDict(TensorDictBase):
 
         return result
 
+    async def _abatch_index(
+        self, key_paths: list[str], idx
+    ) -> dict[str, torch.Tensor | Any]:
+        """Batch-fetch indexed slices of all leaf tensors in one pipeline.
+
+        Combines metadata lookup, byte-range computation, and GETRANGE for
+        tensor keys into a single round-trip. Non-tensor keys are handled
+        separately via a full GET pipeline.
+
+        Returns a flat ``{key_path: indexed_value}`` dict.
+        """
+        if not key_paths:
+            return {}
+
+        # -- Stage 1: fetch metadata for all keys --------------------------
+        # We need to distinguish tensors from non-tensors, so we always
+        # fetch raw metadata for uncached keys.
+        cached_meta: dict[str, tuple[list[int], torch.dtype]] = {}
+        uncached_kps: list[str] = []
+        for kp in key_paths:
+            if self._meta_cache is not None and kp in self._meta_cache:
+                cached_meta[kp] = self._meta_cache[kp]
+            else:
+                uncached_kps.append(kp)
+
+        # Pipeline HGETALL for uncached + GET for any non-tensor keys we
+        # discover.  We don't yet know which are non-tensors, so we start
+        # with metadata only.
+        raw_metas: dict[str, dict] = {}
+        if uncached_kps:
+            pipe = self._client.pipeline()
+            for kp in uncached_kps:
+                pipe.hgetall(self._meta_key(kp))
+            meta_results = await pipe.execute()
+            for kp, raw_meta in zip(uncached_kps, meta_results):
+                raw_metas[kp] = _decode_meta(raw_meta)
+
+        # Classify keys
+        tensor_kps: list[str] = []
+        non_tensor_kps: list[str] = []
+        all_meta: dict[str, tuple[list[int], torch.dtype]] = dict(cached_meta)
+        for kp, meta in raw_metas.items():
+            if meta.get("is_non_tensor") == "1":
+                non_tensor_kps.append(kp)
+            else:
+                shape = json.loads(meta["shape"])
+                dtype = _str_to_dtype(meta["dtype"])
+                all_meta[kp] = (shape, dtype)
+                if self._meta_cache is not None:
+                    self._meta_cache[kp] = (shape, dtype)
+                tensor_kps.append(kp)
+        # Cached keys are always tensors (non-tensors are never cached).
+        for kp in cached_meta:
+            tensor_kps.append(kp)
+
+        # -- Stage 2: build single-GETRANGE pipeline -------------------------
+        pipe = self._client.pipeline()
+
+        # (kp, covering_shape, dtype, local_idx, has_data)
+        plan: list[tuple[str, list[int], torch.dtype, object, bool]] = []
+        fallback_tensor_kps: list[str] = []
+
+        for kp in tensor_kps:
+            shape, dtype = all_meta[kp]
+            cr = _compute_covering_range(shape, dtype, idx)
+            if cr is None:
+                fallback_tensor_kps.append(kp)
+                continue
+            byte_offset, byte_length, local_idx = cr
+            elem_size = torch.tensor([], dtype=dtype).element_size()
+            rest = shape[1:]
+            row_bytes = elem_size * (int(torch.tensor(rest).prod().item()) if rest else 1)
+            covering_rows = byte_length // row_bytes if row_bytes > 0 else 0
+            covering_shape = [covering_rows] + rest
+            has_data = byte_length > 0
+            if has_data:
+                pipe.getrange(
+                    self._data_key(kp),
+                    byte_offset,
+                    byte_offset + byte_length - 1,
+                )
+            plan.append((kp, covering_shape, dtype, local_idx, has_data))
+
+        # Full GET for fallback tensors
+        for kp in fallback_tensor_kps:
+            pipe.get(self._data_key(kp))
+            pipe.hgetall(self._meta_key(kp))
+
+        # Full GET for non-tensor keys
+        for kp in non_tensor_kps:
+            pipe.get(self._data_key(kp))
+
+        all_results = await pipe.execute()
+
+        # -- Stage 3: reassemble results -----------------------------------
+        result: dict[str, torch.Tensor | Any] = {}
+
+        flat_idx = 0
+        for kp, covering_shape, dtype, local_idx, has_data in plan:
+            result_shape = _getitem_result_shape(all_meta[kp][0], idx)
+            if not has_data:
+                result[kp] = torch.empty(result_shape, dtype=dtype)
+                continue
+            data = all_results[flat_idx]
+            flat_idx += 1
+            tensor = _bytes_to_tensor(data, covering_shape, dtype)
+            if local_idx is not None:
+                tensor = tensor[local_idx]
+            tensor = tensor.reshape(result_shape)
+            if self._device is not None:
+                tensor = tensor.to(self._device)
+            result[kp] = tensor
+
+        # Fallback tensor results (full GET + index locally)
+        for kp in fallback_tensor_kps:
+            data = all_results[flat_idx]
+            raw_meta = all_results[flat_idx + 1]
+            flat_idx += 2
+            meta = _decode_meta(raw_meta)
+            shape = json.loads(meta["shape"])
+            dtype = _str_to_dtype(meta["dtype"])
+            tensor = _bytes_to_tensor(data, shape, dtype)
+            if self._device is not None:
+                tensor = tensor.to(self._device)
+            result[kp] = tensor[idx]
+
+        # Non-tensor results (not indexable, returned as-is)
+        for kp in non_tensor_kps:
+            data = all_results[flat_idx]
+            flat_idx += 1
+            result[kp] = self._deserialize_non_tensor(data, raw_metas[kp])
+
+        return result
+
     async def _abatch_set_at(
         self, items: dict[str, tuple[torch.Tensor, object]]
     ):
-        """Batch-write slices of multiple tensors using ``SETRANGE``.
+        """Batch-write slices of multiple tensors.
 
         *items* maps ``key_path`` to ``(value_tensor, idx)``.
-        Falls back to :meth:`_abatch_read_modify_write` for indices that
-        cannot be decomposed into byte ranges.
+
+        Three strategies, chosen per-key:
+
+        1. **Direct SETRANGE** (int, step-1 slice): value bytes are written in
+           a single ``SETRANGE`` without reading first.
+        2. **Partial read-modify-write** (step>1, tensor, bool mask): fetch the
+           *covering range* via ``GETRANGE``, patch in memory, write back with
+           ``SETRANGE``.  2 commands per key across 2 pipelines.
+        3. **Full read-modify-write** fallback for unsupported indices.
         """
         if not items:
             return
@@ -701,33 +926,72 @@ class RedisTensorDict(TensorDictBase):
         key_paths = list(items.keys())
         meta_map = await self._aget_metadata_batch(key_paths)
 
-        # Prepare SETRANGE commands
-        setrange_cmds: list[tuple[str, int, bytes]] = []
+        # Classify each key-path into one of three strategies.
+        # Store (kp, byte_offset, byte_length, local_idx) for covering-range keys.
+        direct_kps: list[tuple[str, int]] = []   # (kp, byte_offset)
+        partial_kps: list[tuple[str, int, int, object, list[int], torch.dtype]] = []
         fallback_kps: list[str] = []
 
         for kp in key_paths:
             shape, dtype = meta_map[kp]
-            value, idx = items[kp]
-            ranges = _compute_byte_ranges(shape, dtype, idx)
-            if ranges is None:
+            _, idx = items[kp]
+            cr = _compute_covering_range(shape, dtype, idx)
+            if cr is None:
                 fallback_kps.append(kp)
                 continue
-            value_bytes = _tensor_to_bytes(value.contiguous())
-            offset = 0
-            for byte_offset, byte_length in ranges:
-                setrange_cmds.append((
+            byte_offset, byte_length, local_idx = cr
+            if local_idx is None:
+                direct_kps.append((kp, byte_offset))
+            else:
+                partial_kps.append((kp, byte_offset, byte_length, local_idx, shape, dtype))
+
+        # --- Strategy 1: direct SETRANGE (single pipeline) -----------------
+        if direct_kps:
+            pipe = self._client.pipeline()
+            for kp, byte_offset in direct_kps:
+                value, _ = items[kp]
+                pipe.setrange(
                     self._data_key(kp),
                     byte_offset,
-                    value_bytes[offset:offset + byte_length],
-                ))
-                offset += byte_length
-
-        if setrange_cmds:
-            pipe = self._client.pipeline()
-            for redis_key, byte_offset, chunk in setrange_cmds:
-                pipe.setrange(redis_key, byte_offset, chunk)
+                    _tensor_to_bytes(value.contiguous()),
+                )
             await pipe.execute()
 
+        # --- Strategy 2: partial covering-range RMW (two pipelines) --------
+        if partial_kps:
+            # Pipeline 1: GETRANGE covering ranges
+            pipe = self._client.pipeline()
+            for kp, byte_offset, byte_length, _, _, _ in partial_kps:
+                pipe.getrange(
+                    self._data_key(kp),
+                    byte_offset,
+                    byte_offset + byte_length - 1,
+                )
+            raw_covers = await pipe.execute()
+
+            # Patch in memory and pipeline 2: SETRANGE
+            pipe = self._client.pipeline()
+            for (kp, byte_offset, byte_length, local_idx, shape, dtype), data in zip(
+                partial_kps, raw_covers
+            ):
+                rest = shape[1:]
+                elem_size = torch.tensor([], dtype=dtype).element_size()
+                row_bytes = elem_size * (
+                    int(torch.tensor(rest).prod().item()) if rest else 1
+                )
+                covering_rows = byte_length // row_bytes if row_bytes > 0 else 0
+                covering_shape = [covering_rows] + rest
+                covering_tensor = _bytes_to_tensor(data, covering_shape, dtype)
+                value, _ = items[kp]
+                covering_tensor[local_idx] = value
+                pipe.setrange(
+                    self._data_key(kp),
+                    byte_offset,
+                    _tensor_to_bytes(covering_tensor.contiguous()),
+                )
+            await pipe.execute()
+
+        # --- Strategy 3: full RMW fallback ---------------------------------
         if fallback_kps:
             await self._abatch_read_modify_write(
                 fallback_kps, {kp: items[kp] for kp in fallback_kps}
@@ -814,6 +1078,58 @@ class RedisTensorDict(TensorDictBase):
                 item.rename_(*td_names)
 
     # ---- Key access / mutation ----
+
+    def _index_tensordict(self, index, new_batch_size=None, names=None):
+        """Eagerly fetch all leaf tensors for the given index in a single pipeline.
+
+        Overrides the default ``TensorDict._index_tensordict`` (which iterates
+        ``self.items()`` -- one Redis round-trip per key) with a batched
+        approach that issues a single pipeline of ``GETRANGE`` commands across
+        all keys.
+        """
+        batch_size = self.batch_size
+
+        if new_batch_size is None:
+            new_batch_size = _getitem_batch_size(batch_size, index)
+        if names is None:
+            names = self._get_names_idx(index)
+
+        # Collect all leaf key paths under our prefix
+        all_keys = self._get_all_keys()
+        prefix = (self._prefix + _KEY_SEP) if self._prefix else ""
+        leaf_kps = sorted(
+            k for k in all_keys
+            if k.startswith(prefix) or not prefix
+        )
+
+        # Single batched pipeline for all keys
+        result_map = self._run_sync(self._abatch_index(leaf_kps, index))
+
+        # Build nested source dict from flat key paths
+        prefix_len = len(prefix)
+        source: dict = {}
+        for kp, value in result_map.items():
+            rel_key = kp[prefix_len:] if prefix else kp
+            parts = rel_key.split(_KEY_SEP)
+            d = source
+            for part in parts[:-1]:
+                d = d.setdefault(part, {})
+            d[parts[-1]] = value
+
+        # Recursively convert nested dicts into TensorDicts
+        def _build(d, bs):
+            for k, v in d.items():
+                if isinstance(v, dict):
+                    # Nested TD: batch_size = new_batch_size + extra dims
+                    d[k] = _build(v, bs)
+            return TensorDict._new_unsafe(
+                source=d,
+                batch_size=bs,
+                device=self._device,
+                names=names,
+            )
+
+        return _build(source, new_batch_size)
 
     def __setitem__(self, index, value):
         index_unravel = _unravel_key_to_tuple(index)
@@ -1674,7 +1990,6 @@ class RedisTensorDict(TensorDictBase):
     _check_is_shared = TensorDict._check_is_shared
     _convert_to_tensordict = TensorDict._convert_to_tensordict
     _get_names_idx = TensorDict._get_names_idx
-    _index_tensordict = TensorDict._index_tensordict
     _multithread_apply_flat = TensorDict._multithread_apply_flat
     _multithread_rebuild = TensorDict._multithread_rebuild
     _to_module = TensorDict._to_module

--- a/test/test_redis.py
+++ b/test/test_redis.py
@@ -624,6 +624,47 @@ class TestRedisTensorDict:
         sub = redis_td[...]
         assert torch.allclose(sub["obs"], obs)
 
+    def test_indexed_read_step_slice(self, redis_td):
+        """td[::2] should return every other row via covering range."""
+        obs = torch.randn(10, 3)
+        redis_td["obs"] = obs
+        sub = redis_td[::2]
+        assert sub["obs"].shape == torch.Size([5, 3])
+        assert torch.allclose(sub["obs"], obs[::2])
+
+    def test_indexed_read_step3(self, redis_td):
+        """td[1::3] should fetch covering range and stride locally."""
+        obs = torch.randn(10, 3)
+        redis_td["obs"] = obs
+        sub = redis_td[1::3]
+        assert sub["obs"].shape == torch.Size([3, 3])
+        assert torch.allclose(sub["obs"], obs[1::3])
+
+    def test_indexed_write_step_slice(self, redis_td):
+        """td[::2] = subtd should use partial covering-range RMW."""
+        redis_td["obs"] = torch.zeros(10, 3)
+        new_vals = torch.ones(5, 3) * 9.0
+        redis_td[::2] = TensorDict({"obs": new_vals}, [5])
+
+        full = redis_td["obs"]
+        assert torch.allclose(full[::2], new_vals)
+        # Odd rows should remain zero
+        assert torch.allclose(full[1::2], torch.zeros(5, 3))
+
+    def test_indexed_write_step3(self, redis_td):
+        """td[1::3] = subtd should use partial covering-range RMW."""
+        redis_td["obs"] = torch.arange(30, dtype=torch.float).reshape(10, 3)
+        original = redis_td["obs"].clone()
+        new_vals = torch.ones(3, 3) * -1.0
+        redis_td[1::3] = TensorDict({"obs": new_vals}, [3])
+
+        full = redis_td["obs"]
+        assert torch.allclose(full[1::3], new_vals)
+        # Unmodified rows should stay the same
+        for i in range(10):
+            if i not in (1, 4, 7):
+                assert torch.allclose(full[i], original[i])
+
     # ---- set_at_ via byte-range ----
 
     def test_set_at_byte_range(self, redis_td):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1566
* __->__ #1565
* #1564
* #1563
* #1562

Add benchmarks/storage/bench_redis.py comparing RedisTensorDict against
local TensorDict for get/set, key iteration, indexed read/write (int,
slice, step-slice, fancy, bool mask), and td[idx].to_tensordict().

Performance improvements:
- Fix _tensor_to_bytes: replace bytes(untyped_storage()) with
  tensor.numpy().tobytes() (~8000x faster serialization).
- Override _index_tensordict with _abatch_index: batch all leaf key
  fetches into a single pipeline instead of one round-trip per key.
- Covering-range strategy (_compute_covering_range): every index type
  (int, slice, step-slice, tensor, bool mask) emits at most ONE
  GETRANGE per key. For non-contiguous indices, the covering byte range
  is fetched and a local post-index extracts the requested rows.
- Coalesce contiguous byte ranges for step-1 slices.
- Partial covering-range RMW for writes: step/fancy/bool writes fetch
  only the covering range, patch locally, write back (2 cmds/key
  instead of N SETRANGEs).