### PR TITLE
[BugFix] Fix state_dict bugs: error message, params forwarding, detach

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -5991,7 +5991,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         for key, item in source.items():
             if not _is_tensor_collection(type(item)):
                 if not keep_vars:
-                    out[prefix + key] = item.detach().clone()
+                    out[prefix + key] = item.detach()
                 else:
                     out[prefix + key] = item
             else:
@@ -6002,7 +6002,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
             )
         if "__device" in out:
             raise KeyError(
-                "Cannot retrieve the state_dict of a TensorDict with `'__batch_size'` key"
+                "Cannot retrieve the state_dict of a TensorDict with `'__device'` key"
             )
         out[prefix + "__batch_size"] = source.batch_size
         out[prefix + "__device"] = source.device

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -1196,7 +1196,7 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
             yield self._apply_get_post_hook(v)
 
     def state_dict(
-        self, *args, destination=None, prefix="", keep_vars=False, flatten=True
+        self, destination=None, prefix="", keep_vars=False, flatten=True
     ):
         # flatten must be True by default to comply with module's state-dict API
         # since we want all params to be visible at root
@@ -1223,7 +1223,7 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
             TensorDict(state_dict_tensors, []).unflatten_keys(".")
         )
         state_dict.update(state_dict_tensors)
-        self.data.load_state_dict(state_dict, strict=True, assign=False)
+        self.data.load_state_dict(state_dict, strict=strict, assign=assign)
         return self
 
     def _load_from_state_dict(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1623
* #1622
* #1621
* #1620
* #1619
* __->__ #1618

----

- Fix wrong error message in TensorDictBase.state_dict: __device check
  was reporting __batch_size
- Forward strict/assign params in TensorDictParams.load_state_dict
  instead of hardcoding them
- Remove stray *args in TensorDictParams.state_dict signature
- Use detach() instead of detach().clone() in state_dict to match
  nn.Module behavior and reduce memory usage

Made-with: Cursor