### PR TITLE
[Feature] Add Redis-backed TensorDict (RedisTensorDict)

### DIFF
--- a/.github/unittest/linux/scripts/environment.yml
+++ b/.github/unittest/linux/scripts/environment.yml
@@ -22,3 +22,4 @@ dependencies:
     - ninja
     - numpy<2.0.0
     - mosaicml-streaming
+    - redis

--- a/.github/unittest/linux/scripts/run_test.sh
+++ b/.github/unittest/linux/scripts/run_test.sh
@@ -26,6 +26,23 @@ export TORCHDYNAMO_INLINE_INBUILT_NN_MODULES=1
 export TD_GET_DEFAULTS_TO_NONE=1
 export LIST_TO_STACK=1
 
+# Start Redis server for test_redis.py (non-fatal if unavailable)
+if command -v redis-server &> /dev/null; then
+    redis-server --daemonize yes --save "" --appendonly no || true
+else
+    case "$(uname -s)" in
+        Linux*)
+            apt update -y && apt install -y redis-server && redis-server --daemonize yes --save "" --appendonly no || echo "Redis server not available, redis tests will be skipped"
+            ;;
+        Darwin*)
+            brew install redis 2>/dev/null && redis-server --daemonize yes --save "" --appendonly no || echo "Redis server not available, redis tests will be skipped"
+            ;;
+        *)
+            echo "Redis server not available on this platform, redis tests will be skipped"
+            ;;
+    esac
+fi
+
 coverage run -m pytest test/smoke_test.py -v --durations 20
 coverage run -m pytest --runslow --instafail -v --durations 20 --timeout 120
 coverage run -m pytest ./benchmarks --instafail -v --durations 20

--- a/.github/unittest/linux/scripts/setup_env.sh
+++ b/.github/unittest/linux/scripts/setup_env.sh
@@ -94,7 +94,7 @@ if [ "${PYTHON_VERSION}" == "3.14t" ]; then
     # Install test dependencies (mirrors environment.yml)
     pip install pybind11 numpy expecttest pyyaml hypothesis future cloudpickle \
         pytest pytest-benchmark pytest-cov pytest-mock pytest-instafail \
-        pytest-rerunfailures pytest-timeout coverage h5py orjson ninja protobuf
+        pytest-rerunfailures pytest-timeout coverage h5py orjson ninja protobuf redis
     # Note: mosaicml-streaming may not be available for 3.14t yet, skip if fails
     pip install mosaicml-streaming || echo "mosaicml-streaming not available for Python 3.14t, skipping"
 else

--- a/tensordict/__init__.py
+++ b/tensordict/__init__.py
@@ -47,6 +47,7 @@ from tensordict.functional import (
 )
 from tensordict.memmap import MemoryMappedTensor
 from tensordict.persistent import PersistentTensorDict
+from tensordict.redis import RedisTensorDict
 from tensordict.tensorclass import (
     from_dataclass,
     MetaData,
@@ -105,6 +106,7 @@ __all__ = [
     "TensorClass",
     "MemoryMappedTensor",
     "PersistentTensorDict",
+    "RedisTensorDict",
     "NestedKey",
     # Factory functions
     "from_dict",

--- a/tensordict/redis.py
+++ b/tensordict/redis.py
@@ -1,0 +1,1373 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Redis-backed TensorDict implementation for out-of-core tensor storage."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import pickle
+import threading
+import uuid
+import weakref
+from typing import Any, Callable, Tuple, Type, TYPE_CHECKING
+
+import torch
+
+from tensordict._td import (
+    _TensorDictKeysView,
+    _unravel_key_to_tuple,
+    CompatibleType,
+    NO_DEFAULT,
+    TensorDict,
+)
+from tensordict.base import (
+    _register_tensor_class,
+    is_tensor_collection,
+    T,
+    TensorDictBase,
+)
+from tensordict.utils import (
+    _as_context_manager,
+    _KEY_ERROR,
+    _LOCK_ERROR,
+    erase_cache,
+    is_non_tensor,
+    lock_blocked,
+    NestedKey,
+    unravel_key,
+)
+
+_has_redis = importlib.util.find_spec("redis", None) is not None
+
+if TYPE_CHECKING:
+    from typing import Self
+else:
+    Self = Any
+
+# Separator used for nested key paths in Redis keys
+_KEY_SEP = "."
+
+
+def _dtype_to_str(dtype: torch.dtype) -> str:
+    """Convert a torch.dtype to its string representation."""
+    return str(dtype)
+
+
+def _str_to_dtype(s: str) -> torch.dtype:
+    """Convert a string representation back to a torch.dtype."""
+    # e.g. "torch.float32" -> torch.float32
+    return getattr(torch, s.split(".")[-1])
+
+
+def _tensor_to_bytes(tensor: torch.Tensor) -> bytes:
+    """Serialize a tensor to raw bytes.
+
+    The tensor is made contiguous and moved to CPU before serialization.
+    """
+    tensor = tensor.detach().contiguous().cpu()
+    return bytes(tensor.untyped_storage())
+
+
+def _bytes_to_tensor(
+    data: bytes,
+    shape: list[int],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Deserialize raw bytes to a tensor using torch.frombuffer.
+
+    Returns a writable tensor (backed by a bytearray copy of the data).
+    """
+    buf = bytearray(data)
+    return torch.frombuffer(buf, dtype=dtype).reshape(shape)
+
+
+class _RedisTDKeysView(_TensorDictKeysView):
+    """Keys view for RedisTensorDict backed by a Redis key registry."""
+
+    def __iter__(self):
+        td = self.tensordict
+        # Get all registered keys from Redis
+        all_keys = td._get_all_keys()
+        prefix = td._prefix
+        prefix_dot = prefix + _KEY_SEP if prefix else ""
+
+        seen = set()
+        for full_key in all_keys:
+            # Filter keys belonging to this prefix level
+            if prefix:
+                if not full_key.startswith(prefix_dot):
+                    continue
+                relative = full_key[len(prefix_dot) :]
+            else:
+                relative = full_key
+
+            parts = relative.split(_KEY_SEP)
+
+            if self.include_nested:
+                # Yield full nested tuple
+                key = tuple(parts) if len(parts) > 1 else parts[0]
+                if self.leaves_only and len(parts) > 1:
+                    # Only yield if this is a leaf (no further nesting)
+                    if key not in seen:
+                        seen.add(key)
+                        yield key
+                elif not self.leaves_only or len(parts) == 1:
+                    if key not in seen:
+                        seen.add(key)
+                        yield key
+            else:
+                # Only yield top-level keys
+                top_key = parts[0]
+                if top_key in seen:
+                    continue
+                seen.add(top_key)
+
+                # Check if this is a leaf or a nested td
+                is_leaf_key = len(parts) == 1
+                if self.leaves_only and not is_leaf_key:
+                    continue
+                yield top_key
+
+    def __contains__(self, key):
+        key = unravel_key(key)
+        td = self.tensordict
+        prefix = td._prefix
+        if isinstance(key, str):
+            full_key = (prefix + _KEY_SEP + key) if prefix else key
+        else:
+            # tuple key
+            full_key = (
+                (prefix + _KEY_SEP + _KEY_SEP.join(key))
+                if prefix
+                else _KEY_SEP.join(key)
+            )
+        all_keys = td._get_all_keys()
+        # Exact leaf match
+        if full_key in all_keys:
+            return True
+        # Prefix match (nested tensordict)
+        prefix_check = full_key + _KEY_SEP
+        return any(k.startswith(prefix_check) for k in all_keys)
+
+    def __len__(self):
+        return sum(1 for _ in self)
+
+
+class RedisTensorDict(TensorDictBase):
+    """A TensorDict backed by a Redis instance for out-of-core storage.
+
+    Tensors are stored as raw bytes in Redis using ``torch.frombuffer``-compatible
+    serialization. Metadata (shape, dtype) is stored in Redis Hashes for fast
+    introspection without downloading tensor data.
+
+    All Redis I/O is performed via an async ``redis.asyncio.Redis`` client
+    running on a dedicated background event loop, ensuring non-blocking
+    operation from the caller's perspective.
+
+    Keyword Args:
+        host (str): Redis server hostname. Defaults to ``"localhost"``.
+        port (int): Redis server port. Defaults to ``6379``.
+        db (int): Redis database number. Defaults to ``0``.
+        unix_socket_path (str, optional): Path to a Unix domain socket for
+            local high-performance connections. Mutually exclusive with
+            ``host``/``port``.
+        prefix (str, optional): A namespace prefix for all Redis keys.
+            Defaults to ``"tensordict"``.
+        batch_size (torch.Size or compatible): The TensorDict batch size.
+            Defaults to ``torch.Size(())``.
+        device (torch.device or compatible, optional): Target device for
+            retrieved tensors. Defaults to ``None`` (CPU).
+        client: An existing ``redis.asyncio.Redis`` client instance. If
+            provided, ``host``/``port``/``db``/``unix_socket_path`` are ignored.
+        td_id (str, optional): A unique identifier for this TensorDict in Redis.
+            Defaults to a new UUID. Pass an existing ID to reconnect to
+            previously stored data.
+        **redis_kwargs: Additional keyword arguments passed to
+            ``redis.asyncio.Redis``.
+
+    Examples:
+        >>> from tensordict.redis import RedisTensorDict
+        >>> td = RedisTensorDict(batch_size=[100])
+        >>> td["obs"] = torch.randn(100, 84)
+        >>> td["obs"]  # fetched from Redis
+        >>> local_td = td.to_local()  # materialize everything into RAM
+
+    .. note::
+        Requires ``redis`` package: ``pip install redis``.
+
+    .. note::
+        Tensors are stored as CPU contiguous bytes. The ``device`` attribute
+        controls the device tensors are cast to upon retrieval.
+    """
+
+    _td_dim_names = None
+
+    def __init__(
+        self,
+        *,
+        host: str = "localhost",
+        port: int = 6379,
+        db: int = 0,
+        unix_socket_path: str | None = None,
+        prefix: str = "tensordict",
+        batch_size=None,
+        device=None,
+        client=None,
+        td_id: str | None = None,
+        **redis_kwargs,
+    ):
+        if not _has_redis:
+            raise ModuleNotFoundError(
+                "Could not import redis. Install it with: pip install redis"
+            )
+        import redis.asyncio as aioredis
+
+        if batch_size is None:
+            batch_size = torch.Size(())
+
+        self._locked_tensordicts = []
+        self._lock_id = set()
+        self._is_shared = False
+        self._is_memmap = False
+
+        # Nested TensorDict cache
+        self._nested_tensordicts: dict[str, RedisTensorDict] = {}
+
+        # Unique identifier for this TensorDict instance in Redis
+        self._td_id = td_id or str(uuid.uuid4())
+
+        # Key prefix within this tensordict (for nested views)
+        self._prefix = ""
+
+        # Namespace prefix for Redis keys
+        self._namespace = prefix
+
+        # Connection parameters (for pickling/reconnection)
+        self._host = host
+        self._port = port
+        self._db = db
+        self._unix_socket_path = unix_socket_path
+        self._redis_kwargs = redis_kwargs
+
+        # Create a new event loop in a background thread
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+        self._owns_loop = True
+
+        if client is not None:
+            self._client = client
+        else:
+            connect_kwargs = dict(redis_kwargs)
+            if unix_socket_path is not None:
+                connect_kwargs["unix_socket_path"] = unix_socket_path
+            else:
+                connect_kwargs["host"] = host
+                connect_kwargs["port"] = port
+            connect_kwargs["db"] = db
+            self._client = aioredis.Redis(**connect_kwargs)
+
+        self._batch_size = torch.Size(batch_size)
+        self._device = torch.device(device) if device is not None else None
+
+        # Persist batch_size and device to Redis
+        self._run_sync(self._apersist_metadata())
+
+    @classmethod
+    def _new_nested(cls, *, parent: RedisTensorDict, key_prefix: str, batch_size=None):
+        """Create a nested view sharing the parent's Redis client and event loop.
+
+        This is an internal factory used for nested TensorDict access. The
+        returned instance shares the same connection and TD identity but
+        operates under a different key prefix.
+        """
+        obj = cls.__new__(cls)
+        obj._locked_tensordicts = []
+        obj._lock_id = set()
+        obj._is_shared = False
+        obj._is_memmap = False
+        obj._nested_tensordicts = {}
+        obj._td_dim_names = None
+
+        obj._td_id = parent._td_id
+        obj._prefix = key_prefix
+        obj._namespace = parent._namespace
+
+        obj._host = parent._host
+        obj._port = parent._port
+        obj._db = parent._db
+        obj._unix_socket_path = parent._unix_socket_path
+        obj._redis_kwargs = parent._redis_kwargs
+
+        obj._client = parent._client
+        obj._loop = parent._loop
+        obj._thread = parent._thread
+        obj._owns_loop = False
+
+        obj._batch_size = (
+            torch.Size(batch_size) if batch_size is not None else parent._batch_size
+        )
+        obj._device = parent._device
+        return obj
+
+    def _run_sync(self, coro):
+        """Run an async coroutine synchronously via the background event loop."""
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    # ---- Redis key construction ----
+
+    def _redis_key(self, suffix: str) -> str:
+        """Build a Redis key with hash tag for cluster compatibility.
+
+        Format: {namespace}:{td_id}:{suffix}
+        The {td_id} is wrapped in Redis hash tags so all keys for this
+        TensorDict land on the same shard.
+        """
+        return f"{self._namespace}:{{{self._td_id}}}:{suffix}"
+
+    def _data_key(self, key_path: str) -> str:
+        """Redis key for tensor data."""
+        return self._redis_key(f"d:{key_path}")
+
+    def _meta_key(self, key_path: str) -> str:
+        """Redis key for tensor metadata hash."""
+        return self._redis_key(f"m:{key_path}")
+
+    @property
+    def _keys_registry_key(self) -> str:
+        """Redis key for the Set of all leaf key paths."""
+        return self._redis_key("__keys__")
+
+    @property
+    def _batch_size_key(self) -> str:
+        """Redis key for stored batch size."""
+        return self._redis_key("__batch_size__")
+
+    @property
+    def _device_key(self) -> str:
+        """Redis key for stored device."""
+        return self._redis_key("__device__")
+
+    def _full_key_path(self, key: str) -> str:
+        """Build the full dot-separated key path including prefix."""
+        if self._prefix:
+            return self._prefix + _KEY_SEP + key
+        return key
+
+    # ---- Async internal methods ----
+
+    async def _apersist_metadata(self):
+        """Persist batch_size and device to Redis."""
+        pipe = self._client.pipeline()
+        pipe.set(self._batch_size_key, json.dumps(list(self._batch_size)))
+        device_str = str(self._device) if self._device is not None else ""
+        pipe.set(self._device_key, device_str)
+        await pipe.execute()
+
+    async def _aset_tensor(self, key_path: str, tensor: torch.Tensor):
+        """Store a tensor's data and metadata in Redis."""
+        data = _tensor_to_bytes(tensor)
+        meta = {
+            "shape": json.dumps(list(tensor.shape)),
+            "dtype": _dtype_to_str(tensor.dtype),
+        }
+        pipe = self._client.pipeline()
+        pipe.set(self._data_key(key_path), data)
+        pipe.hset(self._meta_key(key_path), mapping=meta)
+        pipe.sadd(self._keys_registry_key, key_path)
+        await pipe.execute()
+
+    async def _aset_non_tensor(self, key_path: str, value: Any):
+        """Store a non-tensor value in Redis."""
+        # Try JSON first, fall back to pickle
+        try:
+            serialized = json.dumps(value)
+            encoding = "json"
+        except (TypeError, ValueError):
+            serialized = pickle.dumps(value)
+            encoding = "pickle"
+
+        meta = {
+            "is_non_tensor": "1",
+            "encoding": encoding,
+        }
+        data = (
+            serialized if isinstance(serialized, bytes) else serialized.encode("utf-8")
+        )
+        pipe = self._client.pipeline()
+        pipe.set(self._data_key(key_path), data)
+        pipe.hset(self._meta_key(key_path), mapping=meta)
+        pipe.sadd(self._keys_registry_key, key_path)
+        await pipe.execute()
+
+    async def _aget_tensor(self, key_path: str) -> torch.Tensor | None:
+        """Retrieve a tensor from Redis. Returns None if not found."""
+        pipe = self._client.pipeline()
+        pipe.get(self._data_key(key_path))
+        pipe.hgetall(self._meta_key(key_path))
+        data, meta = await pipe.execute()
+
+        if data is None:
+            return None
+
+        meta = {
+            k.decode() if isinstance(k, bytes) else k: (
+                v.decode() if isinstance(v, bytes) else v
+            )
+            for k, v in meta.items()
+        }
+
+        if meta.get("is_non_tensor") == "1":
+            return self._deserialize_non_tensor(data, meta)
+
+        shape = json.loads(meta["shape"])
+        dtype = _str_to_dtype(meta["dtype"])
+        tensor = _bytes_to_tensor(data, shape, dtype)
+        if self._device is not None:
+            tensor = tensor.to(self._device)
+        return tensor
+
+    async def _aget_metadata(self, key_path: str) -> dict:
+        """Retrieve metadata for a key without downloading tensor data."""
+        raw = await self._client.hgetall(self._meta_key(key_path))
+        return {
+            k.decode() if isinstance(k, bytes) else k: (
+                v.decode() if isinstance(v, bytes) else v
+            )
+            for k, v in raw.items()
+        }
+
+    async def _adel_key(self, key_path: str):
+        """Delete a key's data, metadata, and registry entry."""
+        pipe = self._client.pipeline()
+        pipe.delete(self._data_key(key_path))
+        pipe.delete(self._meta_key(key_path))
+        pipe.srem(self._keys_registry_key, key_path)
+        await pipe.execute()
+
+    async def _aget_all_keys(self) -> set[str]:
+        """Get all registered key paths from Redis."""
+        raw = await self._client.smembers(self._keys_registry_key)
+        return {k.decode() if isinstance(k, bytes) else k for k in raw}
+
+    async def _aget_batch_tensors(
+        self, key_paths: list[str]
+    ) -> dict[str, torch.Tensor]:
+        """Batch-fetch multiple tensors using a Redis pipeline."""
+        if not key_paths:
+            return {}
+
+        # Batch get data
+        pipe = self._client.pipeline()
+        for kp in key_paths:
+            pipe.get(self._data_key(kp))
+        data_list = await pipe.execute()
+
+        # Batch get metadata
+        pipe = self._client.pipeline()
+        for kp in key_paths:
+            pipe.hgetall(self._meta_key(kp))
+        meta_list = await pipe.execute()
+
+        result = {}
+        for kp, data, raw_meta in zip(key_paths, data_list, meta_list):
+            if data is None:
+                continue
+            meta = {
+                k.decode() if isinstance(k, bytes) else k: (
+                    v.decode() if isinstance(v, bytes) else v
+                )
+                for k, v in raw_meta.items()
+            }
+            if meta.get("is_non_tensor") == "1":
+                result[kp] = self._deserialize_non_tensor(data, meta)
+            else:
+                shape = json.loads(meta["shape"])
+                dtype = _str_to_dtype(meta["dtype"])
+                tensor = _bytes_to_tensor(data, shape, dtype)
+                if self._device is not None:
+                    tensor = tensor.to(self._device)
+                result[kp] = tensor
+        return result
+
+    # ---- Sync helpers ----
+
+    def _get_all_keys(self) -> set[str]:
+        """Get all registered key paths (sync wrapper)."""
+        return self._run_sync(self._aget_all_keys())
+
+    @staticmethod
+    def _deserialize_non_tensor(data: bytes, meta: dict) -> Any:
+        """Deserialize a non-tensor value from Redis."""
+        encoding = meta.get("encoding", "json")
+        if encoding == "json":
+            return json.loads(data.decode() if isinstance(data, bytes) else data)
+        return pickle.loads(data)
+
+    # ---- TensorDictBase interface: batch_size / device / names ----
+
+    @property
+    def batch_size(self) -> torch.Size:
+        return self._batch_size
+
+    @batch_size.setter
+    def batch_size(self, value):
+        old = self._batch_size
+        try:
+            self._batch_size = torch.Size(value)
+            self._check_batch_size(self._batch_size)
+            self._run_sync(self._apersist_metadata())
+        except ValueError:
+            self._batch_size = old
+
+    @property
+    def device(self) -> torch.device | None:
+        return self._device
+
+    @device.setter
+    def device(self, value):
+        self._device = torch.device(value) if value is not None else None
+        self._run_sync(self._apersist_metadata())
+
+    _erase_names = TensorDict._erase_names
+    _has_names = TensorDict._has_names
+    _set_names = TensorDict._set_names
+    names = TensorDict.names
+
+    def _rename_subtds(self, names):
+        if names is None:
+            names = [None] * self.ndim
+        for item in self._nested_tensordicts.values():
+            if is_tensor_collection(item):
+                td_names = list(names) + [None] * (item.ndim - self.ndim)
+                item.rename_(*td_names)
+
+    # ---- Key access / mutation ----
+
+    def __setitem__(self, index, value):
+        index_unravel = _unravel_key_to_tuple(index)
+        if index_unravel:
+            return self.set(index_unravel, value, inplace=True)
+
+        if isinstance(index, list):
+            index = torch.tensor(index)
+        sub_td = self._get_sub_tensordict(index)
+        err_set_batch_size = None
+        if not isinstance(value, TensorDictBase):
+            value = TensorDict.from_dict(value, batch_size=[])
+            try:
+                value.batch_size = sub_td.batch_size
+            except RuntimeError as err0:
+                err_set_batch_size = err0
+        if value.shape != sub_td.shape:
+            try:
+                value = value.expand(sub_td.shape)
+            except RuntimeError as err:
+                if err_set_batch_size is not None:
+                    raise err from err_set_batch_size
+                raise RuntimeError(
+                    f"Cannot broadcast the tensordict {value} to the shape of "
+                    f"the indexed {type(self).__name__} {self}[{index}]."
+                ) from err
+        sub_td.update(value, inplace=True)
+
+    def _get_str(self, key, default=NO_DEFAULT, **kwargs):
+        key_path = self._full_key_path(key)
+        all_keys = self._get_all_keys()
+
+        # Check if it's a nested tensordict (key is a prefix of other keys)
+        prefix_check = key_path + _KEY_SEP
+        nested_keys = [k for k in all_keys if k.startswith(prefix_check)]
+        if nested_keys:
+            # Return a nested RedisTensorDict view
+            nested = self._nested_tensordicts.get(key)
+            if nested is None:
+                nested = RedisTensorDict._new_nested(
+                    parent=self,
+                    key_prefix=key_path,
+                )
+                self._nested_tensordicts[key] = nested
+            return nested
+
+        # Check if it's a direct leaf key
+        if key_path in all_keys:
+            result = self._run_sync(self._aget_tensor(key_path))
+            if result is not None:
+                return result
+
+        if default is not NO_DEFAULT:
+            return default
+        raise KeyError(f"key {key} not found in {type(self).__name__}")
+
+    _get_tuple = TensorDict._get_tuple
+
+    def _convert_inplace(self, inplace, key):
+        """Convert BEST_ATTEMPT_INPLACE sentinel to a bool."""
+        if inplace is not False:
+            key_path = self._full_key_path(key)
+            all_keys = self._get_all_keys()
+            has_key = key_path in all_keys
+            # Also check if it's a nested key prefix
+            if not has_key:
+                prefix_check = key_path + _KEY_SEP
+                has_key = any(k.startswith(prefix_check) for k in all_keys)
+            if inplace is True and not has_key:
+                raise KeyError(
+                    _KEY_ERROR.format(key, type(self).__name__, sorted(self.keys()))
+                )
+            inplace = has_key
+        return inplace
+
+    def _set_str(
+        self,
+        key: str,
+        value: Any,
+        *,
+        inplace: bool,
+        validated: bool,
+        ignore_lock: bool = False,
+        non_blocking: bool = False,
+    ):
+        inplace = self._convert_inplace(inplace, key)
+        if not validated:
+            value = self._validate_value(value, check_shape=True)
+        if self.is_locked and not ignore_lock:
+            if not inplace:
+                raise RuntimeError(_LOCK_ERROR)
+
+        key_path = self._full_key_path(key)
+
+        if is_non_tensor(value):
+            from tensordict.tensorclass import NonTensorData
+
+            if isinstance(value, NonTensorData):
+                raw_value = value.data
+            else:
+                raw_value = value
+            self._run_sync(self._aset_non_tensor(key_path, raw_value))
+            return self
+
+        if is_tensor_collection(value):
+            # Create nested tensordict and populate it
+            target_td = self._nested_tensordicts.get(key)
+            if target_td is None:
+                target_td = RedisTensorDict._new_nested(
+                    parent=self,
+                    key_prefix=key_path,
+                    batch_size=value.batch_size,
+                )
+                self._nested_tensordicts[key] = target_td
+            target_td.update(value, inplace=inplace)
+            return self
+
+        if isinstance(value, torch.Tensor):
+            self._run_sync(self._aset_tensor(key_path, value))
+            return self
+
+        # Fallback: try to convert to tensor
+        try:
+            value = torch.as_tensor(value)
+            self._run_sync(self._aset_tensor(key_path, value))
+        except (ValueError, TypeError):
+            self._run_sync(self._aset_non_tensor(key_path, value))
+        return self
+
+    def _set_tuple(self, key, value, *, inplace, validated, non_blocking):
+        key = _unravel_key_to_tuple(key)
+        if len(key) == 1:
+            return self._set_str(
+                key[0],
+                value,
+                inplace=inplace,
+                validated=validated,
+                non_blocking=non_blocking,
+            )
+        elif key[0] in self.keys():
+            return self._get_str(key[0], NO_DEFAULT)._set_tuple(
+                key[1:],
+                value,
+                inplace=inplace,
+                validated=validated,
+                non_blocking=non_blocking,
+            )
+        # Direct set with full key path
+        key_path = self._full_key_path(_KEY_SEP.join(key))
+        if not validated:
+            value = self._validate_value(value, check_shape=True)
+        if self.is_locked and not inplace:
+            raise RuntimeError(_LOCK_ERROR)
+
+        if isinstance(value, torch.Tensor):
+            self._run_sync(self._aset_tensor(key_path, value))
+        elif is_non_tensor(value):
+            from tensordict.tensorclass import NonTensorData
+
+            raw_value = value.data if isinstance(value, NonTensorData) else value
+            self._run_sync(self._aset_non_tensor(key_path, raw_value))
+        elif is_tensor_collection(value):
+            nested_prefix = self._full_key_path(_KEY_SEP.join(key))
+            nested = RedisTensorDict._new_nested(
+                parent=self,
+                key_prefix=nested_prefix,
+                batch_size=value.batch_size,
+            )
+            nested.update(value, inplace=inplace)
+        else:
+            self._run_sync(self._aset_non_tensor(key_path, value))
+        return self
+
+    def _set_at_str(self, key, value, idx, *, validated, non_blocking):
+        # For Redis, we need to read-modify-write
+        key_path = self._full_key_path(key)
+        existing = self._run_sync(self._aget_tensor(key_path))
+        if existing is None:
+            raise KeyError(f"key {key} not found in {type(self).__name__} for set_at_")
+        existing[idx] = value
+        self._run_sync(self._aset_tensor(key_path, existing))
+        return self
+
+    def _set_at_tuple(self, key, value, idx, *, validated, non_blocking):
+        key = _unravel_key_to_tuple(key)
+        if len(key) == 1:
+            return self._set_at_str(
+                key[0], value, idx, validated=validated, non_blocking=non_blocking
+            )
+        td = self._get_str(key[0], NO_DEFAULT)
+        return td._set_at_tuple(
+            key[1:], value, idx, validated=validated, non_blocking=non_blocking
+        )
+
+    # ---- Keys / structure ----
+
+    def keys(
+        self,
+        include_nested: bool = False,
+        leaves_only: bool = False,
+        is_leaf: Callable[[Type], bool] | None = None,
+        *,
+        sort: bool = False,
+    ) -> _RedisTDKeysView:
+        return _RedisTDKeysView(
+            tensordict=self,
+            include_nested=include_nested,
+            leaves_only=leaves_only,
+            is_leaf=is_leaf,
+            sort=sort,
+        )
+
+    @lock_blocked
+    def del_(self, key: NestedKey) -> RedisTensorDict:
+        if isinstance(key, str):
+            key_path = self._full_key_path(key)
+        else:
+            key = _unravel_key_to_tuple(key)
+            key_path = self._full_key_path(_KEY_SEP.join(key))
+
+        all_keys = self._get_all_keys()
+        # Delete exact key
+        if key_path in all_keys:
+            self._run_sync(self._adel_key(key_path))
+
+        # Delete nested keys (prefix match)
+        prefix_check = key_path + _KEY_SEP
+        nested_to_delete = [k for k in all_keys if k.startswith(prefix_check)]
+        for nested_key in nested_to_delete:
+            self._run_sync(self._adel_key(nested_key))
+
+        # Clean up nested cache
+        cache_key = key if isinstance(key, str) else key[0]
+        self._nested_tensordicts.pop(cache_key, None)
+
+        return self
+
+    def rename_key_(
+        self, old_key: NestedKey, new_key: NestedKey, safe: bool = False
+    ) -> RedisTensorDict:
+        if isinstance(old_key, str):
+            old_path = self._full_key_path(old_key)
+        else:
+            old_key_tuple = _unravel_key_to_tuple(old_key)
+            old_path = self._full_key_path(_KEY_SEP.join(old_key_tuple))
+
+        if isinstance(new_key, str):
+            new_path = self._full_key_path(new_key)
+        else:
+            new_key_tuple = _unravel_key_to_tuple(new_key)
+            new_path = self._full_key_path(_KEY_SEP.join(new_key_tuple))
+
+        if safe and new_path in self._get_all_keys():
+            raise KeyError(f"key {new_key} already present in {type(self).__name__}.")
+
+        async def _arename(old_path, new_path):
+            all_keys = await self._aget_all_keys()
+            # Rename exact match
+            if old_path in all_keys:
+                pipe = self._client.pipeline()
+                pipe.rename(self._data_key(old_path), self._data_key(new_path))
+                pipe.rename(self._meta_key(old_path), self._meta_key(new_path))
+                pipe.srem(self._keys_registry_key, old_path)
+                pipe.sadd(self._keys_registry_key, new_path)
+                await pipe.execute()
+            # Rename nested keys
+            old_prefix = old_path + _KEY_SEP
+            new_prefix = new_path + _KEY_SEP
+            nested = [k for k in all_keys if k.startswith(old_prefix)]
+            for k in nested:
+                new_k = new_prefix + k[len(old_prefix) :]
+                pipe = self._client.pipeline()
+                pipe.rename(self._data_key(k), self._data_key(new_k))
+                pipe.rename(self._meta_key(k), self._meta_key(new_k))
+                pipe.srem(self._keys_registry_key, k)
+                pipe.sadd(self._keys_registry_key, new_k)
+                await pipe.execute()
+
+        self._run_sync(_arename(old_path, new_path))
+        return self
+
+    def entry_class(self, key: NestedKey) -> type:
+        if isinstance(key, str):
+            key_path = self._full_key_path(key)
+        else:
+            key = _unravel_key_to_tuple(key)
+            key_path = self._full_key_path(_KEY_SEP.join(key))
+
+        all_keys = self._get_all_keys()
+        # Direct leaf
+        if key_path in all_keys:
+            meta = self._run_sync(self._aget_metadata(key_path))
+            if meta.get("is_non_tensor") == "1":
+                from tensordict.tensorclass import NonTensorData
+
+                return NonTensorData
+            return torch.Tensor
+
+        # Nested TD
+        prefix_check = key_path + _KEY_SEP
+        if any(k.startswith(prefix_check) for k in all_keys):
+            return RedisTensorDict
+
+        raise KeyError(f"key {key} not found in {type(self).__name__}")
+
+    # ---- Locking ----
+
+    def _propagate_lock(self, lock_parents_weakrefs=None, *, is_compiling):
+        self._is_locked = True
+        if lock_parents_weakrefs is not None:
+            lock_parents_weakrefs = [
+                ref
+                for ref in lock_parents_weakrefs
+                if not any(refref is ref for refref in self._lock_parents_weakrefs)
+            ]
+        if not is_compiling:
+            is_root = lock_parents_weakrefs is None
+            if is_root:
+                lock_parents_weakrefs = []
+            else:
+                self._lock_parents_weakrefs = (
+                    self._lock_parents_weakrefs + lock_parents_weakrefs
+                )
+            lock_parents_weakrefs = list(lock_parents_weakrefs)
+            lock_parents_weakrefs.append(weakref.ref(self))
+        for _td in self._nested_tensordicts.values():
+            _td._propagate_lock(lock_parents_weakrefs, is_compiling=is_compiling)
+
+    @erase_cache
+    def _propagate_unlock(self):
+        self._is_locked = False
+        self._is_shared = False
+        self._is_memmap = False
+        sub_tds = []
+        for _td in self._nested_tensordicts.values():
+            sub_tds.extend(_td._propagate_unlock())
+            sub_tds.append(_td)
+        return sub_tds
+
+    # ---- Materialization ----
+
+    def to_local(self) -> TensorDict:
+        """Pull the entire Redis-backed dict into local RAM.
+
+        Alias for :meth:`to_tensordict`.
+        """
+        return self.to_tensordict()
+
+    def contiguous(self) -> TensorDict:
+        """Materialize into a regular TensorDict."""
+        return self.to_tensordict()
+
+    # ---- Construction ----
+
+    @classmethod
+    def from_dict(
+        cls,
+        input_dict,
+        *,
+        host: str = "localhost",
+        port: int = 6379,
+        db: int = 0,
+        unix_socket_path: str | None = None,
+        prefix: str = "tensordict",
+        auto_batch_size: bool = False,
+        batch_size=None,
+        device=None,
+        **kwargs,
+    ):
+        """Create a RedisTensorDict from a dictionary or TensorDict.
+
+        Args:
+            input_dict: A dictionary or TensorDict to store in Redis.
+
+        Keyword Args:
+            host, port, db, unix_socket_path, prefix: Redis connection params.
+            auto_batch_size: If True, infer batch_size from data.
+            batch_size: Explicit batch_size.
+            device: Target device for tensor retrieval.
+            **kwargs: Additional Redis connection kwargs.
+
+        Returns:
+            A new RedisTensorDict.
+        """
+        if batch_size is None:
+            if is_tensor_collection(input_dict):
+                batch_size = input_dict.batch_size
+            else:
+                batch_size = torch.Size([])
+
+        connect_kwargs = {}
+        if unix_socket_path is not None:
+            connect_kwargs["unix_socket_path"] = unix_socket_path
+        else:
+            connect_kwargs["host"] = host
+            connect_kwargs["port"] = port
+        connect_kwargs["db"] = db
+
+        out = cls(
+            batch_size=batch_size,
+            device=device,
+            prefix=prefix,
+            **connect_kwargs,
+            **kwargs,
+        )
+        if is_tensor_collection(input_dict):
+            out.update(input_dict)
+        else:
+            out.update(TensorDict(input_dict, batch_size=batch_size))
+        return out
+
+    from_dict_instance = TensorDict.from_dict_instance
+
+    # ---- Cloning ----
+
+    def _clone(self, recurse: bool = True) -> RedisTensorDict:
+        if recurse:
+            # Deep clone: new UUID, copies all data
+            new_td = RedisTensorDict(
+                host=self._host,
+                port=self._port,
+                db=self._db,
+                unix_socket_path=self._unix_socket_path,
+                prefix=self._namespace,
+                batch_size=self._batch_size,
+                device=self._device,
+            )
+            new_td.update(self.to_tensordict())
+            return new_td
+        else:
+            # Shallow clone: same Redis data, new Python wrapper
+            return RedisTensorDict._new_nested(
+                parent=self,
+                key_prefix=self._prefix,
+            )
+
+    # ---- Misc required overrides ----
+
+    def is_contiguous(self) -> bool:
+        return False
+
+    def detach_(self) -> Self:
+        return self
+
+    @lock_blocked
+    def popitem(self) -> Tuple[NestedKey, CompatibleType]:
+        keys_list = list(self.keys())
+        if not keys_list:
+            raise KeyError(f"popitem(): {type(self).__name__} is empty")
+        key = keys_list[-1]
+        value = self.get(key)
+        self.del_(key)
+        return key, value
+
+    def _change_batch_size(self, new_size: torch.Size) -> None:
+        self._batch_size = new_size
+        self._run_sync(self._apersist_metadata())
+
+    def zero_(self) -> Self:
+        for key in self.keys():
+            self.fill_(key, 0)
+        return self
+
+    def fill_(self, key: NestedKey, value: float | bool) -> TensorDictBase:
+        existing = self.get(key)
+        if is_tensor_collection(existing):
+            for subkey in existing.keys():
+                existing.fill_(subkey, value)
+        else:
+            existing = existing.fill_(value)
+            self.set_(key, existing)
+        return self
+
+    def empty(
+        self, recurse=False, *, batch_size=None, device=NO_DEFAULT, names=None
+    ) -> T:
+        if recurse:
+            out = self.empty(
+                recurse=False, batch_size=batch_size, device=device, names=names
+            )
+            for key, val in self.items():
+                if is_tensor_collection(val):
+                    out._set_str(
+                        key,
+                        val.empty(
+                            recurse=True,
+                            batch_size=batch_size,
+                            device=device,
+                            names=names,
+                        ),
+                        inplace=False,
+                        validated=True,
+                        non_blocking=False,
+                    )
+            return out
+        return TensorDict(
+            {},
+            device=self.device if device is NO_DEFAULT else device,
+            batch_size=self.batch_size if batch_size is None else batch_size,
+            names=self.names if names is None and self._has_names() else names,
+        )
+
+    def masked_fill(self, mask, value):
+        return self.to_tensordict().masked_fill(mask, value)
+
+    def masked_fill_(self, mask, value):
+        for key in self.keys(include_nested=True, leaves_only=True):
+            tensor = self.get(key)
+            tensor = tensor.masked_fill(mask, value)
+            self.set_(key, tensor)
+        return self
+
+    def masked_select(self, mask):
+        return self.to_tensordict().masked_select(mask)
+
+    def where(self, condition, other, *, out=None, pad=None, update_batch_size=False):
+        return self.to_tensordict().where(
+            condition=condition,
+            other=other,
+            out=out,
+            pad=pad,
+            update_batch_size=update_batch_size,
+        )
+
+    # ---- Pickling ----
+
+    def __getstate__(self):
+        state = {
+            "_host": self._host,
+            "_port": self._port,
+            "_db": self._db,
+            "_unix_socket_path": self._unix_socket_path,
+            "_namespace": self._namespace,
+            "_td_id": self._td_id,
+            "_prefix": self._prefix,
+            "_batch_size": self._batch_size,
+            "_device": self._device,
+            "_redis_kwargs": self._redis_kwargs,
+            "_is_locked": self._is_locked,
+            "_td_dim_names": self._td_dim_names,
+        }
+        return state
+
+    def __setstate__(self, state):
+        import redis.asyncio as aioredis
+
+        self._host = state["_host"]
+        self._port = state["_port"]
+        self._db = state["_db"]
+        self._unix_socket_path = state["_unix_socket_path"]
+        self._namespace = state["_namespace"]
+        self._td_id = state["_td_id"]
+        self._prefix = state["_prefix"]
+        self._batch_size = state["_batch_size"]
+        self._device = state["_device"]
+        self._redis_kwargs = state["_redis_kwargs"]
+        self._td_dim_names = state["_td_dim_names"]
+
+        self._locked_tensordicts = []
+        self._lock_id = set()
+        self._is_shared = False
+        self._is_memmap = False
+        self._nested_tensordicts = {}
+
+        # Recreate event loop and client
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+        self._owns_loop = True
+
+        connect_kwargs = dict(self._redis_kwargs)
+        if self._unix_socket_path is not None:
+            connect_kwargs["unix_socket_path"] = self._unix_socket_path
+        else:
+            connect_kwargs["host"] = self._host
+            connect_kwargs["port"] = self._port
+        connect_kwargs["db"] = self._db
+        self._client = aioredis.Redis(**connect_kwargs)
+
+        was_locked = state.get("_is_locked", False)
+        self._is_locked = False
+        if was_locked:
+            self.lock_()
+
+    # ---- Cleanup ----
+
+    def close(self):
+        """Close the Redis connection and stop the background event loop."""
+        if hasattr(self, "_owns_loop") and self._owns_loop:
+            if (
+                hasattr(self, "_client")
+                and hasattr(self, "_loop")
+                and self._loop.is_running()
+            ):
+                try:
+                    future = asyncio.run_coroutine_threadsafe(
+                        self._client.aclose(), self._loop
+                    )
+                    future.result(timeout=2)
+                except Exception:
+                    pass
+            if hasattr(self, "_loop") and self._loop.is_running():
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            if hasattr(self, "_thread") and self._thread.is_alive():
+                self._thread.join(timeout=2)
+            self._owns_loop = False
+
+    def clear_redis(self):
+        """Delete all keys associated with this TensorDict from Redis.
+
+        This removes all tensor data, metadata, and the key registry.
+        """
+
+        async def _aclear():
+            all_keys = await self._aget_all_keys()
+            if not all_keys:
+                pipe = self._client.pipeline()
+                pipe.delete(self._keys_registry_key)
+                pipe.delete(self._batch_size_key)
+                pipe.delete(self._device_key)
+                await pipe.execute()
+                return
+            pipe = self._client.pipeline()
+            for key_path in all_keys:
+                pipe.delete(self._data_key(key_path))
+                pipe.delete(self._meta_key(key_path))
+            pipe.delete(self._keys_registry_key)
+            pipe.delete(self._batch_size_key)
+            pipe.delete(self._device_key)
+            await pipe.execute()
+
+        self._run_sync(_aclear())
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def __repr__(self):
+        keys_str = list(self.keys())
+        device = self.device
+        batch_size = self.batch_size
+        return (
+            f"RedisTensorDict(\n"
+            f"    keys={keys_str},\n"
+            f"    batch_size={batch_size},\n"
+            f"    device={device},\n"
+            f"    td_id={self._td_id!r})"
+        )
+
+    # ---- Delegated to TensorDict (same pattern as PersistentTensorDict) ----
+
+    __eq__ = TensorDict.__eq__
+    __ne__ = TensorDict.__ne__
+    __xor__ = TensorDict.__xor__
+    __or__ = TensorDict.__or__
+    __ge__ = TensorDict.__ge__
+    __gt__ = TensorDict.__gt__
+    __le__ = TensorDict.__le__
+    __lt__ = TensorDict.__lt__
+
+    _apply_nest = TensorDict._apply_nest
+    _cast_reduction = TensorDict._cast_reduction
+    _check_device = TensorDict._check_device
+    _check_is_shared = TensorDict._check_is_shared
+    _convert_to_tensordict = TensorDict._convert_to_tensordict
+    _get_names_idx = TensorDict._get_names_idx
+    _index_tensordict = TensorDict._index_tensordict
+    _multithread_apply_flat = TensorDict._multithread_apply_flat
+    _multithread_rebuild = TensorDict._multithread_rebuild
+    _to_module = TensorDict._to_module
+    _unbind = TensorDict._unbind
+    all = TensorDict.all
+    any = TensorDict.any
+    expand = TensorDict.expand
+    _repeat = TensorDict._repeat
+    repeat_interleave = TensorDict.repeat_interleave
+    reshape = TensorDict.reshape
+    split = TensorDict.split
+
+    # ---- Shape ops: raise NotImplementedError ----
+
+    def _view(self, *args, **kwargs):
+        raise RuntimeError(
+            f"Cannot call `view` on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def _transpose(self, dim0, dim1):
+        raise RuntimeError(
+            f"Cannot call `transpose` on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def _permute(self, *args, **kwargs):
+        raise RuntimeError(
+            f"Cannot call `permute` on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def _squeeze(self, dim=None):
+        raise RuntimeError(
+            f"Cannot call `squeeze` on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def _unsqueeze(self, dim: int):
+        raise RuntimeError(
+            f"Cannot call `unsqueeze` on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def chunk(self, chunks: int, dim: int = 0) -> tuple[TensorDictBase, ...]:
+        splits = -(self.batch_size[dim] // -chunks)
+        return self.split(splits, dim)
+
+    # ---- Memory ops: not supported ----
+
+    def share_memory_(self):
+        raise NotImplementedError(
+            f"Cannot call share_memory_ on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def _memmap_(
+        self,
+        *,
+        prefix,
+        copy_existing,
+        executor,
+        futures,
+        inplace,
+        like,
+        share_non_tensor,
+        existsok,
+        robust_key,
+    ):
+        raise RuntimeError(
+            f"Cannot call memmap on a {type(self).__name__} in-place. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def make_memmap(self, key, shape, *, dtype=None, robust_key=None):
+        raise RuntimeError(
+            f"Cannot make memory-mapped tensor on a {type(self).__name__}."
+        )
+
+    def make_memmap_from_storage(
+        self, key, storage, shape, *, dtype=None, robust_key=None
+    ):
+        raise RuntimeError(
+            f"Cannot make memory-mapped tensor on a {type(self).__name__}."
+        )
+
+    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=None):
+        raise RuntimeError(
+            f"Cannot make memory-mapped tensor on a {type(self).__name__}."
+        )
+
+    def memmap_(self, prefix=None, copy_existing=False, num_threads=0):
+        raise RuntimeError(
+            f"Cannot build a memmap TensorDict in-place from a {type(self).__name__}. "
+            "Use `td.memmap()` instead."
+        )
+
+    def pin_memory(self, *args, **kwargs):
+        raise RuntimeError(
+            f"Cannot pin memory of a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` before making this call."
+        )
+
+    def _add_batch_dim(self, *, in_dim, vmap_level):
+        raise RuntimeError(f"{type(self).__name__} cannot be used with vmap.")
+
+    def _remove_batch_dim(self, vmap_level, batch_size, out_dim): ...
+
+    def _maybe_remove_batch_dim(self, funcname, vmap_level, batch_size, out_dim): ...
+
+    def _select(self, *keys, inplace=False, strict=True, set_shared=True):
+        raise NotImplementedError(
+            f"Cannot call select on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    def _exclude(self, *keys, inplace=False, set_shared=True):
+        raise NotImplementedError(
+            f"Cannot call exclude on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+    @_as_context_manager()
+    def flatten_keys(self, separator=".", inplace=False):
+        if inplace:
+            raise ValueError(
+                f"Cannot call flatten_keys in_place with a {type(self).__name__}."
+            )
+        return self.to_tensordict().flatten_keys(separator=separator)
+
+    @_as_context_manager()
+    def unflatten_keys(self, separator=".", inplace=False):
+        if inplace:
+            raise ValueError(
+                f"Cannot call unflatten_keys in_place with a {type(self).__name__}."
+            )
+        return self.to_tensordict().unflatten_keys(separator=separator)
+
+    _load_memmap = TensorDict._load_memmap
+
+    def _set_non_tensor(self, key: NestedKey, value: Any):
+        raise NotImplementedError(
+            f"set_non_tensor is not compatible with the tensordict type {type(self).__name__}."
+        )
+
+    def _stack_onto_(self, list_item, dim):
+        raise RuntimeError(
+            f"Cannot call _stack_onto_ on a {type(self).__name__}. "
+            "Call `to_tensordict()` or `to_local()` first."
+        )
+
+
+_register_tensor_class(RedisTensorDict)

--- a/test/test_redis.py
+++ b/test/test_redis.py
@@ -1,0 +1,421 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import importlib
+import pickle
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.redis import RedisTensorDict
+
+_has_redis = importlib.util.find_spec("redis", None) is not None
+
+
+def _redis_available():
+    """Check if a Redis server is reachable on localhost:6379."""
+    if not _has_redis:
+        return False
+    import redis
+
+    try:
+        r = redis.Redis(host="localhost", port=6379, db=0, socket_connect_timeout=2)
+        r.ping()
+        r.close()
+        return True
+    except (redis.ConnectionError, redis.exceptions.ConnectionError, OSError):
+        return False
+
+
+_skip_no_redis_pkg = pytest.mark.skipif(
+    not _has_redis, reason="redis package not installed."
+)
+_skip_no_redis_server = pytest.mark.skipif(
+    not _redis_available(), reason="Redis server not reachable on localhost:6379."
+)
+
+skip_redis = pytest.mark.usefixtures()
+
+
+@_skip_no_redis_pkg
+@_skip_no_redis_server
+class TestRedisTensorDict:
+    """Tests for RedisTensorDict requiring a running Redis server."""
+
+    @pytest.fixture(autouse=True)
+    def redis_td(self):
+        """Create a fresh RedisTensorDict and clean up after the test."""
+
+        td = RedisTensorDict(batch_size=[10], db=15)
+        yield td
+        td.clear_redis()
+        td.close()
+
+    def test_basic_set_get(self, redis_td):
+        """Store and retrieve a tensor."""
+        tensor = torch.randn(10, 3)
+        redis_td["obs"] = tensor
+        result = redis_td["obs"]
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (10, 3)
+        assert torch.allclose(result, tensor)
+
+    def test_multiple_keys(self, redis_td):
+        """Store and retrieve multiple tensors."""
+        obs = torch.randn(10, 84)
+        action = torch.randn(10, 4)
+        reward = torch.randn(10, 1)
+        redis_td["obs"] = obs
+        redis_td["action"] = action
+        redis_td["reward"] = reward
+
+        assert torch.allclose(redis_td["obs"], obs)
+        assert torch.allclose(redis_td["action"], action)
+        assert torch.allclose(redis_td["reward"], reward)
+
+    def test_dtypes(self, redis_td):
+        """Store and retrieve tensors of different dtypes."""
+        for dtype in [
+            torch.float32,
+            torch.float64,
+            torch.int32,
+            torch.int64,
+            torch.bool,
+        ]:
+            key = f"tensor_{dtype}".replace(".", "_")
+            tensor = torch.zeros(10, 5, dtype=dtype)
+            redis_td[key] = tensor
+            result = redis_td[key]
+            assert result.dtype == dtype, f"Failed for dtype {dtype}"
+            assert result.shape == (10, 5)
+
+    def test_nested_keys(self, redis_td):
+        """Store and retrieve tensors with nested keys."""
+        tensor = torch.randn(10, 4)
+        redis_td["nested", "obs"] = tensor
+
+        # Access the nested value
+        result = redis_td["nested", "obs"]
+        assert torch.allclose(result, tensor)
+
+        # Access the nested tensordict
+        nested = redis_td["nested"]
+
+        assert isinstance(nested, RedisTensorDict)
+        result2 = nested["obs"]
+        assert torch.allclose(result2, tensor)
+
+    def test_nested_from_tensordict(self, redis_td):
+        """Store a nested TensorDict."""
+        inner = TensorDict({"a": torch.randn(10, 3), "b": torch.randn(10, 2)}, [10])
+        redis_td["inner"] = inner
+
+        assert torch.allclose(redis_td["inner", "a"], inner["a"])
+        assert torch.allclose(redis_td["inner", "b"], inner["b"])
+
+    def test_batch_size(self, redis_td):
+        """Verify batch_size is correctly stored and accessible."""
+        assert redis_td.batch_size == torch.Size([10])
+
+    def test_from_dict(self):
+        """Construct from a dict."""
+
+        source = {"obs": torch.randn(5, 3), "reward": torch.randn(5, 1)}
+        td = RedisTensorDict.from_dict(source, batch_size=[5], db=15)
+        try:
+            assert td.batch_size == torch.Size([5])
+            assert torch.allclose(td["obs"], source["obs"])
+            assert torch.allclose(td["reward"], source["reward"])
+        finally:
+            td.clear_redis()
+            td.close()
+
+    def test_from_tensordict(self):
+        """Construct from a TensorDict."""
+
+        source = TensorDict(
+            {"obs": torch.randn(5, 3), "reward": torch.randn(5, 1)}, [5]
+        )
+        td = RedisTensorDict.from_dict(source, db=15)
+        try:
+            assert td.batch_size == torch.Size([5])
+            assert torch.allclose(td["obs"], source["obs"])
+            assert torch.allclose(td["reward"], source["reward"])
+        finally:
+            td.clear_redis()
+            td.close()
+
+    def test_to_local(self, redis_td):
+        """Materialize to a local TensorDict."""
+        obs = torch.randn(10, 4)
+        action = torch.randn(10, 2)
+        redis_td["obs"] = obs
+        redis_td["action"] = action
+
+        local = redis_td.to_local()
+        assert isinstance(local, TensorDict)
+        assert local.batch_size == torch.Size([10])
+        assert torch.allclose(local["obs"], obs)
+        assert torch.allclose(local["action"], action)
+
+    def test_to_tensordict(self, redis_td):
+        """to_tensordict should be equivalent to to_local."""
+        tensor = torch.randn(10, 3)
+        redis_td["x"] = tensor
+
+        local = redis_td.to_tensordict()
+        assert isinstance(local, TensorDict)
+        assert torch.allclose(local["x"], tensor)
+
+    def test_contiguous(self, redis_td):
+        """contiguous should materialize."""
+        tensor = torch.randn(10, 3)
+        redis_td["x"] = tensor
+        local = redis_td.contiguous()
+        assert isinstance(local, TensorDict)
+        assert torch.allclose(local["x"], tensor)
+
+    def test_keys_view(self, redis_td):
+        """Test keys iteration."""
+        redis_td["a"] = torch.randn(10, 2)
+        redis_td["b"] = torch.randn(10, 3)
+        redis_td["nested", "c"] = torch.randn(10, 4)
+
+        # Top-level keys (non-nested)
+        keys = set(redis_td.keys())
+        assert "a" in keys
+        assert "b" in keys
+        assert "nested" in keys
+
+    def test_keys_include_nested(self, redis_td):
+        """Test keys with include_nested=True."""
+        redis_td["a"] = torch.randn(10, 2)
+        redis_td["nested", "b"] = torch.randn(10, 3)
+
+        nested_keys = set(redis_td.keys(include_nested=True))
+        assert "a" in nested_keys
+        # The nested key should appear as a tuple
+        assert ("nested", "b") in nested_keys or "nested" in nested_keys
+
+    def test_keys_leaves_only(self, redis_td):
+        """Test keys with leaves_only=True."""
+        redis_td["a"] = torch.randn(10, 2)
+        redis_td["nested", "b"] = torch.randn(10, 3)
+
+        leaf_keys = list(redis_td.keys(leaves_only=True))
+        assert "a" in leaf_keys
+        # "nested" should not appear since it is not a leaf
+        assert "nested" not in leaf_keys
+
+    def test_contains(self, redis_td):
+        """Test __contains__ via 'in' operator."""
+        redis_td["obs"] = torch.randn(10, 3)
+        redis_td["nested", "val"] = torch.randn(10, 2)
+
+        assert "obs" in redis_td.keys()
+        assert "nested" in redis_td.keys()
+        assert ("nested", "val") in redis_td.keys(include_nested=True)
+        assert "nonexistent" not in redis_td.keys()
+
+    def test_del(self, redis_td):
+        """Test key deletion."""
+        redis_td["obs"] = torch.randn(10, 3)
+        redis_td["action"] = torch.randn(10, 2)
+        assert "obs" in redis_td.keys()
+
+        redis_td.del_("obs")
+        assert "obs" not in redis_td.keys()
+        assert "action" in redis_td.keys()
+
+    def test_del_nested(self, redis_td):
+        """Test deletion of nested keys."""
+        redis_td["nested", "a"] = torch.randn(10, 2)
+        redis_td["nested", "b"] = torch.randn(10, 3)
+        assert "nested" in redis_td.keys()
+
+        redis_td.del_("nested")
+        assert "nested" not in redis_td.keys()
+
+    def test_locking(self, redis_td):
+        """Test lock/unlock."""
+        redis_td["obs"] = torch.randn(10, 3)
+        redis_td.lock_()
+        assert redis_td.is_locked
+
+        # Should raise when trying to set a new key
+        with pytest.raises(RuntimeError):
+            redis_td["new_key"] = torch.randn(10, 2)
+
+        redis_td.unlock_()
+        assert not redis_td.is_locked
+        redis_td["new_key"] = torch.randn(10, 2)
+
+    def test_set_at_(self, redis_td):
+        """Test setting a value at a specific index."""
+        tensor = torch.zeros(10, 3)
+        redis_td["obs"] = tensor
+        new_vals = torch.ones(3)
+        redis_td.set_at_("obs", new_vals, 0)
+        result = redis_td["obs"]
+        assert torch.allclose(result[0], new_vals)
+        assert torch.allclose(result[1:], torch.zeros(9, 3))
+
+    def test_update(self, redis_td):
+        """Test batch update from a dict."""
+        source = TensorDict(
+            {"obs": torch.randn(10, 3), "action": torch.randn(10, 2)}, [10]
+        )
+        redis_td.update(source)
+        assert torch.allclose(redis_td["obs"], source["obs"])
+        assert torch.allclose(redis_td["action"], source["action"])
+
+    def test_clone_recurse(self, redis_td):
+        """Test deep clone."""
+
+        redis_td["obs"] = torch.randn(10, 3)
+        cloned = redis_td.clone()
+        try:
+            assert isinstance(cloned, RedisTensorDict)
+            assert cloned._td_id != redis_td._td_id
+            assert torch.allclose(cloned["obs"], redis_td["obs"])
+        finally:
+            cloned.clear_redis()
+            cloned.close()
+
+    def test_clone_no_recurse(self, redis_td):
+        """Test shallow clone (same Redis data)."""
+
+        redis_td["obs"] = torch.randn(10, 3)
+        shallow = redis_td.clone(False)
+        assert isinstance(shallow, RedisTensorDict)
+        assert shallow._td_id == redis_td._td_id
+        assert torch.allclose(shallow["obs"], redis_td["obs"])
+
+    def test_pickling(self, redis_td):
+        """Test pickle round-trip."""
+        redis_td["obs"] = torch.randn(10, 3)
+        data = pickle.dumps(redis_td)
+        restored = pickle.loads(data)
+        try:
+            assert torch.allclose(restored["obs"], redis_td["obs"])
+            assert restored._td_id == redis_td._td_id
+        finally:
+            restored.close()
+
+    def test_entry_class(self, redis_td):
+        """Test entry_class returns correct types."""
+
+        redis_td["obs"] = torch.randn(10, 3)
+        redis_td["nested", "a"] = torch.randn(10, 2)
+        assert redis_td.entry_class("obs") is torch.Tensor
+        assert redis_td.entry_class("nested") is RedisTensorDict
+
+    def test_device(self):
+        """Test device attribute."""
+
+        td = RedisTensorDict(batch_size=[5], device="cpu", db=15)
+        try:
+            td["x"] = torch.randn(5, 3)
+            assert td.device == torch.device("cpu")
+            result = td["x"]
+            assert result.device == torch.device("cpu")
+        finally:
+            td.clear_redis()
+            td.close()
+
+    def test_repr(self, redis_td):
+        """Test string representation."""
+        redis_td["obs"] = torch.randn(10, 3)
+        s = repr(redis_td)
+        assert "RedisTensorDict" in s
+        assert "obs" in s
+
+    def test_empty(self, redis_td):
+        """Test empty()."""
+        redis_td["obs"] = torch.randn(10, 3)
+        empty = redis_td.empty()
+        assert isinstance(empty, TensorDict)
+        assert empty.batch_size == torch.Size([10])
+        assert len(list(empty.keys())) == 0
+
+    def test_fill_(self, redis_td):
+        """Test fill_."""
+        redis_td["obs"] = torch.randn(10, 3)
+        redis_td.fill_("obs", 42.0)
+        result = redis_td["obs"]
+        assert torch.allclose(result, torch.full((10, 3), 42.0))
+
+    def test_is_contiguous(self, redis_td):
+        """Redis TDs are not contiguous."""
+        assert not redis_td.is_contiguous()
+
+    def test_shape_ops_raise(self, redis_td):
+        """Shape ops raise on RedisTensorDict but work after to_local()."""
+        redis_td["obs"] = torch.randn(10, 3)
+
+        with pytest.raises(RuntimeError):
+            redis_td.view(2, 5)
+        with pytest.raises(RuntimeError):
+            redis_td.permute(0)
+        with pytest.raises(RuntimeError):
+            redis_td.unsqueeze(0)
+        with pytest.raises(RuntimeError):
+            redis_td.squeeze(0)
+
+        # Escape hatch: materialize first, then shape ops work
+        local = redis_td.to_local()
+        assert local.view(2, 5).shape == torch.Size([2, 5])
+        assert local.unsqueeze(0).shape == torch.Size([1, 10])
+        assert local.squeeze(0).shape == torch.Size([10])
+
+    def test_share_memory_raises(self, redis_td):
+        """share_memory_ should raise."""
+        with pytest.raises(NotImplementedError):
+            redis_td.share_memory_()
+
+    def test_reconnect_by_id(self):
+        """Connect to an existing RedisTensorDict by ID."""
+
+        td1 = RedisTensorDict(batch_size=[5], db=15)
+        try:
+            td1["obs"] = torch.randn(5, 3)
+            saved_obs = td1["obs"].clone()
+            td_id = td1._td_id
+
+            # Create a new instance pointing to the same data
+            td2 = RedisTensorDict(batch_size=[5], db=15, td_id=td_id)
+            try:
+                assert torch.allclose(td2["obs"], saved_obs)
+            finally:
+                td2.close()
+        finally:
+            td1.clear_redis()
+            td1.close()
+
+    def test_popitem(self, redis_td):
+        """Test popitem."""
+        redis_td["a"] = torch.randn(10, 2)
+        redis_td["b"] = torch.randn(10, 3)
+        key, val = redis_td.popitem()
+        assert key in ("a", "b")
+        assert isinstance(val, torch.Tensor)
+        # Only one key should remain
+        remaining = list(redis_td.keys())
+        assert len(remaining) == 1
+
+    def test_rename_key(self, redis_td):
+        """Test rename_key_."""
+        tensor = torch.randn(10, 3)
+        redis_td["old_name"] = tensor
+        redis_td.rename_key_("old_name", "new_name")
+        assert "old_name" not in redis_td.keys()
+        assert "new_name" in redis_td.keys()
+        assert torch.allclose(redis_td["new_name"], tensor)
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1571
* #1570
* #1569
* #1568
* __->__ #1567

Adds RedisTensorDict, a TensorDictBase subclass that stores tensors in a
Redis instance for out-of-core storage. This enables datasets that exceed
local RAM to be accessed with the familiar TensorDict interface.

MVP features:
- Async redis.asyncio client on a background event loop with sync wrappers
- Zero-copy serialization via torch.frombuffer / untyped_storage bytes
- Metadata (shape, dtype) stored in Redis Hashes for fast introspection
- Redis Cluster-compatible key schema using hash tags
- Pipelined batch I/O for all get/set operations
- Nested TensorDict support via lightweight prefix-based views
- Pickle support for multi-process usage
- from_dict() factory, to_local() / to_tensordict() materialization
- CI: install redis package and start redis-server before tests