### PR TITLE
[CI] Add pytorch-probot.yml for Dr. CI integration

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,0 +1,3 @@
+retryable_workflows:
+- Build M1
+- Wheels


### PR DESCRIPTION
Adds `.github/pytorch-probot.yml` so that the Dr. CI bot can post comments on PRs with:
- Links to the HUD dashboard for CI status
- Doc preview links (rendered docs built from the PR)
- CI failure summaries

This mirrors the config already present in `pytorch/rl` and other domain libraries.

**Companion PR needed**: `pytorch/test-infra` needs to add `"tensordict"` to:
1. `isDrCIEnabled()` in `torchci/lib/bot/utils.ts`
2. The matrix in `.github/workflows/update-drci-comments.yml`