### PR TITLE
[Refactor] Move state_dict metadata to _metadata attribute

### DIFF
--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -458,19 +458,30 @@ class UnbatchedTensor(TensorClass):
         """Returns the dtype of the underlying data tensor."""
         return self.data.dtype
 
-    def state_dict(self, destination=None, prefix="", keep_vars=False):
-        """Returns a state dict containing the data and batch_size."""
+    def state_dict(self, destination=None, prefix="", keep_vars=False, flatten=False):
+        """Returns a state dict containing the data and batch_size.
+
+        Metadata is stored in the ``_metadata`` attribute on the returned
+        OrderedDict, following the same convention as
+        :meth:`TensorDictBase.state_dict`.
+        """
         import collections
 
         out = collections.OrderedDict()
+        out._metadata = collections.OrderedDict()
         if not keep_vars:
-            out[prefix + "data"] = self.data.detach().clone()
+            out[prefix + "data"] = self.data.detach()
         else:
             out[prefix + "data"] = self.data
-        out[prefix + "__batch_size"] = self.batch_size
-        out[prefix + "__is_unbatched"] = True
+        out._metadata[""] = {
+            "batch_size": self.batch_size,
+            "is_unbatched": True,
+        }
         if destination is not None:
             destination.update(out)
+            if not hasattr(destination, "_metadata"):
+                destination._metadata = collections.OrderedDict()
+            destination._metadata.update(out._metadata)
             return destination
         return out
 
@@ -478,7 +489,11 @@ class UnbatchedTensor(TensorClass):
     def from_state_dict(cls, state_dict, prefix=""):
         """Creates an UnbatchedTensor from a state dict."""
         data = state_dict[prefix + "data"]
-        batch_size = state_dict[prefix + "__batch_size"]
+        _metadata = getattr(state_dict, "_metadata", None)
+        if _metadata is not None:
+            batch_size = _metadata.get("", {}).get("batch_size", torch.Size([]))
+        else:
+            batch_size = state_dict[prefix + "__batch_size"]
         result = cls(data)
         result.batch_size = batch_size
         return result
@@ -486,7 +501,11 @@ class UnbatchedTensor(TensorClass):
     def load_state_dict(self, state_dict, strict=True, assign=False):
         """Loads a state dict into the UnbatchedTensor."""
         data = state_dict.get("data")
-        batch_size = state_dict.get("__batch_size", self.batch_size)
+        _metadata = getattr(state_dict, "_metadata", None)
+        if _metadata is not None:
+            batch_size = _metadata.get("", {}).get("batch_size", self.batch_size)
+        else:
+            batch_size = state_dict.get("__batch_size", self.batch_size)
         if data is not None:
             if assign:
                 self._tensordict.set("data", data)

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import collections
 import functools
 import inspect
 import re
@@ -1210,8 +1211,7 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
     def load_state_dict(
         self, state_dict: OrderedDict[str, Any], strict=True, assign=False
     ):
-        # The state-dict is presumably the result of a call to TensorDictParams.state_dict
-        # but can't be sure.
+        _metadata = getattr(state_dict, "_metadata", None)
 
         state_dict_tensors = {}
         state_dict = dict(state_dict)
@@ -1223,6 +1223,9 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
             TensorDict(state_dict_tensors, []).unflatten_keys(".")
         )
         state_dict.update(state_dict_tensors)
+        state_dict = collections.OrderedDict(state_dict)
+        if _metadata is not None:
+            state_dict._metadata = _metadata
         self.data.load_state_dict(state_dict, strict=strict, assign=assign)
         return self
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1623
* #1622
* #1621
* #1620
* __->__ #1619
* #1618

Store batch_size and device in a _metadata attribute on the returned
OrderedDict instead of polluting the data namespace with __batch_size
and __device sentinel keys. This follows the same convention as
torch.nn.Module.state_dict.

- state_dict() now sets out._metadata with batch_size/device per level
- load_state_dict() reads _metadata first, falls back to legacy
  __batch_size/__device keys, or preserves current values if neither
  is present (e.g. when called from nn.Module pipeline)
- UnbatchedTensor.state_dict() updated to use _metadata and accept
  flatten parameter
- TensorDictParams.load_state_dict() preserves _metadata through
  the unflatten conversion

Made-with: Cursor