### PR TITLE
[BugFix] Fix replace() recompiles under torch.compile

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8381,6 +8381,13 @@ class TensorDictBase(MutableMapping, TensorCollection):
             and the kwargs are empty, ``self`` is returned.
 
         """
+        if is_compiling() and not args:
+            if not kwargs:
+                return self
+            result = self.copy()
+            for k, v in kwargs.items():
+                result[k] = v
+            return result
         if args:
             if len(args) > 1:
                 raise RuntimeError(


### PR DESCRIPTION
## Summary
- Fix `TensorDictBase.replace(**kwargs)` causing O(N) Dynamo recompiles where N = number of unique kwarg key patterns across call sites
- Root cause: `dict.update(kwargs)` installs `DICT_KEYS_MATCH` guards on the kwargs dict; each call site with different kwargs keys triggers a recompile
- Under `is_compiling()`, the new path avoids intermediate dict creation and sets each key-value pair individually via `result[k] = v`
- Eager path is completely unchanged

## Test plan
- [x] New `test_td_replace_no_recompile` test: 10 distinct kwarg patterns with `fullgraph=True` (zero graph breaks)
- [x] Existing `test_tc_shadow_replace` still passes (no regression)
- [x] Full `TestTC` and `TestTD` compile suites pass

Made with [Cursor](https://cursor.com)