### PR TITLE
[CI] Add @tensordictbot PR management bot

### DIFF
--- a/.github/tensordictbot/README.md
+++ b/.github/tensordictbot/README.md
@@ -1,0 +1,120 @@
+# @tensordictbot
+
+A GitHub bot for managing Pull Requests in the **tensordict** repository.
+Inspired by PyTorch's [@pytorchbot](https://github.com/pytorch/pytorch/wiki/Bot-commands).
+
+## How it works
+
+`@tensordictbot` is powered by a GitHub Actions workflow (`.github/workflows/tensordictbot.yml`)
+that triggers on PR comments containing `@tensordictbot`. A Python script
+(`.github/tensordictbot/tensordictbot.py`) parses the command and executes the appropriate
+action.
+
+## Usage
+
+Add a comment on any PR starting with `@tensordictbot` followed by a command:
+
+```
+@tensordictbot <command> [options]
+```
+
+### Commands
+
+#### `merge`
+
+Merge a PR. If the PR was created with **ghstack**, the bot uses `ghstack land`;
+otherwise it performs a squash merge via `gh pr merge --squash`.
+
+```
+@tensordictbot merge [-f MESSAGE]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` `MESSAGE` | Force merge with a reason. Bypasses the approval check and uses `--admin` for non-ghstack PRs. |
+
+**Examples:**
+
+```
+@tensordictbot merge
+@tensordictbot merge -f 'Trivial doc fix, tests passing'
+```
+
+**Requirements:**
+- The commenter must have **write** (or higher) permission on the repository.
+- The PR must be **approved** unless `-f` is used.
+- **Admins and maintainers** can merge without approval (the approval gate is
+  skipped automatically).
+
+#### `rebase`
+
+Rebase the PR branch onto a target branch (default: `main`).
+
+```
+@tensordictbot rebase [-b BRANCH]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-b`, `--branch` `BRANCH` | Target branch to rebase onto (default: `main`). |
+
+**Examples:**
+
+```
+@tensordictbot rebase
+@tensordictbot rebase -b release/0.6
+```
+
+**Requirements:**
+- The commenter must have **write** (or higher) permission on the repository.
+
+#### `help`
+
+Display the help message with all available commands.
+
+```
+@tensordictbot help
+```
+
+## Permissions
+
+All commands require the commenter to have **write** access to the repository.
+This prevents external contributors from triggering merges or rebases. The bot
+checks permissions via the GitHub API before executing any action.
+
+## Architecture
+
+```
+.github/
+├── tensordictbot/
+│   ├── tensordictbot.py   # Command parser and handler
+│   └── README.md          # This file
+└── workflows/
+    └── tensordictbot.yml  # GitHub Actions workflow (issue_comment trigger)
+```
+
+The workflow:
+
+1. **Trigger**: An `issue_comment` event fires when someone comments on a PR.
+2. **Filter**: The job only runs if the comment is on a PR and contains `@tensordictbot`.
+3. **Parse**: `tensordictbot.py` reads the GitHub event payload, extracts the command
+   line from the comment, and parses it with `argparse`.
+4. **Validate**: The bot checks that the commenter has write permission and that
+   the PR meets any required conditions (e.g., approval status for merge).
+5. **Execute**: The appropriate handler runs (`ghstack land`, `gh pr merge`,
+   `git rebase`, etc.) and posts status comments back on the PR.
+
+## Adding new commands
+
+1. Add a handler function `cmd_<name>(ctx, args)` in `tensordictbot.py`.
+2. Register a subparser in `build_parser()`.
+3. Add the handler to the `COMMAND_HANDLERS` dict.
+4. Update `HELP_TEXT` and this README.
+
+## Secrets and tokens
+
+The bot uses `GITHUB_TOKEN` (automatically provided by GitHub Actions) for all
+API calls. No additional secrets are required for basic operation.
+
+For `ghstack land`, the token is passed via `GH_TOKEN` which `ghstack` picks up
+automatically.

--- a/.github/tensordictbot/tensordictbot.py
+++ b/.github/tensordictbot/tensordictbot.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""tensordictbot - A GitHub bot for managing PRs in the tensordict repository.
+
+Triggered by PR comments starting with ``@tensordictbot``. Supports commands:
+  - merge: Merge a PR (or ghstack) using ghstack land or gh pr merge
+  - rebase: Rebase a PR onto a target branch
+
+Inspired by PyTorch's @pytorchbot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def gh(*args: str, **kwargs) -> subprocess.CompletedProcess:
+    """Run a ``gh`` CLI command and return the result."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+
+
+def git(*args: str, **kwargs) -> subprocess.CompletedProcess:
+    """Run a ``git`` command and return the result."""
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+
+
+def post_comment(repo: str, pr_number: int, body: str) -> None:
+    """Post a comment on the given PR."""
+    gh("pr", "comment", str(pr_number), "--repo", repo, "--body", body)
+
+
+def react_to_comment(repo: str, comment_id: int, reaction: str) -> None:
+    """Add a reaction to a comment."""
+    try:
+        gh(
+            "api",
+            f"repos/{repo}/issues/comments/{comment_id}/reactions",
+            "-f",
+            f"content={reaction}",
+            "--silent",
+        )
+    except subprocess.CalledProcessError:
+        pass
+
+
+def get_pr_info(repo: str, pr_number: int) -> dict:
+    """Fetch PR metadata via ``gh``."""
+    result = gh(
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "headRefName,baseRefName,author,title,url,labels,mergeable,reviewDecision",
+    )
+    return json.loads(result.stdout)
+
+
+def get_permission(repo: str, username: str) -> str | None:
+    """Return the permission level of *username* on *repo*, or ``None`` on error."""
+    try:
+        result = gh(
+            "api",
+            f"repos/{repo}/collaborators/{username}/permission",
+        )
+        data = json.loads(result.stdout)
+        return data.get("permission")
+    except subprocess.CalledProcessError:
+        return None
+
+
+def check_write_permission(repo: str, username: str) -> bool:
+    """Return True if *username* has write (or higher) permission on *repo*."""
+    return get_permission(repo, username) in ("admin", "maintain", "write")
+
+
+def check_admin_permission(repo: str, username: str) -> bool:
+    """Return True if *username* has admin or maintain permission on *repo*."""
+    return get_permission(repo, username) in ("admin", "maintain")
+
+
+def is_ghstack_pr(head_branch: str) -> bool:
+    """Detect whether the PR was created by ghstack."""
+    return bool(re.match(r"^gh/[^/]+/\d+/head$", head_branch))
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CommandContext:
+    repo: str
+    pr_number: int
+    comment_id: int
+    comment_author: str
+    pr_info: dict = field(default_factory=dict)
+
+
+def cmd_merge(ctx: CommandContext, args: argparse.Namespace) -> None:
+    """Handle ``@tensordictbot merge``."""
+    pr = ctx.pr_info
+    head = pr["headRefName"]
+
+    if not check_write_permission(ctx.repo, ctx.comment_author):
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"@{ctx.comment_author} you don't have write permission on this repository. "
+            "Only collaborators with write access can merge PRs.",
+        )
+        return
+
+    is_admin = check_admin_permission(ctx.repo, ctx.comment_author)
+    if not args.force and not is_admin:
+        decision = pr.get("reviewDecision", "")
+        if decision != "APPROVED":
+            post_comment(
+                ctx.repo,
+                ctx.pr_number,
+                f"@{ctx.comment_author} this PR has not been approved yet "
+                f"(current status: **{decision or 'REVIEW_REQUIRED'}**). "
+                "Use `@tensordictbot merge -f 'reason'` to force merge.",
+            )
+            return
+
+    if is_ghstack_pr(head):
+        _merge_ghstack(ctx, args)
+    else:
+        _merge_regular(ctx, args)
+
+
+def _merge_ghstack(ctx: CommandContext, args: argparse.Namespace) -> None:
+    """Merge a ghstack PR using ``ghstack land``."""
+    pr = ctx.pr_info
+    url = pr["url"]
+
+    post_comment(
+        ctx.repo,
+        ctx.pr_number,
+        f"Merging ghstack PR via `ghstack land` (requested by @{ctx.comment_author}).\n\n"
+        + (f"Force reason: {args.force}\n" if args.force else ""),
+    )
+
+    try:
+        subprocess.run(
+            ["ghstack", "land", url],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        post_comment(ctx.repo, ctx.pr_number, "ghstack land completed successfully.")
+    except subprocess.CalledProcessError as exc:
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"ghstack land **failed**.\n\n```\n{exc.stderr or exc.stdout}\n```",
+        )
+        sys.exit(1)
+
+
+def _merge_regular(ctx: CommandContext, args: argparse.Namespace) -> None:
+    """Merge a regular (non-ghstack) PR using ``gh pr merge``."""
+    merge_args = [
+        "pr",
+        "merge",
+        str(ctx.pr_number),
+        "--repo",
+        ctx.repo,
+        "--squash",
+        "--delete-branch",
+    ]
+
+    msg_parts = [f"Merging PR (requested by @{ctx.comment_author})."]
+    if args.force:
+        msg_parts.append(f"Force reason: {args.force}")
+        merge_args.append("--admin")
+
+    post_comment(ctx.repo, ctx.pr_number, "\n".join(msg_parts))
+
+    try:
+        gh(*merge_args)
+        post_comment(ctx.repo, ctx.pr_number, "PR merged successfully.")
+    except subprocess.CalledProcessError as exc:
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"Merge **failed**.\n\n```\n{exc.stderr or exc.stdout}\n```",
+        )
+        sys.exit(1)
+
+
+def cmd_rebase(ctx: CommandContext, args: argparse.Namespace) -> None:
+    """Handle ``@tensordictbot rebase``."""
+    pr = ctx.pr_info
+    head = pr["headRefName"]
+    target_branch = args.branch
+
+    if not check_write_permission(ctx.repo, ctx.comment_author):
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"@{ctx.comment_author} you don't have write permission on this repository. "
+            "Only collaborators with write access can rebase PRs.",
+        )
+        return
+
+    post_comment(
+        ctx.repo,
+        ctx.pr_number,
+        f"Rebasing `{head}` onto `{target_branch}` (requested by @{ctx.comment_author}).",
+    )
+
+    try:
+        git("fetch", "origin", target_branch)
+        git("fetch", "origin", head)
+        git("checkout", head)
+        git("rebase", f"origin/{target_branch}")
+        git("push", "origin", head, "--force-with-lease")
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"Rebase onto `{target_branch}` completed successfully.",
+        )
+    except subprocess.CalledProcessError as exc:
+        try:
+            git("rebase", "--abort")
+        except subprocess.CalledProcessError:
+            pass
+        post_comment(
+            ctx.repo,
+            ctx.pr_number,
+            f"Rebase **failed**.\n\n```\n{exc.stderr or exc.stdout}\n```",
+        )
+        sys.exit(1)
+
+
+def cmd_help(ctx: CommandContext, _args: argparse.Namespace) -> None:
+    """Handle ``@tensordictbot help``."""
+    post_comment(ctx.repo, ctx.pr_number, HELP_TEXT)
+
+
+# ---------------------------------------------------------------------------
+# CLI parser
+# ---------------------------------------------------------------------------
+
+HELP_TEXT = """\
+## @tensordictbot Help
+
+```
+usage: @tensordictbot {merge,rebase,help}
+```
+
+### `merge`
+Merge a PR. For ghstack PRs, uses `ghstack land`; otherwise uses `gh pr merge --squash`.
+
+```
+@tensordictbot merge [-f MESSAGE]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force merge with a reason (bypasses approval check, uses `--admin`) |
+
+> **Note:** Repository admins and maintainers can merge without approval. The
+> approval gate only applies to regular collaborators with write access.
+
+### `rebase`
+Rebase the PR branch onto a target branch.
+
+```
+@tensordictbot rebase [-b BRANCH]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-b`, `--branch` | Target branch (default: `main`) |
+
+### `help`
+Show this help message.
+
+```
+@tensordictbot help
+```
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="@tensordictbot", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+
+    merge_p = sub.add_parser("merge", add_help=False)
+    merge_p.add_argument(
+        "-f",
+        "--force",
+        type=str,
+        default=None,
+        help="Force merge with a reason (bypasses approval gate)",
+    )
+
+    rebase_p = sub.add_parser("rebase", add_help=False)
+    rebase_p.add_argument(
+        "-b",
+        "--branch",
+        type=str,
+        default="main",
+        help="Branch to rebase onto (default: main)",
+    )
+
+    sub.add_parser("help", add_help=False)
+
+    return parser
+
+
+COMMAND_HANDLERS = {
+    "merge": cmd_merge,
+    "rebase": cmd_rebase,
+    "help": cmd_help,
+}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_command(comment_body: str) -> list[str] | None:
+    """Extract the @tensordictbot command tokens from a comment body.
+
+    Scans for the first line that starts with ``@tensordictbot`` (ignoring
+    leading whitespace) and returns the tokens after ``@tensordictbot``.
+    """
+    for line in comment_body.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("@tensordictbot"):
+            rest = stripped[len("@tensordictbot") :].strip()
+            if not rest:
+                return []
+            return rest.split()
+    return None
+
+
+def main() -> None:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        sys.stderr.write(
+            "GITHUB_EVENT_PATH not set -- are you running inside GitHub Actions?\n"
+        )
+        sys.exit(1)
+
+    with open(event_path) as f:
+        event = json.load(f)
+
+    repo = os.environ["GITHUB_REPOSITORY"]
+
+    comment_body = event["comment"]["body"]
+    comment_id = event["comment"]["id"]
+    comment_author = event["comment"]["user"]["login"]
+    pr_number = event["issue"]["number"]
+
+    tokens = parse_command(comment_body)
+    if tokens is None:
+        return
+
+    react_to_comment(repo, comment_id, "+1")
+
+    parser = build_parser()
+
+    if not tokens:
+        ctx = CommandContext(
+            repo=repo,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            comment_author=comment_author,
+        )
+        cmd_help(ctx, argparse.Namespace())
+        return
+
+    try:
+        args = parser.parse_args(tokens)
+    except SystemExit:
+        ctx = CommandContext(
+            repo=repo,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            comment_author=comment_author,
+        )
+        post_comment(
+            repo,
+            pr_number,
+            f"@{comment_author} I couldn't parse that command. "
+            f"Run `@tensordictbot help` to see available commands.\n\n"
+            f"Input: `@tensordictbot {' '.join(tokens)}`",
+        )
+        return
+
+    handler = COMMAND_HANDLERS.get(args.command)
+    if handler is None:
+        ctx = CommandContext(
+            repo=repo,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            comment_author=comment_author,
+        )
+        cmd_help(ctx, args)
+        return
+
+    pr_info = get_pr_info(repo, pr_number)
+
+    ctx = CommandContext(
+        repo=repo,
+        pr_number=pr_number,
+        comment_id=comment_id,
+        comment_author=comment_author,
+        pr_info=pr_info,
+    )
+
+    handler(ctx, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/tensordictbot.yml
+++ b/.github/workflows/tensordictbot.yml
@@ -1,0 +1,54 @@
+# @tensordictbot - PR management bot for tensordict
+#
+# Triggered by PR comments starting with `@tensordictbot`.
+# See .github/tensordictbot/README.md for full documentation.
+#
+# Commands:
+#   @tensordictbot merge [-f 'reason']   Merge a PR (ghstack land or squash merge)
+#   @tensordictbot rebase [-b BRANCH]    Rebase PR onto a branch (default: main)
+#   @tensordictbot help                  Show available commands
+
+name: TensorDictBot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  tensordictbot:
+    # Only run on PR comments (not issue comments) that mention @tensordictbot
+    if: >-
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@tensordictbot')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history needed for rebase operations
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ghstack
+        run: pip install ghstack
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run tensordictbot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python .github/tensordictbot/tensordictbot.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1597
* #1596
* __->__ #1595

Add a GitHub bot triggered by PR comments starting with @tensordictbot.
Supports merge (ghstack land or squash merge), rebase, and help commands.
Inspired by TorchRL's @torchrlbot.

Co-authored-by: Cursor <cursoragent@cursor.com>