### PR TITLE
[Refactor] Make state_dict flat by default, add auto-detection to load_state_dict

### DIFF
--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -458,7 +458,7 @@ class UnbatchedTensor(TensorClass):
         """Returns the dtype of the underlying data tensor."""
         return self.data.dtype
 
-    def state_dict(self, destination=None, prefix="", keep_vars=False, flatten=False):
+    def state_dict(self, destination=None, prefix="", keep_vars=False, flatten=True):
         """Returns a state dict containing the data and batch_size.
 
         Metadata is stored in the ``_metadata`` attribute on the returned

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -2266,22 +2266,23 @@ class TestTensorClass:
         )
 
         sd = tc.state_dict()
-        # Unexpected top-level key
+        # Unexpected key in flat state_dict
         sd["a"] = None
         with pytest.raises(KeyError, match="Key 'a' wasn't expected in the state-dict"):
             tc.load_state_dict(sd)
         del sd["a"]
-        # Unexpected key in nested tensorclass state_dict
-        sd["y"]["a"] = None
-        with pytest.raises(
-            (KeyError, RuntimeError),
-        ):
-            tc.load_state_dict(sd)
-        del sd["y"]["a"]
         # Unexpected key in _metadata non_tensor data
         sd._metadata[""]["_non_tensor"]["a"] = None
         with pytest.raises(KeyError, match="Key 'a' wasn't expected in the state-dict"):
             tc.load_state_dict(sd)
+        del sd._metadata[""]["_non_tensor"]["a"]
+        # Nested format: unexpected key in nested tensorclass state_dict
+        sd_nested = tc.state_dict(flatten=False)
+        sd_nested["y"]["a"] = None
+        with pytest.raises(
+            (KeyError, RuntimeError),
+        ):
+            tc.load_state_dict(sd_nested)
 
     def test_tensorclass_get_at(self):
         @tensorclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1623
* #1622
* __->__ #1621
* #1620
* #1619
* #1618

state_dict() now defaults to flatten=True, producing a flat OrderedDict
with dot-separated keys that matches nn.Module conventions. Metadata is
stored in _metadata keyed by prefix. load_state_dict() auto-detects the
format (flat, nested, or legacy) and handles unflattening transparently.

Made-with: Cursor