### PR TITLE
[CI] Add intelligent PR labeling with file-based auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,73 @@
+# File-based auto-labeling configuration
+# Works with actions/labeler@v5
+# This complements pr-label.yml (title-based labeling) by detecting which files changed
+
+# =============================================================================
+# Core Module Labels
+# =============================================================================
+"nn":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/nn/**'
+      - 'test/test_nn.py'
+
+"store":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/store/**'
+      - 'test/test_store.py'
+
+"prototype":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/prototype/**'
+
+"tensorclass":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/tensorclass.py'
+      - 'tensordict/tensorclass.pyi'
+      - 'test/test_tensorclass.py'
+
+"memmap":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/memmap.py'
+      - 'test/test_memmap.py'
+
+"persistent":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/persistent.py'
+      - 'test/test_h5.py'
+
+"functional":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tensordict/functional.py'
+      - 'test/test_functorch.py'
+
+# =============================================================================
+# Documentation & CI
+# =============================================================================
+"Documentation":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
+
+"CI":
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
+
+"Benchmarks":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'benchmarks/**'
+
+"Test":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'test/**'

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,31 @@
+# Automatically add labels to PRs based on which files changed
+#
+# This complements pr-label.yml (title-based labeling):
+# - pr-label.yml: Labels based on PR title prefix ([BugFix], [Feature], etc.)
+# - auto-labeler.yml: Labels based on which files/directories changed
+#
+# Together they provide complete PR categorization:
+# - Title-based labels capture the INTENT (bug fix, feature, etc.)
+# - File-based labels capture the SCOPE (which components changed)
+#------------------------------------------------------------
+
+name: Auto Label PR (File-Based)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Apply labels based on changed files
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          # Don't remove labels that aren't in the config
+          # This preserves manually-added labels and title-based labels from pr-label.yml
+          sync-labels: false

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,16 +1,31 @@
 # Automatically add a label to PRs based on the [Label] prefix in the title
 #
 # Usage:
-#  - PR title must start with [Label] where Label is the desired label
-#  - Example: "[Bug] Fix memory leak" will add the "Bug" label
-#  - Fails if no [Label] prefix is found
+#   - PR title must start with a [Label] prefix in brackets
+#   - Example: "[BugFix] Fix memory leak" will add the "BugFix" label
+#   - Fails if no valid prefix is found
+#   - Labels are ONLY ADDED, never removed (preserves manual labels)
+#
+# Supported prefixes (supports common variations):
+#   - [BugFix], [Bugfix], [bugfix] -> BugFix
+#   - [Feature], [Features] -> Feature
+#   - [Doc], [Docs], [Documentation] -> Documentation
+#   - [Refactor], [Refactoring] -> Refactor
+#   - [CI], [ci] -> CI
+#   - [Test], [Tests] -> Test
+#   - [Compile], [compile] -> Compile
+#   - [Performance], [Perf] -> Perf
+#   - [Deprecation], [Deprecated] -> Deprecation
+#   - [Setup], [setup] -> Setup
 #------------------------------------------------------------
 
 name: PR Label
 
 on:
-  pull_request:
-    types: [opened, edited]
+  # Using pull_request_target to have write access for PRs from forks
+  # This is safe because we only read PR metadata (title), not code from the fork
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   add-label:
@@ -27,41 +42,97 @@ jobs:
         run: |
           set -euo pipefail
 
+          post_help_comment() {
+            local reason="$1"
+            local current_title="$2"
+            cat > /tmp/pr_comment.md << 'COMMENT_EOF'
+          ## PR Title Label Error
+
+          REASON_PLACEHOLDER
+
+          **Current title:** `TITLE_PLACEHOLDER`
+
+          ### Supported Prefixes
+
+          Your PR title must start with **exactly** one of these prefixes:
+
+          | Prefix | Label Applied | Example |
+          |--------|---------------|---------|
+          | `[BugFix]` | BugFix | `[BugFix] Fix memory leak in TensorDict` |
+          | `[Feature]` | Feature | `[Feature] Add new storage backend` |
+          | `[Doc]` or `[Docs]` | Documentation | `[Doc] Update installation guide` |
+          | `[Refactor]` | Refactor | `[Refactor] Clean up module imports` |
+          | `[CI]` | CI | `[CI] Fix workflow permissions` |
+          | `[Test]` or `[Tests]` | Test | `[Test] Add unit tests for nn module` |
+          | `[Compile]` | Compile | `[Compile] Fix torch.compile issue` |
+          | `[Performance]` or `[Perf]` | Perf | `[Perf] Optimize tensor operations` |
+          | `[Deprecation]` | Deprecation | `[Deprecation] Mark old function` |
+          | `[Setup]` | Setup | `[Setup] Update build configuration` |
+
+          **Note:** Common variations like singular/plural are supported (e.g., `[Doc]` or `[Docs]`).
+          COMMENT_EOF
+            sed -i 's/^ *//' /tmp/pr_comment.md
+            sed -i "s/REASON_PLACEHOLDER/$reason/" /tmp/pr_comment.md
+            sed -i "s|TITLE_PLACEHOLDER|$current_title|" /tmp/pr_comment.md
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/pr_comment.md
+          }
+
           echo "PR Title: $PR_TITLE"
 
           # Check if title starts with [...]
           if [[ ! "$PR_TITLE" =~ ^\[([^\]]+)\] ]]; then
             echo "::error::PR title must start with [Label]. Got: '$PR_TITLE'"
+            post_help_comment "PR title must start with a label prefix in brackets (e.g., \`[BugFix]\`)." "$PR_TITLE"
             exit 1
           fi
 
-          # Extract the label
-          LABEL="${BASH_REMATCH[1]}"
+          # Extract the prefix
+          PREFIX="${BASH_REMATCH[1]}"
 
-          # Check if label is empty
-          if [[ -z "$LABEL" ]]; then
-            echo "::error::Label inside brackets cannot be empty"
-            exit 1
-          fi
+          echo "Extracted prefix: $PREFIX"
 
-          echo "Extracted label: $LABEL"
+          # Map prefixes to GitHub label names (supports common variations)
+          case "$PREFIX" in
+            BugFix|Bugfix|bugfix)
+              LABEL="BugFix"
+              ;;
+            Feature|Features|feature|features)
+              LABEL="Feature"
+              ;;
+            Doc|Docs|Documentation|doc|docs)
+              LABEL="Documentation"
+              ;;
+            Refactor|Refactoring|refactor|refactoring)
+              LABEL="Refactor"
+              ;;
+            CI|ci)
+              LABEL="CI"
+              ;;
+            Test|Tests|test|tests)
+              LABEL="Test"
+              ;;
+            Compile|compile)
+              LABEL="Compile"
+              ;;
+            Performance|Perf|performance|perf)
+              LABEL="Perf"
+              ;;
+            Deprecation|Deprecated|deprecation|deprecated)
+              LABEL="Deprecation"
+              ;;
+            Setup|setup)
+              LABEL="Setup"
+              ;;
+            *)
+              echo "::error::Unknown or invalid prefix '[$PREFIX]'."
+              post_help_comment "Unknown or invalid prefix \`[$PREFIX]\`." "$PR_TITLE"
+              exit 1
+              ;;
+          esac
 
-          # Validate against accepted labels
-          ACCEPTED_LABELS="BugFix CI Compile Deprecation Docs Feature Perf Refactor Setup Test"
-          FOUND=0
-          for ACCEPTED in $ACCEPTED_LABELS; do
-            if [[ "$LABEL" == "$ACCEPTED" ]]; then
-              FOUND=1
-              break
-            fi
-          done
+          echo "Mapped to label: $LABEL"
 
-          if [[ "$FOUND" -eq 0 ]]; then
-            echo "::error::Label '$LABEL' is not in the accepted list: $ACCEPTED_LABELS"
-            exit 1
-          fi
-
-          # Add the label to the PR
+          # Add the label to the PR (never remove existing labels)
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
 
           echo "Successfully added label '$LABEL' to PR #$PR_NUMBER"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1597
* __->__ #1596
* #1595

Upgrade pr-label.yml with plural/singular/case-insensitive prefix
mapping (e.g. [Doc], [Docs], [Documentation] all map to Documentation)
and helpful error comments when the prefix is missing or invalid.
Switch to pull_request_target for fork compatibility.

Add file-based auto-labeling via actions/labeler@v5 to automatically
tag PRs based on which directories changed (nn, store, tensorclass,
Documentation, CI, Benchmarks, etc.).

Co-authored-by: Cursor <cursoragent@cursor.com>