### PR TITLE
[Doc] Link README features to tutorials, add functional programming tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Docs](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=tensordict)][#docs-package]
-[![Discord](https://dcbadge.vercel.app/api/server/tz3TgTAe3D)](https://discord.gg/tz3TgTAe3D)
+[![Discord](https://img.shields.io/badge/Discord-blue?logo=discord&logoColor=white)](https://discord.gg/tz3TgTAe3D)
 [![Python version](https://img.shields.io/pypi/pyversions/tensordict.svg)](https://www.python.org/downloads/)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)][#github-license]
 <a href="https://pypi.org/project/tensordict"><img src="https://img.shields.io/pypi/v/tensordict" alt="pypi version"></a>
 [![Downloads](https://static.pepy.tech/personalized-badge/tensordict?period=total&units=international_system&left_color=blue&right_color=orange&left_text=Downloads)][#pepy-package]
 [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/tensordict?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
 
-[#docs-package]: https://pytorch.github.io/tensordict/
-[#docs-package-benchmark]: https://pytorch.github.io/tensordict/dev/bench/
+[#docs-package]: https://docs.pytorch.org/tensordict/stable/
+[#docs-package-benchmark]: https://docs.pytorch.org/tensordict/stable/dev/bench/
 [#github-license]: https://github.com/pytorch/tensordict/blob/main/LICENSE
 [#pepy-package]: https://pepy.tech/project/tensordict
 [#conda-forge-package]: https://anaconda.org/conda-forge/tensordict
@@ -16,8 +16,8 @@
 
 TensorDict is a dictionary-like class that inherits properties from tensors,
 such as indexing, shape operations, casting to device or storage and many more.
-The code-base consists of two main components: [`TensorDict`](https://pytorch.github.io/tensordict/reference/generated/tensordict.TensorDict.html),
-a specialized dictionary for PyTorch tensors, and [`tensorclass`](https://pytorch.github.io/tensordict/reference/generated/tensordict.tensorclass.html),
+The code-base consists of two main components: [`TensorDict`](https://docs.pytorch.org/tensordict/stable/reference/generated/tensordict.TensorDict.html),
+a specialized dictionary for PyTorch tensors, and [`tensorclass`](https://docs.pytorch.org/tensordict/stable/reference/generated/tensordict.tensorclass.html),
 a dataclass for tensors.
 
 ```python
@@ -48,14 +48,23 @@ TensorDict makes your code-bases more _readable_, _compact_, _modular_ and _fast
 It abstracts away tailored operations, dispatching them on the leaves for you.
 
 - **Composability**: `TensorDict` generalizes `torch.Tensor` operations to collections of tensors.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_shapes.html)
 - **Speed**: asynchronous transfer to device, fast node-to-node communication through `consolidate`, compatible with `torch.compile`.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_memory.html)
 - **Shape operations**: indexing, slicing, concatenation, reshaping -- everything you can do with a tensor.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_slicing.html)
 - **Distributed / multiprocessed**: distribute TensorDict instances across workers, devices and machines.
+  [[doc]](https://docs.pytorch.org/tensordict/stable/distributed.html)
 - **Serialization** and memory-mapping for efficient checkpointing.
+  [[doc]](https://docs.pytorch.org/tensordict/stable/saving.html)
 - **Functional programming** and compatibility with `torch.vmap`.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/functional.html)
 - **Nesting**: nest TensorDict instances to create hierarchical structures.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_keys.html)
 - **Lazy preallocation**: preallocate memory without initializing tensors.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_preallocation.html)
 - **`@tensorclass`**: a specialized dataclass for `torch.Tensor`.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensorclass_fashion.html)
 
 ## Examples
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,7 @@ tensordict.nn
    :maxdepth: 1
 
    tutorials/tensordict_module
+   tutorials/functional
    tutorials/export
 
 Dataloading

--- a/tutorials/sphinx_tuto/functional.py
+++ b/tutorials/sphinx_tuto/functional.py
@@ -1,0 +1,107 @@
+"""
+Functional Programming with TensorDict
+=======================================
+**Author**: `Vincent Moens <https://github.com/vmoens>`_
+
+In this tutorial you will learn how to use :class:`~.TensorDict` for
+functional-style programming with :class:`~torch.nn.Module`, including
+parameter swapping, model ensembling with :func:`~torch.vmap`, and
+functional calls with :func:`~torch.func.functional_call`.
+"""
+
+##############################################################################
+# TensorDict as a parameter container
+# ------------------------------------
+#
+# :meth:`~.TensorDict.from_module` extracts the parameters of a module into a
+# nested :class:`~.TensorDict` whose structure mirrors the module hierarchy.
+
+# sphinx_gallery_start_ignore
+import warnings
+
+warnings.filterwarnings("ignore")
+# sphinx_gallery_end_ignore
+import torch
+import torch.nn as nn
+from tensordict import TensorDict
+
+module = nn.Sequential(nn.Linear(3, 4), nn.ReLU(), nn.Linear(4, 1))
+params = TensorDict.from_module(module)
+print(params)
+
+##############################################################################
+# The resulting :class:`~.TensorDict` holds the same
+# :class:`~torch.nn.Parameter` objects as the module. We can manipulate them
+# as a batch -- for example, zeroing all parameters at once:
+
+params_zero = params.detach().clone().zero_()
+print("All zeros:", (params_zero == 0).all())
+
+##############################################################################
+# Swapping parameters with a context manager
+# -------------------------------------------
+#
+# :meth:`~.TensorDict.to_module` temporarily replaces the parameters of a
+# module within a context manager. The original parameters are restored on
+# exit.
+
+x = torch.randn(5, 3)
+
+with params_zero.to_module(module):
+    y_zero = module(x)
+
+print("Output with zeroed params:", y_zero)
+assert (y_zero == 0).all()
+
+y_original = module(x)
+print("Output with original params:", y_original)
+assert not (y_original == 0).all()
+
+##############################################################################
+# Model ensembling with ``torch.vmap``
+# -------------------------------------
+#
+# Because :class:`~.TensorDict` supports batching and stacking, we can stack
+# multiple parameter configurations and use :func:`~torch.vmap` to run the
+# model across all of them in a single vectorized call.
+
+params_ones = params.detach().clone().apply_(lambda t: t.fill_(1.0))
+params_stack = torch.stack([params_zero, params_ones, params])
+
+print("Stacked params batch_size:", params_stack.batch_size)
+
+
+def call(x, td):
+    with td.to_module(module):
+        return module(x)
+
+
+x = torch.randn(3, 5, 3)
+y = torch.vmap(call)(x, params_stack)
+print("Output shape:", y.shape)
+
+assert (y[0] == 0).all()
+
+##############################################################################
+# Functional calls with ``torch.func``
+# --------------------------------------
+#
+# :func:`~torch.func.functional_call` works with the state-dict extracted
+# by :meth:`~.TensorDict.from_module`. Because ``from_module`` returns a
+# :class:`~.TensorDict` with the same structure as a state-dict, we can
+# convert it to a regular dict and pass it directly.
+
+from torch.func import functional_call
+
+flat_params = params.flatten_keys(".")
+state_dict = dict(flat_params.items())
+x = torch.randn(5, 3)
+y = functional_call(module, state_dict, x)
+print("functional_call output:", y.shape)
+
+##############################################################################
+# The combination of :meth:`~.TensorDict.from_module`,
+# :meth:`~.TensorDict.to_module`, and :func:`~torch.vmap` makes it
+# straightforward to do things like compute per-sample gradients, run
+# model ensembles, or implement meta-learning inner loops -- all without
+# leaving the standard PyTorch API.


### PR DESCRIPTION
## Summary

- Each bullet point in the README Key Features section now links to the corresponding tutorial or doc page.
- Added a new `tutorials/sphinx_tuto/functional.py` tutorial covering functional programming with TensorDict (`from_module`, `to_module` context manager, `vmap` ensembling, `functional_call`).
- Registered the new tutorial in `docs/source/index.rst`.

Feature → tutorial/doc mapping:
| Feature | Link |
|---------|------|
| Composability | `tensordict_shapes` tutorial |
| Speed | `tensordict_memory` tutorial |
| Shape operations | `tensordict_slicing` tutorial |
| Distributed | `distributed` doc page |
| Serialization | `saving` doc page |
| Functional programming | **new** `functional` tutorial |
| Nesting | `tensordict_keys` tutorial |
| Lazy preallocation | `tensordict_preallocation` tutorial |
| `@tensorclass` | `tensorclass_fashion` tutorial |

## Test plan
- [x] `python tutorials/sphinx_tuto/functional.py` runs without errors


Made with [Cursor](https://cursor.com)