### PR TITLE
[Fix] Per-element non-tensor indexing and empty-store writes in TensorDictStore

### DIFF
--- a/tensordict/store/_store.py
+++ b/tensordict/store/_store.py
@@ -706,9 +706,7 @@ class TensorDictStore(TensorDictBase):
         if self._keys_cache[0] is not None:
             self._keys_cache[0].add(key_path)
 
-    async def _aset_non_tensor_at(
-        self, key_path: str, value: Any, idx: int | slice
-    ):
+    async def _aset_non_tensor_at(self, key_path: str, value: Any, idx: int | slice):
         """Read-modify-write a single element of a batched non-tensor key.
 
         On the first per-element write the storage format is promoted from a
@@ -763,7 +761,9 @@ class TensorDictStore(TensorDictBase):
         When the metadata cache already contains ``(shape, dtype)`` for this
         key, only a single ``GET`` is issued (no ``HGETALL``).
         """
-        cached = self._meta_cache.get(key_path) if self._meta_cache is not None else None
+        cached = (
+            self._meta_cache.get(key_path) if self._meta_cache is not None else None
+        )
         if cached is not None:
             # Fast path: metadata cached — single GET
             data = await self._client.get(self._data_key(key_path))
@@ -1919,16 +1919,12 @@ class TensorDictStore(TensorDictBase):
         # Filter to keys under our prefix
         if self._prefix:
             prefix_check = self._prefix + _KEY_SEP
-            leaf_kps = sorted(
-                k for k in all_keys if k.startswith(prefix_check)
-            )
+            leaf_kps = sorted(k for k in all_keys if k.startswith(prefix_check))
         else:
             leaf_kps = sorted(all_keys)
 
         if not leaf_kps:
-            return TensorDict(
-                {}, batch_size=self.batch_size, device=self.device
-            )
+            return TensorDict({}, batch_size=self.batch_size, device=self.device)
 
         result_map = self._run_sync(self._aget_batch_tensors(leaf_kps))
 

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -1298,9 +1298,7 @@ class TestNonTensorIndexing:
         td = TensorDict({"obs": torch.zeros(5, 4), "label": "a"}, [5])
         store = TensorDictStore.from_tensordict(td, **store_kwargs)
         try:
-            store[1:3] = TensorDict(
-                {"obs": torch.ones(2, 4), "label": "b"}, [2]
-            )
+            store[1:3] = TensorDict({"obs": torch.ones(2, 4), "label": "b"}, [2])
             assert store[0]["label"] == "a"
             assert store[1]["label"] == "b"
             assert store[2]["label"] == "b"
@@ -1327,9 +1325,7 @@ class TestNonTensorIndexing:
         an index must work."""
         store = TensorDictStore(batch_size=[4], **store_kwargs)
         try:
-            store[0] = TensorDict(
-                {"obs": torch.randn(3), "label": "hello"}, []
-            )
+            store[0] = TensorDict({"obs": torch.randn(3), "label": "hello"}, [])
             assert store[0]["obs"].shape == torch.Size([3])
             assert store[0]["label"] == "hello"
             assert store[1]["label"] is None  # uninitialised slot


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1585
* #1584
* #1583
* #1582
* #1581
* #1580
* #1579
* __->__ #1578
* #1577
* #1576
* #1575

Fix two issues reported in ISSUE.md:

1. Non-tensor data now supports per-element indexing. When store[i] is used
   on a key that holds non-tensor data (strings, etc.), the i-th element is
   returned instead of the full blob. Per-element writes (store[i] = td with
   non-tensor fields) promote the storage from a single-blob format to a
   json_array, enabling subsequent indexed reads and writes.

2. Writing to an empty TensorDictStore at an index (store[0] = td) no longer
   raises KeyError. The store auto-creates zero-initialised tensors with the
   correct shape before proceeding with the indexed write.

Co-authored-by: Cursor <cursoragent@cursor.com>