### PR TITLE
[Fix] Fix auto_batch_size regression: NonTensorStack batch dimensions not detected

### DIFF
--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1497,9 +1497,7 @@ def _set_max_batch_size(
     """Updates a tensordict with its maximum batch size."""
     from tensordict.base import _is_tensor_collection
 
-    # Exclude pass-through values (UnbatchedTensor, NonTensorData, MetaData) from batch size computation
-    # They will adopt whatever batch size is determined by regular tensors
-    tensor_data = [val for val in source.values() if not _pass_through(val)]
+    tensor_data = [val for val in source.values() if not _is_unbatched(val)]
 
     for val in tensor_data:
         if _is_tensor_collection(type(val)):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -14157,6 +14157,15 @@ class TestUnbatchedTensor:
         assert td.unflatten_keys(separator="_")["c", "d"] is td["c_d"]
         assert td.unflatten_keys(separator="_").flatten_keys()["c.d"] is td["c_d"]
 
+    def test_auto_batch_size_nontensor_not_excluded(self):
+        td = TensorDict.from_dict(
+            {"query": ["str1", "str2", "str3", "str4"]},
+            auto_batch_size=True,
+            batch_dims=1,
+        )
+        assert td.batch_size == torch.Size([4])
+        assert "query" in td.keys()
+
 
 def _to_float(td, td_name, tmpdir):
     if hasattr(td, "_source"):


### PR DESCRIPTION
## Summary

- Fix regression introduced by #1544 where `_set_max_batch_size` unconditionally excluded all `_pass_through` values (including `NonTensorStack`/`NonTensorData`) from batch size computation. Now uses `_is_unbatched` to only exclude `UnbatchedTensor`, which is the correct behavior.
- Add regression test verifying `TensorDict.from_dict` with list data and `auto_batch_size=True` correctly detects batch dimensions from `NonTensorStack`.

Fixes #1608

## Test plan

- [x] `test_auto_batch_size_nontensor_not_excluded` — verifies `from_dict({"query": [...]}, auto_batch_size=True, batch_dims=1)` produces `batch_size=[4]`
- [x] Existing `test_auto_batch_size` for `UnbatchedTensor` still passes (UnbatchedTensor excluded from batch inference)
- [x] 740 `auto_batch_size` and `non_tensor` related tests pass with 0 failures


Made with [Cursor](https://cursor.com)