### PR TITLE
[DTensor] Add transfer plan computation and transport abstraction

### DIFF
--- a/tensordict/_dtensor.py
+++ b/tensordict/_dtensor.py
@@ -17,14 +17,10 @@ import itertools
 import json
 import struct
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable, Sequence, TYPE_CHECKING
+from typing import Any, Protocol, runtime_checkable, Sequence
 
-import numpy as np
 import torch
 from torch import Tensor
-
-if TYPE_CHECKING:
-    from tensordict._ucxx import TensorDictPipe
 
 _has_ucxx = importlib.util.find_spec("ucxx") is not None
 
@@ -194,8 +190,9 @@ class ShardingDescriptor:
 
 
 def _chunk_slice(total_size: int, num_chunks: int, chunk_idx: int) -> slice:
-    """Return the slice for ``chunk_idx`` when splitting *total_size* into
-    *num_chunks* using ``torch.chunk`` semantics (last chunk may be smaller).
+    """Return the slice for ``chunk_idx`` when splitting into chunks.
+
+    Uses ``torch.chunk`` semantics (last chunk may be smaller).
     """
     chunk_size = (total_size + num_chunks - 1) // num_chunks
     start = chunk_idx * chunk_size
@@ -313,9 +310,9 @@ def _deduplicate_src_specs(
     if not has_replica:
         return src_specs
 
-    seen: dict[tuple[slice, ...], _ShardSpec] = {}
+    seen: dict[tuple[tuple[int, int], ...], _ShardSpec] = {}
     for spec in src_specs:
-        key = spec.slices
+        key = tuple((s.start, s.stop) for s in spec.slices)
         if key not in seen or spec.rank < seen[key].rank:
             seen[key] = spec
     return list(seen.values())
@@ -356,9 +353,7 @@ def _compute_transfer_plan(
     )
 
     # Deduplicate replicated src specs
-    src_specs_dedup = _deduplicate_src_specs(
-        src_specs, src_placements, src_mesh_shape
-    )
+    src_specs_dedup = _deduplicate_src_specs(src_specs, src_placements, src_mesh_shape)
 
     plan = _TransferPlan(global_shape=global_shape)
 
@@ -418,9 +413,7 @@ def execute_transfer_plan(
     recv_bufs: list[tuple[Tensor, _ChunkTransfer]] = []
     if dst_buffer is not None:
         for transfer in recvs:
-            chunk_shape = tuple(
-                s.stop - s.start for s in transfer.global_slices
-            )
+            chunk_shape = tuple(s.stop - s.start for s in transfer.global_slices)
             buf = torch.empty(
                 chunk_shape, dtype=dst_buffer.dtype, device=dst_buffer.device
             )
@@ -490,7 +483,7 @@ class _TorchDistributedBackend:
         length = int(length_t.item())
         data_t = torch.empty(length, dtype=torch.uint8, device="cuda")
         dist.recv(data_t, src=src, group=self.group)
-        return json.loads(bytes(data_t.cpu().numpy()))
+        return json.loads(bytes(data_t.cpu().tolist()))
 
 
 class _UCXXBackend:
@@ -514,10 +507,10 @@ class _UCXXBackend:
     def __init__(self, endpoint):
         self._endpoint = endpoint
 
-    def _tensor_to_numpy(self, t: Tensor) -> np.ndarray:
-        return np.frombuffer(
-            t.contiguous().view(torch.uint8).numpy(), dtype=np.uint8
-        )
+    def _tensor_to_numpy(self, t: Tensor):
+        import numpy as np
+
+        return np.frombuffer(t.contiguous().view(torch.uint8).numpy(), dtype=np.uint8)
 
     def send_tensor(self, tensor: Tensor, dst: int, *, tag: int = 0) -> None:
         import asyncio
@@ -554,12 +547,16 @@ class _UCXXBackend:
         return asyncio.run(self._arecv_object())
 
     async def _asend_object(self, obj: Any) -> None:
+        import numpy as np
+
         data = json.dumps(obj).encode("utf-8")
         length = struct.pack("<Q", len(data))
         await self._endpoint.send(np.frombuffer(length, dtype=np.uint8))
         await self._endpoint.send(np.frombuffer(data, dtype=np.uint8).copy())
 
     async def _arecv_object(self) -> Any:
+        import numpy as np
+
         len_buf = np.empty(8, dtype=np.uint8)
         await self._endpoint.recv(len_buf)
         length = struct.unpack("<Q", len_buf.tobytes())[0]

--- a/test/test_dtensor_transfer.py
+++ b/test/test_dtensor_transfer.py
@@ -23,7 +23,6 @@ from tensordict._dtensor import (
     _intersect_slices,
     _ShardSpec,
     _slice_relative_to,
-    _TransferPlan,
     execute_transfer_plan,
     ShardingDescriptor,
 )
@@ -171,15 +170,11 @@ class TestComputeLocalSlices:
     def test_2d_shard_shard(self):
         # shape [100, 200], mesh (2, 4), [Shard(0), Shard(1)]
         # rank (0, 0) -> rows 0-50, cols 0-50
-        sl = _compute_local_slices(
-            [100, 200], [2, 4], [_Shard(0), _Shard(1)], [0, 0]
-        )
+        sl = _compute_local_slices([100, 200], [2, 4], [_Shard(0), _Shard(1)], [0, 0])
         assert sl == (slice(0, 50), slice(0, 50))
 
         # rank (1, 3) -> rows 50-100, cols 150-200
-        sl = _compute_local_slices(
-            [100, 200], [2, 4], [_Shard(0), _Shard(1)], [1, 3]
-        )
+        sl = _compute_local_slices([100, 200], [2, 4], [_Shard(0), _Shard(1)], [1, 3])
         assert sl == (slice(50, 100), slice(150, 200))
 
     def test_2d_shard_replicate(self):
@@ -209,9 +204,7 @@ class TestComputeAllLocalSlices:
         assert specs[1].rank == 20
 
     def test_2d_mesh(self):
-        specs = _compute_all_local_slices(
-            [100, 200], [2, 2], [_Shard(0), _Shard(1)]
-        )
+        specs = _compute_all_local_slices([100, 200], [2, 2], [_Shard(0), _Shard(1)])
         assert len(specs) == 4
         # rank 0 = coords (0,0), rank 1 = coords (0,1), etc.
         assert specs[0].slices == (slice(0, 50), slice(0, 100))
@@ -540,8 +533,7 @@ class TestTransferPlan:
         )
         # src ranks 2,3 have empty shards -> no transfers from them
         transfers_with_data = [
-            t for t in plan.transfers
-            if all(s.start < s.stop for s in t.global_slices)
+            t for t in plan.transfers if all(s.start < s.stop for s in t.global_slices)
         ]
         assert len(transfers_with_data) == 2
         src_ranks = sorted(t.src_rank for t in transfers_with_data)
@@ -575,9 +567,9 @@ class TestTransferPlanSimulation:
         # Verify
         expected = list(full.chunk(2))
         for i in range(2):
-            assert torch.equal(dst_shards[i], expected[i]), (
-                f"dst rank {i}: expected {expected[i]}, got {dst_shards[i]}"
-            )
+            assert torch.equal(
+                dst_shards[i], expected[i]
+            ), f"dst rank {i}: expected {expected[i]}, got {dst_shards[i]}"
 
     def test_2d_to_1d_simulation(self):
         """Simulate [Shard(0), Shard(1)] on 2x2 -> [Shard(0)] on 2."""
@@ -587,8 +579,8 @@ class TestTransferPlanSimulation:
         top = full[:5]
         bottom = full[5:]
         src_shards = {
-            0: top[:, :10],   # (0-5, 0-10)
-            1: top[:, 10:],   # (0-5, 10-20)
+            0: top[:, :10],  # (0-5, 0-10)
+            1: top[:, 10:],  # (0-5, 10-20)
             2: bottom[:, :10],  # (5-10, 0-10)
             3: bottom[:, 10:],  # (5-10, 10-20)
         }
@@ -659,9 +651,9 @@ class TestTransferPlanSimulation:
             dst_buffers[t.dst_rank][t.dst_slices[0]] = src_data
 
         for i in range(2):
-            assert torch.equal(dst_buffers[i], dst_shards[i]), (
-                f"rank {i}: expected {dst_shards[i]}, got {dst_buffers[i]}"
-            )
+            assert torch.equal(
+                dst_buffers[i], dst_shards[i]
+            ), f"rank {i}: expected {dst_shards[i]}, got {dst_buffers[i]}"
 
 
 # ---------------------------------------------------------------------------
@@ -904,9 +896,7 @@ class TestExecuteTransferPlan:
 
         # Only rank 0 sends (dedup)
         for rank in range(2):
-            execute_transfer_plan(
-                plan, full.clone(), None, rank, mock.for_rank(rank)
-            )
+            execute_transfer_plan(plan, full.clone(), None, rank, mock.for_rank(rank))
 
         dst_buffers = [torch.zeros(25) for _ in range(4)]
         for rank in range(4):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1651
* #1650
* #1649
* #1647
* #1646
* #1645
* #1644
* __->__ #1643

Pure-logic module for computing optimal P2P transfers between
different DeviceMesh sharding layouts. Includes:

- Shard-algebra functions for computing local slices and slice
  intersections between source and destination meshes.
- _compute_transfer_plan: computes minimal P2P transfers (testable
  without GPUs or a distributed runtime).
- _TransportBackend protocol with _TorchDistributedBackend (NCCL-safe
  JSON-over-CUDA metadata serialization) and _UCXXBackend implementations.
- DeviceMesh helper utilities (_mesh_to_rank_map, _mesh_all_ranks).
- Comprehensive CPU-only unit tests.

Made-with: Cursor