### PR TITLE
[DTensor] Add transfer plan computation for cross-mesh DTensor redistribution

### DIFF
--- a/tensordict/_dtensor.py
+++ b/tensordict/_dtensor.py
@@ -1,0 +1,433 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Private module for cross-mesh DTensor transfer utilities.
+
+Everything here is private (underscore-prefixed) and subject to change.
+The only public API surface is ``dtensor_send`` / ``dtensor_recv`` on
+``TensorDictBase``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import struct
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable, Sequence, TYPE_CHECKING
+
+import numpy as np
+import torch
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from tensordict._ucxx import TensorDictPipe
+
+_has_ucxx = importlib.util.find_spec("ucxx") is not None
+
+
+# ---------------------------------------------------------------------------
+# Placement helpers -- lightweight stand-ins so that compute_transfer_plan
+# can be tested without importing torch.distributed.
+# ---------------------------------------------------------------------------
+
+
+def _placement_is_shard(p) -> bool:
+    return hasattr(p, "dim") and not _placement_is_partial(p)
+
+
+def _placement_shard_dim(p) -> int:
+    return p.dim
+
+
+def _placement_is_replicate(p) -> bool:
+    return hasattr(p, "is_replicate") and p.is_replicate()
+
+
+def _placement_is_partial(p) -> bool:
+    return hasattr(p, "is_partial") and p.is_partial()
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ShardSpec:
+    """What a single rank holds, expressed as slices into the global tensor."""
+
+    rank: int
+    slices: tuple[slice, ...]
+
+
+@dataclass(frozen=True)
+class _ChunkTransfer:
+    """One point-to-point transfer instruction."""
+
+    src_rank: int
+    dst_rank: int
+    src_slices: tuple[slice, ...]
+    dst_slices: tuple[slice, ...]
+    global_slices: tuple[slice, ...]
+
+
+@dataclass
+class _TransferPlan:
+    """Complete plan for transferring one tensor between two sharding specs."""
+
+    global_shape: torch.Size
+    transfers: list[_ChunkTransfer] = field(default_factory=list)
+
+    def sends_for_rank(self, rank: int) -> list[_ChunkTransfer]:
+        return [t for t in self.transfers if t.src_rank == rank]
+
+    def recvs_for_rank(self, rank: int) -> list[_ChunkTransfer]:
+        return [t for t in self.transfers if t.dst_rank == rank]
+
+
+# ---------------------------------------------------------------------------
+# Slice arithmetic
+# ---------------------------------------------------------------------------
+
+
+def _chunk_slice(total_size: int, num_chunks: int, chunk_idx: int) -> slice:
+    """Return the slice for ``chunk_idx`` when splitting *total_size* into
+    *num_chunks* using ``torch.chunk`` semantics (last chunk may be smaller).
+    """
+    chunk_size = (total_size + num_chunks - 1) // num_chunks
+    start = chunk_idx * chunk_size
+    stop = min(start + chunk_size, total_size)
+    if start >= total_size:
+        return slice(0, 0)
+    return slice(start, stop)
+
+
+def _intersect_1d(a: slice, b: slice) -> slice | None:
+    """Intersect two *simple* slices (step=1, non-negative start/stop)."""
+    lo = max(a.start, b.start)
+    hi = min(a.stop, b.stop)
+    if lo >= hi:
+        return None
+    return slice(lo, hi)
+
+
+def _intersect_slices(
+    a: tuple[slice, ...], b: tuple[slice, ...]
+) -> tuple[slice, ...] | None:
+    """Intersect two tuples of per-dimension slices. Returns ``None`` if empty."""
+    result = []
+    for sa, sb in zip(a, b):
+        inter = _intersect_1d(sa, sb)
+        if inter is None:
+            return None
+        result.append(inter)
+    return tuple(result)
+
+
+def _slice_relative_to(inner: slice, outer: slice) -> slice:
+    """Express *inner* (global coords) relative to *outer* (also global)."""
+    return slice(inner.start - outer.start, inner.stop - outer.start)
+
+
+# ---------------------------------------------------------------------------
+# Core algorithm
+# ---------------------------------------------------------------------------
+
+
+def _compute_local_slices(
+    global_shape: Sequence[int],
+    mesh_shape: Sequence[int],
+    placements: Sequence,
+    rank_coords: Sequence[int],
+) -> tuple[slice, ...]:
+    """Compute the global-coordinate slices held by *rank_coords*.
+
+    Args:
+        global_shape: shape of the full logical tensor.
+        mesh_shape: shape of the device mesh (one int per mesh dim).
+        placements: one Placement per mesh dim.
+        rank_coords: coordinate of the rank in the mesh (one int per mesh dim).
+
+    Returns:
+        A tuple of slices (one per tensor dimension) in global coordinates.
+    """
+    ndim = len(global_shape)
+    slices = [slice(0, s) for s in global_shape]
+
+    for mesh_dim_idx, placement in enumerate(placements):
+        if _placement_is_shard(placement):
+            shard_dim = _placement_shard_dim(placement)
+            if shard_dim < 0:
+                shard_dim += ndim
+            num_chunks = mesh_shape[mesh_dim_idx]
+            chunk_idx = rank_coords[mesh_dim_idx]
+            current_dim_size = slices[shard_dim].stop - slices[shard_dim].start
+            chunk_sl = _chunk_slice(current_dim_size, num_chunks, chunk_idx)
+            base = slices[shard_dim].start
+            slices[shard_dim] = slice(base + chunk_sl.start, base + chunk_sl.stop)
+        # Replicate / Partial: slices stay as full range
+
+    return tuple(slices)
+
+
+def _compute_all_local_slices(
+    global_shape: Sequence[int],
+    mesh_shape: Sequence[int],
+    placements: Sequence,
+    rank_map: dict[tuple[int, ...], int] | None = None,
+) -> list[_ShardSpec]:
+    """Compute :class:`_ShardSpec` for every rank in the mesh.
+
+    Args:
+        global_shape: shape of the full logical tensor.
+        mesh_shape: shape of the device mesh.
+        placements: one Placement per mesh dim.
+        rank_map: optional mapping from mesh coordinates to global rank ids.
+            If *None*, ranks are numbered in row-major order.
+    """
+    specs: list[_ShardSpec] = []
+    ranges = [range(s) for s in mesh_shape]
+    for flat_idx, coords in enumerate(itertools.product(*ranges)):
+        rank = rank_map[coords] if rank_map is not None else flat_idx
+        slices = _compute_local_slices(global_shape, mesh_shape, placements, coords)
+        specs.append(_ShardSpec(rank=rank, slices=slices))
+    return specs
+
+
+def _deduplicate_src_specs(
+    src_specs: list[_ShardSpec],
+    placements: Sequence,
+    mesh_shape: Sequence[int],
+) -> list[_ShardSpec]:
+    """When src has Replicate or Partial dims, multiple ranks hold the same data.
+
+    Keep only one representative per unique slice (the one with the lowest rank)
+    to avoid redundant transfers.
+    """
+    has_replica = any(
+        _placement_is_replicate(p) or _placement_is_partial(p) for p in placements
+    )
+    if not has_replica:
+        return src_specs
+
+    seen: dict[tuple[slice, ...], _ShardSpec] = {}
+    for spec in src_specs:
+        key = spec.slices
+        if key not in seen or spec.rank < seen[key].rank:
+            seen[key] = spec
+    return list(seen.values())
+
+
+def _compute_transfer_plan(
+    global_shape: Sequence[int],
+    src_mesh_shape: Sequence[int],
+    src_placements: Sequence,
+    dst_mesh_shape: Sequence[int],
+    dst_placements: Sequence,
+    src_rank_map: dict[tuple[int, ...], int] | None = None,
+    dst_rank_map: dict[tuple[int, ...], int] | None = None,
+) -> _TransferPlan:
+    """Compute the optimal P2P transfer plan for one tensor.
+
+    This is pure computation -- no GPU, no distributed runtime needed.
+
+    Args:
+        global_shape: shape of the full logical tensor.
+        src_mesh_shape: shape of the source device mesh.
+        src_placements: placement per source mesh dim (Shard/Replicate/Partial).
+        dst_mesh_shape: shape of the destination device mesh.
+        dst_placements: placement per destination mesh dim.
+        src_rank_map: mesh-coords -> global rank for src. Row-major if None.
+        dst_rank_map: mesh-coords -> global rank for dst. Row-major if None.
+
+    Returns:
+        A :class:`_TransferPlan` describing the minimal set of P2P transfers.
+    """
+    global_shape = torch.Size(global_shape)
+
+    src_specs = _compute_all_local_slices(
+        global_shape, src_mesh_shape, src_placements, src_rank_map
+    )
+    dst_specs = _compute_all_local_slices(
+        global_shape, dst_mesh_shape, dst_placements, dst_rank_map
+    )
+
+    # Deduplicate replicated src specs
+    src_specs_dedup = _deduplicate_src_specs(
+        src_specs, src_placements, src_mesh_shape
+    )
+
+    plan = _TransferPlan(global_shape=global_shape)
+
+    for dst_spec in dst_specs:
+        for src_spec in src_specs_dedup:
+            overlap = _intersect_slices(src_spec.slices, dst_spec.slices)
+            if overlap is None:
+                continue
+            # Skip empty slices
+            if any(s.start >= s.stop for s in overlap):
+                continue
+
+            src_local = tuple(
+                _slice_relative_to(o, s) for o, s in zip(overlap, src_spec.slices)
+            )
+            dst_local = tuple(
+                _slice_relative_to(o, d) for o, d in zip(overlap, dst_spec.slices)
+            )
+
+            plan.transfers.append(
+                _ChunkTransfer(
+                    src_rank=src_spec.rank,
+                    dst_rank=dst_spec.rank,
+                    src_slices=src_local,
+                    dst_slices=dst_local,
+                    global_slices=overlap,
+                )
+            )
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Transport abstraction
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _TransportBackend(Protocol):
+    """Protocol for transport backends."""
+
+    def send_tensor(self, tensor: Tensor, dst: int, *, tag: int = 0) -> None: ...
+    def recv_tensor(self, tensor: Tensor, src: int, *, tag: int = 0) -> None: ...
+    def send_object(self, obj: Any, dst: int) -> None: ...
+    def recv_object(self, src: int) -> Any: ...
+
+
+class _TorchDistributedBackend:
+    """Transport backend using ``torch.distributed`` P2P primitives."""
+
+    def __init__(self, group=None):
+        self.group = group
+
+    def send_tensor(self, tensor: Tensor, dst: int, *, tag: int = 0) -> None:
+        from torch import distributed as dist
+
+        dist.send(tensor.contiguous(), dst=dst, tag=tag, group=self.group)
+
+    def recv_tensor(self, tensor: Tensor, src: int, *, tag: int = 0) -> None:
+        from torch import distributed as dist
+
+        dist.recv(tensor, src=src, tag=tag, group=self.group)
+
+    def send_object(self, obj: Any, dst: int) -> None:
+        from torch import distributed as dist
+
+        dist.send_object_list([obj], dst=dst, group=self.group)
+
+    def recv_object(self, src: int) -> Any:
+        from torch import distributed as dist
+
+        buf = [None]
+        dist.recv_object_list(buf, src=src, group=self.group)
+        return buf[0]
+
+
+class _UCXXBackend:
+    """Transport backend using UCXX endpoints."""
+
+    def __init__(self, endpoint):
+        self._endpoint = endpoint
+
+    def _tensor_to_numpy(self, t: Tensor) -> np.ndarray:
+        return np.frombuffer(
+            t.contiguous().view(torch.uint8).numpy(), dtype=np.uint8
+        )
+
+    def send_tensor(self, tensor: Tensor, dst: int, *, tag: int = 0) -> None:
+        import asyncio
+
+        asyncio.run(self._asend_tensor(tensor))
+
+    def recv_tensor(self, tensor: Tensor, src: int, *, tag: int = 0) -> None:
+        import asyncio
+
+        asyncio.run(self._arecv_tensor(tensor))
+
+    async def _asend_tensor(self, tensor: Tensor) -> None:
+        t = tensor.contiguous()
+        if t.is_cuda:
+            await self._endpoint.send(t)
+        else:
+            await self._endpoint.send(self._tensor_to_numpy(t))
+
+    async def _arecv_tensor(self, tensor: Tensor) -> None:
+        if tensor.is_cuda:
+            await self._endpoint.recv(tensor)
+        else:
+            buf = self._tensor_to_numpy(tensor)
+            await self._endpoint.recv(buf)
+
+    def send_object(self, obj: Any, dst: int) -> None:
+        import asyncio
+
+        asyncio.run(self._asend_object(obj))
+
+    def recv_object(self, src: int) -> Any:
+        import asyncio
+
+        return asyncio.run(self._arecv_object())
+
+    async def _asend_object(self, obj: Any) -> None:
+        data = json.dumps(obj).encode("utf-8")
+        length = struct.pack("<Q", len(data))
+        await self._endpoint.send(np.frombuffer(length, dtype=np.uint8))
+        await self._endpoint.send(np.frombuffer(data, dtype=np.uint8).copy())
+
+    async def _arecv_object(self) -> Any:
+        len_buf = np.empty(8, dtype=np.uint8)
+        await self._endpoint.recv(len_buf)
+        length = struct.unpack("<Q", len_buf.tobytes())[0]
+        data_buf = np.empty(length, dtype=np.uint8)
+        await self._endpoint.recv(data_buf)
+        return json.loads(bytes(data_buf))
+
+
+def _get_transport_backend(
+    transport: str,
+    dst_or_src,
+    group=None,
+) -> _TransportBackend:
+    """Resolve transport string to a backend instance.
+
+    Args:
+        transport: ``"torch_distributed"``, ``"ucxx"``, or ``"auto"``.
+        dst_or_src: the destination/source argument passed by the user
+            (int rank or TensorDictPipe). Used for auto-detection.
+        group: process group for torch.distributed backend.
+    """
+    if transport == "auto":
+        from tensordict._ucxx import TensorDictPipe
+
+        if isinstance(dst_or_src, TensorDictPipe):
+            transport = "ucxx"
+        else:
+            transport = "torch_distributed"
+
+    if transport == "torch_distributed":
+        return _TorchDistributedBackend(group=group)
+    elif transport == "ucxx":
+        if not isinstance(dst_or_src, _UCXXBackend):
+            from tensordict._ucxx import TensorDictPipe
+
+            if isinstance(dst_or_src, TensorDictPipe):
+                return _UCXXBackend(endpoint=dst_or_src._endpoint)
+        return _UCXXBackend(endpoint=dst_or_src)
+    else:
+        raise ValueError(
+            f"Unknown transport {transport!r}. "
+            "Expected 'torch_distributed', 'ucxx', or 'auto'."
+        )

--- a/test/test_dtensor_transfer.py
+++ b/test/test_dtensor_transfer.py
@@ -1,0 +1,662 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the cross-mesh DTensor transfer plan computation.
+
+All tests are pure logic -- no GPU, no torch.distributed needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tensordict._dtensor import (
+    _chunk_slice,
+    _ChunkTransfer,
+    _compute_all_local_slices,
+    _compute_local_slices,
+    _compute_transfer_plan,
+    _intersect_1d,
+    _intersect_slices,
+    _ShardSpec,
+    _slice_relative_to,
+    _TransferPlan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight placement stubs for testing without torch.distributed
+# ---------------------------------------------------------------------------
+
+
+class _Shard:
+    """Test stub matching the Shard placement interface."""
+
+    def __init__(self, dim: int):
+        self.dim = dim
+
+    def is_replicate(self):
+        return False
+
+    def is_partial(self):
+        return False
+
+    def __repr__(self):
+        return f"Shard({self.dim})"
+
+
+class _Replicate:
+    """Test stub matching the Replicate placement interface."""
+
+    def is_replicate(self):
+        return True
+
+    def is_partial(self):
+        return False
+
+    def __repr__(self):
+        return "Replicate()"
+
+
+class _Partial:
+    """Test stub matching the Partial placement interface."""
+
+    def is_replicate(self):
+        return False
+
+    def is_partial(self):
+        return True
+
+    def __repr__(self):
+        return "Partial()"
+
+
+# ---------------------------------------------------------------------------
+# Slice helpers
+# ---------------------------------------------------------------------------
+
+
+class TestChunkSlice:
+    def test_even_split(self):
+        # 100 into 4 -> 25 each
+        assert _chunk_slice(100, 4, 0) == slice(0, 25)
+        assert _chunk_slice(100, 4, 1) == slice(25, 50)
+        assert _chunk_slice(100, 4, 2) == slice(50, 75)
+        assert _chunk_slice(100, 4, 3) == slice(75, 100)
+
+    def test_uneven_split(self):
+        # 10 into 3 -> chunks of size 4, 4, 2
+        assert _chunk_slice(10, 3, 0) == slice(0, 4)
+        assert _chunk_slice(10, 3, 1) == slice(4, 8)
+        assert _chunk_slice(10, 3, 2) == slice(8, 10)
+
+    def test_more_chunks_than_elements(self):
+        # 2 into 4 -> chunk_size=1, last two are empty
+        assert _chunk_slice(2, 4, 0) == slice(0, 1)
+        assert _chunk_slice(2, 4, 1) == slice(1, 2)
+        assert _chunk_slice(2, 4, 2) == slice(0, 0)
+        assert _chunk_slice(2, 4, 3) == slice(0, 0)
+
+    def test_single_chunk(self):
+        assert _chunk_slice(50, 1, 0) == slice(0, 50)
+
+
+class TestIntersect1D:
+    def test_overlap(self):
+        assert _intersect_1d(slice(0, 10), slice(5, 15)) == slice(5, 10)
+
+    def test_no_overlap(self):
+        assert _intersect_1d(slice(0, 5), slice(5, 10)) is None
+
+    def test_contained(self):
+        assert _intersect_1d(slice(0, 20), slice(5, 15)) == slice(5, 15)
+
+    def test_identical(self):
+        assert _intersect_1d(slice(3, 7), slice(3, 7)) == slice(3, 7)
+
+    def test_empty(self):
+        assert _intersect_1d(slice(0, 0), slice(0, 10)) is None
+
+
+class TestIntersectSlices:
+    def test_2d_overlap(self):
+        a = (slice(0, 10), slice(0, 20))
+        b = (slice(5, 15), slice(10, 30))
+        result = _intersect_slices(a, b)
+        assert result == (slice(5, 10), slice(10, 20))
+
+    def test_2d_no_overlap(self):
+        a = (slice(0, 10), slice(0, 5))
+        b = (slice(10, 20), slice(5, 10))
+        assert _intersect_slices(a, b) is None
+
+    def test_partial_overlap_one_dim(self):
+        a = (slice(0, 10), slice(0, 5))
+        b = (slice(5, 15), slice(5, 10))
+        assert _intersect_slices(a, b) is None
+
+
+class TestSliceRelativeTo:
+    def test_basic(self):
+        result = _slice_relative_to(slice(5, 10), slice(3, 15))
+        assert result == slice(2, 7)
+
+    def test_same_start(self):
+        result = _slice_relative_to(slice(5, 10), slice(5, 20))
+        assert result == slice(0, 5)
+
+
+# ---------------------------------------------------------------------------
+# Local slices computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLocalSlices:
+    def test_1d_shard(self):
+        # shape [100], mesh (4,), Shard(0)
+        sl = _compute_local_slices([100], [4], [_Shard(0)], [0])
+        assert sl == (slice(0, 25),)
+        sl = _compute_local_slices([100], [4], [_Shard(0)], [3])
+        assert sl == (slice(75, 100),)
+
+    def test_1d_replicate(self):
+        sl = _compute_local_slices([100], [4], [_Replicate()], [2])
+        assert sl == (slice(0, 100),)
+
+    def test_2d_shard_shard(self):
+        # shape [100, 200], mesh (2, 4), [Shard(0), Shard(1)]
+        # rank (0, 0) -> rows 0-50, cols 0-50
+        sl = _compute_local_slices(
+            [100, 200], [2, 4], [_Shard(0), _Shard(1)], [0, 0]
+        )
+        assert sl == (slice(0, 50), slice(0, 50))
+
+        # rank (1, 3) -> rows 50-100, cols 150-200
+        sl = _compute_local_slices(
+            [100, 200], [2, 4], [_Shard(0), _Shard(1)], [1, 3]
+        )
+        assert sl == (slice(50, 100), slice(150, 200))
+
+    def test_2d_shard_replicate(self):
+        # mesh (2, 2), [Shard(0), Replicate()]
+        sl = _compute_local_slices(
+            [100, 200], [2, 2], [_Shard(0), _Replicate()], [0, 1]
+        )
+        assert sl == (slice(0, 50), slice(0, 200))
+
+    def test_uneven_shard(self):
+        # shape [10], mesh (3,), Shard(0) -> chunks 4,4,2
+        sl = _compute_local_slices([10], [3], [_Shard(0)], [2])
+        assert sl == (slice(8, 10),)
+
+
+class TestComputeAllLocalSlices:
+    def test_1d(self):
+        specs = _compute_all_local_slices([100], [4], [_Shard(0)])
+        assert len(specs) == 4
+        assert specs[0] == _ShardSpec(rank=0, slices=(slice(0, 25),))
+        assert specs[3] == _ShardSpec(rank=3, slices=(slice(75, 100),))
+
+    def test_with_rank_map(self):
+        rank_map = {(0,): 10, (1,): 20}
+        specs = _compute_all_local_slices([100], [2], [_Shard(0)], rank_map)
+        assert specs[0].rank == 10
+        assert specs[1].rank == 20
+
+    def test_2d_mesh(self):
+        specs = _compute_all_local_slices(
+            [100, 200], [2, 2], [_Shard(0), _Shard(1)]
+        )
+        assert len(specs) == 4
+        # rank 0 = coords (0,0), rank 1 = coords (0,1), etc.
+        assert specs[0].slices == (slice(0, 50), slice(0, 100))
+        assert specs[1].slices == (slice(0, 50), slice(100, 200))
+        assert specs[2].slices == (slice(50, 100), slice(0, 100))
+        assert specs[3].slices == (slice(50, 100), slice(100, 200))
+
+
+# ---------------------------------------------------------------------------
+# Transfer plan computation
+# ---------------------------------------------------------------------------
+
+
+class TestTransferPlan:
+    def test_shard_to_shard_same_size(self):
+        """Same mesh size, same shard dim -> each rank sends to itself."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[4],
+            dst_placements=[_Shard(0)],
+        )
+        assert len(plan.transfers) == 4
+        for t in plan.transfers:
+            assert t.src_rank == t.dst_rank
+
+    def test_shard_to_shard_different_sizes(self):
+        """src: 4 ranks, dst: 2 ranks, both Shard(0) on 100 elements."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # src: [0-25, 25-50, 50-75, 75-100]
+        # dst: [0-50, 50-100]
+        # transfers: src0->dst0, src1->dst0, src2->dst1, src3->dst1
+        assert len(plan.transfers) == 4
+
+        dst0_recvs = plan.recvs_for_rank(0)
+        assert len(dst0_recvs) == 2
+        src_ranks = sorted(t.src_rank for t in dst0_recvs)
+        assert src_ranks == [0, 1]
+
+        dst1_recvs = plan.recvs_for_rank(1)
+        assert len(dst1_recvs) == 2
+        src_ranks = sorted(t.src_rank for t in dst1_recvs)
+        assert src_ranks == [2, 3]
+
+    def test_shard_to_replicate(self):
+        """src: Shard(0) on 4 ranks, dst: Replicate on 2 ranks."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Replicate()],
+        )
+        # Each dst rank needs the full tensor, so receives from all 4 src ranks
+        for dst_rank in range(2):
+            recvs = plan.recvs_for_rank(dst_rank)
+            assert len(recvs) == 4
+
+    def test_replicate_to_shard(self):
+        """src: Replicate on 4 ranks, dst: Shard(0) on 2 ranks.
+
+        Should deduplicate so only one src rank sends each piece.
+        """
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Replicate()],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # All src ranks hold the full tensor but are deduplicated to rank 0.
+        # dst0 needs [0-50], dst1 needs [50-100] -> 2 transfers
+        assert len(plan.transfers) == 2
+        assert all(t.src_rank == 0 for t in plan.transfers)
+
+    def test_replicate_to_replicate(self):
+        """src: Replicate on 2, dst: Replicate on 3."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[2],
+            src_placements=[_Replicate()],
+            dst_mesh_shape=[3],
+            dst_placements=[_Replicate()],
+        )
+        # Deduplicated: only src rank 0 sends, to each of 3 dst ranks
+        assert len(plan.transfers) == 3
+        assert all(t.src_rank == 0 for t in plan.transfers)
+
+    def test_2d_to_1d(self):
+        """Training: [Shard(0), Shard(1)] on 2x2 mesh.
+        Inference: [Shard(0)] on 2 mesh.
+        Tensor shape: [100, 200].
+        """
+        plan = _compute_transfer_plan(
+            global_shape=[100, 200],
+            src_mesh_shape=[2, 2],
+            src_placements=[_Shard(0), _Shard(1)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # src: rank0=(0-50,0-100), rank1=(0-50,100-200),
+        #      rank2=(50-100,0-100), rank3=(50-100,100-200)
+        # dst: rank0=(0-50,0-200), rank1=(50-100,0-200)
+        #
+        # dst0 needs (0-50, 0-200): overlap with src0 (0-50,0-100) and src1 (0-50,100-200)
+        # dst1 needs (50-100, 0-200): overlap with src2 (50-100,0-100) and src3 (50-100,100-200)
+        assert len(plan.transfers) == 4
+
+        dst0_recvs = plan.recvs_for_rank(0)
+        assert len(dst0_recvs) == 2
+        src_ranks = sorted(t.src_rank for t in dst0_recvs)
+        assert src_ranks == [0, 1]
+
+        dst1_recvs = plan.recvs_for_rank(1)
+        assert len(dst1_recvs) == 2
+        src_ranks = sorted(t.src_rank for t in dst1_recvs)
+        assert src_ranks == [2, 3]
+
+    def test_1d_to_2d(self):
+        """Inference->Training direction: [Shard(0)] on 2 mesh -> [Shard(0), Shard(1)] on 2x2.
+        Tensor: [100, 200].
+        """
+        plan = _compute_transfer_plan(
+            global_shape=[100, 200],
+            src_mesh_shape=[2],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2, 2],
+            dst_placements=[_Shard(0), _Shard(1)],
+        )
+        # src: rank0=(0-50, 0-200), rank1=(50-100, 0-200)
+        # dst: rank0=(0-50,0-100), rank1=(0-50,100-200),
+        #      rank2=(50-100,0-100), rank3=(50-100,100-200)
+        #
+        # dst0: overlap with src0 on (0-50,0-100)
+        # dst1: overlap with src0 on (0-50,100-200)
+        # dst2: overlap with src1 on (50-100,0-100)
+        # dst3: overlap with src1 on (50-100,100-200)
+        assert len(plan.transfers) == 4
+        assert plan.recvs_for_rank(0)[0].src_rank == 0
+        assert plan.recvs_for_rank(1)[0].src_rank == 0
+        assert plan.recvs_for_rank(2)[0].src_rank == 1
+        assert plan.recvs_for_rank(3)[0].src_rank == 1
+
+    def test_identity(self):
+        """Same mesh, same placements -> self-transfers."""
+        plan = _compute_transfer_plan(
+            global_shape=[100, 200],
+            src_mesh_shape=[2],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        assert len(plan.transfers) == 2
+        for t in plan.transfers:
+            assert t.src_rank == t.dst_rank
+            # Full local tensor
+            assert t.src_slices == t.dst_slices
+
+    def test_uneven_shard(self):
+        """Tensor of 10 elements, src: 3 ranks Shard(0), dst: 2 ranks Shard(0)."""
+        plan = _compute_transfer_plan(
+            global_shape=[10],
+            src_mesh_shape=[3],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # src: [0-4, 4-8, 8-10]
+        # dst: [0-5, 5-10]
+        # Overlaps:
+        #   src0(0-4) & dst0(0-5) -> (0-4) -- full src0
+        #   src1(4-8) & dst0(0-5) -> (4-5) -- 1 element from src1
+        #   src1(4-8) & dst1(5-10) -> (5-8) -- 3 elements from src1
+        #   src2(8-10) & dst1(5-10) -> (8-10) -- full src2
+        assert len(plan.transfers) == 4
+
+    def test_partial_to_shard(self):
+        """src: Partial on 2 ranks, dst: Shard(0) on 2 ranks.
+
+        Partial is deduplicated to one canonical src rank.
+        """
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[2],
+            src_placements=[_Partial()],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # Partial: both src ranks hold full data, but deduplicated to rank 0
+        assert len(plan.transfers) == 2
+        assert all(t.src_rank == 0 for t in plan.transfers)
+
+    def test_partial_to_replicate(self):
+        """src: Partial on 2, dst: Replicate on 3."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[2],
+            src_placements=[_Partial()],
+            dst_mesh_shape=[3],
+            dst_placements=[_Replicate()],
+        )
+        assert len(plan.transfers) == 3
+        assert all(t.src_rank == 0 for t in plan.transfers)
+
+    def test_custom_rank_maps(self):
+        """Verify that custom rank maps are respected."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[2],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+            src_rank_map={(0,): 10, (1,): 11},
+            dst_rank_map={(0,): 20, (1,): 21},
+        )
+        assert len(plan.transfers) == 2
+        src_ranks = {t.src_rank for t in plan.transfers}
+        dst_ranks = {t.dst_rank for t in plan.transfers}
+        assert src_ranks == {10, 11}
+        assert dst_ranks == {20, 21}
+
+    def test_sends_and_recvs_for_rank(self):
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # src rank 0 sends to dst rank 0
+        sends = plan.sends_for_rank(0)
+        assert len(sends) == 1
+        assert sends[0].dst_rank == 0
+
+        # dst rank 1 receives from src ranks 2, 3
+        recvs = plan.recvs_for_rank(1)
+        assert len(recvs) == 2
+
+    def test_transfer_slices_correctness(self):
+        """Verify that src_slices and dst_slices correctly index into local tensors."""
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+        # src0 holds [0-25], dst0 needs [0-50]
+        # transfer: src0 -> dst0, global [0-25]
+        t = [x for x in plan.transfers if x.src_rank == 0 and x.dst_rank == 0][0]
+        # src_slices: relative to src0's local [0-25] -> slice(0, 25)
+        assert t.src_slices == (slice(0, 25),)
+        # dst_slices: relative to dst0's local [0-50] -> slice(0, 25)
+        assert t.dst_slices == (slice(0, 25),)
+
+        # src1 holds [25-50], dst0 needs [0-50]
+        t = [x for x in plan.transfers if x.src_rank == 1 and x.dst_rank == 0][0]
+        assert t.src_slices == (slice(0, 25),)  # full src1 local
+        assert t.dst_slices == (slice(25, 50),)  # offset 25 in dst0 local
+
+    def test_shard_different_dim(self):
+        """src: Shard(0) on 2 ranks, dst: Shard(1) on 2 ranks.
+        Tensor: [100, 200].
+        """
+        plan = _compute_transfer_plan(
+            global_shape=[100, 200],
+            src_mesh_shape=[2],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(1)],
+        )
+        # src0: (0-50, 0-200), src1: (50-100, 0-200)
+        # dst0: (0-100, 0-100), dst1: (0-100, 100-200)
+        # Overlaps:
+        #   src0 & dst0: (0-50, 0-100)
+        #   src0 & dst1: (0-50, 100-200)
+        #   src1 & dst0: (50-100, 0-100)
+        #   src1 & dst1: (50-100, 100-200)
+        assert len(plan.transfers) == 4
+
+    def test_dp_tp_training_to_tp_inference(self):
+        """Realistic scenario: FSDP+TP training -> TP-only inference.
+
+        Training: 2D mesh [DP=2, TP=2], placements [Shard(0), Shard(1)]
+        Inference: 1D mesh [TP=2], placements [Shard(1)]
+        Tensor: [8, 16] (small for clarity)
+        """
+        plan = _compute_transfer_plan(
+            global_shape=[8, 16],
+            src_mesh_shape=[2, 2],
+            src_placements=[_Shard(0), _Shard(1)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(1)],
+        )
+        # src: rank0=(0-4,0-8), rank1=(0-4,8-16),
+        #      rank2=(4-8,0-8), rank3=(4-8,8-16)
+        # dst: rank0=(0-8,0-8), rank1=(0-8,8-16)
+        #
+        # dst0 needs (0-8, 0-8): from src0 (0-4,0-8) and src2 (4-8,0-8)
+        # dst1 needs (0-8, 8-16): from src1 (0-4,8-16) and src3 (4-8,8-16)
+        assert len(plan.transfers) == 4
+
+        dst0_recvs = plan.recvs_for_rank(0)
+        assert len(dst0_recvs) == 2
+        assert sorted(t.src_rank for t in dst0_recvs) == [0, 2]
+
+        dst1_recvs = plan.recvs_for_rank(1)
+        assert len(dst1_recvs) == 2
+        assert sorted(t.src_rank for t in dst1_recvs) == [1, 3]
+
+    def test_empty_shard(self):
+        """Tensor smaller than mesh -> some ranks get empty shards."""
+        plan = _compute_transfer_plan(
+            global_shape=[2],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[1],
+            dst_placements=[_Replicate()],
+        )
+        # src ranks 2,3 have empty shards -> no transfers from them
+        transfers_with_data = [
+            t for t in plan.transfers
+            if all(s.start < s.stop for s in t.global_slices)
+        ]
+        assert len(transfers_with_data) == 2
+        src_ranks = sorted(t.src_rank for t in transfers_with_data)
+        assert src_ranks == [0, 1]
+
+
+class TestTransferPlanSimulation:
+    """End-to-end simulation: use the transfer plan to actually move tensor data."""
+
+    def test_shard4_to_shard2(self):
+        """Simulate Shard(0) on 4 ranks -> Shard(0) on 2 ranks."""
+        full = torch.arange(100, dtype=torch.float32)
+
+        # Create local shards for src (4 ranks)
+        src_shards = list(full.chunk(4))
+
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[4],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+
+        # Simulate: allocate dst buffers and fill via the plan
+        dst_shards = [torch.zeros(50) for _ in range(2)]
+        for t in plan.transfers:
+            src_data = src_shards[t.src_rank][t.src_slices[0]]
+            dst_shards[t.dst_rank][t.dst_slices[0]] = src_data
+
+        # Verify
+        expected = list(full.chunk(2))
+        for i in range(2):
+            assert torch.equal(dst_shards[i], expected[i]), (
+                f"dst rank {i}: expected {expected[i]}, got {dst_shards[i]}"
+            )
+
+    def test_2d_to_1d_simulation(self):
+        """Simulate [Shard(0), Shard(1)] on 2x2 -> [Shard(0)] on 2."""
+        full = torch.arange(200, dtype=torch.float32).reshape(10, 20)
+
+        # src shards: 2x2 mesh, [Shard(0), Shard(1)]
+        top = full[:5]
+        bottom = full[5:]
+        src_shards = {
+            0: top[:, :10],   # (0-5, 0-10)
+            1: top[:, 10:],   # (0-5, 10-20)
+            2: bottom[:, :10],  # (5-10, 0-10)
+            3: bottom[:, 10:],  # (5-10, 10-20)
+        }
+
+        plan = _compute_transfer_plan(
+            global_shape=[10, 20],
+            src_mesh_shape=[2, 2],
+            src_placements=[_Shard(0), _Shard(1)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+
+        # dst shards: 2 ranks, Shard(0) -> each gets 5 rows, full 20 cols
+        dst_shards = {
+            0: torch.zeros(5, 20),
+            1: torch.zeros(5, 20),
+        }
+
+        for t in plan.transfers:
+            src_data = src_shards[t.src_rank][t.src_slices]
+            dst_shards[t.dst_rank][t.dst_slices] = src_data
+
+        assert torch.equal(dst_shards[0], full[:5])
+        assert torch.equal(dst_shards[1], full[5:])
+
+    def test_replicate_to_shard_simulation(self):
+        """Simulate Replicate on 2 -> Shard(0) on 4."""
+        full = torch.arange(100, dtype=torch.float32)
+
+        plan = _compute_transfer_plan(
+            global_shape=[100],
+            src_mesh_shape=[2],
+            src_placements=[_Replicate()],
+            dst_mesh_shape=[4],
+            dst_placements=[_Shard(0)],
+        )
+
+        # src: only rank 0 used (deduplicated)
+        src_full = full.clone()
+
+        dst_shards = [torch.zeros(25) for _ in range(4)]
+        for t in plan.transfers:
+            src_data = src_full[t.src_slices[0]]
+            dst_shards[t.dst_rank][t.dst_slices[0]] = src_data
+
+        expected = list(full.chunk(4))
+        for i in range(4):
+            assert torch.equal(dst_shards[i], expected[i])
+
+    def test_uneven_simulation(self):
+        """Simulate uneven Shard(0): 10 elements, 3 src ranks -> 2 dst ranks."""
+        full = torch.arange(10, dtype=torch.float32)
+        src_shards = list(full.chunk(3))  # [4, 4, 2]
+
+        plan = _compute_transfer_plan(
+            global_shape=[10],
+            src_mesh_shape=[3],
+            src_placements=[_Shard(0)],
+            dst_mesh_shape=[2],
+            dst_placements=[_Shard(0)],
+        )
+
+        dst_shards = list(full.chunk(2))  # [5, 5]
+        dst_buffers = [torch.zeros_like(s) for s in dst_shards]
+
+        for t in plan.transfers:
+            src_data = src_shards[t.src_rank][t.src_slices[0]]
+            dst_buffers[t.dst_rank][t.dst_slices[0]] = src_data
+
+        for i in range(2):
+            assert torch.equal(dst_buffers[i], dst_shards[i]), (
+                f"rank {i}: expected {dst_shards[i]}, got {dst_buffers[i]}"
+            )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1642
* #1641
* #1640
* __->__ #1639

Add tensordict/_dtensor.py with:
- Shard algebra: compute per-rank local slices from mesh shape + placements
- Transfer plan computation: given src/dst mesh+placements, compute the
  minimal set of P2P transfers (which byte ranges go from which src rank
  to which dst rank)
- Transport abstraction: _TransportBackend protocol with
  _TorchDistributedBackend and _UCXXBackend implementations

The transfer plan is pure computation (no GPU, no distributed runtime)
and can be tested in isolation. It supports Shard, Replicate, and Partial
placements on arbitrary n-D meshes, uneven sharding, and custom rank maps.

All new classes are private (underscore-prefixed).

Made-with: Cursor