### PR TITLE
[Refactor] Unify state_dict/load_state_dict signatures across all subclasses

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -537,7 +537,7 @@ class LazyStackedTensorDict(TensorDictBase):
         destination=None,
         prefix="",
         keep_vars=False,
-        flatten=False,
+        flatten=True,
     ) -> OrderedDict[str, Any]: ...
 
     @_fails_exclusive_keys

--- a/tensordict/_tensorcollection.pyi
+++ b/tensordict/_tensorcollection.pyi
@@ -771,14 +771,14 @@ class TensorCollection:
         destination: Incomplete | None = None,
         prefix: str = "",
         keep_vars: bool = False,
-        flatten: bool = False,
+        flatten: bool = True,
     ) -> OrderedDict[str, Any]: ...
     def load_state_dict(
         self,
         state_dict: OrderedDict[str, Any],
         strict: bool = True,
         assign: bool = False,
-        from_flatten: bool = False,
+        from_flatten: bool | None = None,
     ) -> Self: ...
     def is_shared(self) -> bool: ...
     def is_memmap(self) -> bool: ...

--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -498,7 +498,7 @@ class UnbatchedTensor(TensorClass):
         result.batch_size = batch_size
         return result
 
-    def load_state_dict(self, state_dict, strict=True, assign=False):
+    def load_state_dict(self, state_dict, strict=True, assign=False, from_flatten=None):
         """Loads a state dict into the UnbatchedTensor."""
         data = state_dict.get("data")
         _metadata = getattr(state_dict, "_metadata", None)

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -1209,7 +1209,11 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
         )
 
     def load_state_dict(
-        self, state_dict: OrderedDict[str, Any], strict=True, assign=False
+        self,
+        state_dict: OrderedDict[str, Any],
+        strict=True,
+        assign=False,
+        from_flatten=None,
     ):
         _metadata = getattr(state_dict, "_metadata", None)
 
@@ -1226,7 +1230,9 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
         state_dict = collections.OrderedDict(state_dict)
         if _metadata is not None:
             state_dict._metadata = _metadata
-        self.data.load_state_dict(state_dict, strict=strict, assign=assign)
+        self.data.load_state_dict(
+            state_dict, strict=strict, assign=assign, from_flatten=from_flatten
+        )
         return self
 
     def _load_from_state_dict(

--- a/tensordict/tensorclass.pyi
+++ b/tensordict/tensorclass.pyi
@@ -749,14 +749,14 @@ class TensorClass:
         destination: Incomplete | None = None,
         prefix: str = "",
         keep_vars: bool = False,
-        flatten: bool = False,
+        flatten: bool = True,
     ) -> OrderedDict[str, Any]: ...
     def load_state_dict(
         self,
         state_dict: OrderedDict[str, Any],
         strict: bool = True,
         assign: bool = False,
-        from_flatten: bool = False,
+        from_flatten: bool | None = None,
     ) -> Self: ...
     def is_shared(self) -> bool: ...
     def is_memmap(self) -> bool: ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1623
* __->__ #1622
* #1621
* #1620
* #1619
* #1618

Align parameter names, defaults, and type stubs across TensorDictBase,
TensorClass, LazyStackedTensorDict, UnbatchedTensor, and TensorDictParams.
All state_dict defaults to flatten=True and load_state_dict accepts
from_flatten=None for auto-detection.

Made-with: Cursor