### PR TITLE
[BugFix] fix ragged_idx of consolidated tensor

### DIFF
--- a/tensordict/_reductions.py
+++ b/tensordict/_reductions.py
@@ -98,7 +98,12 @@ def _rebuild_tensordict_files_consolidated(
             )
             for (key, (data, batch_size, device)) in non_tensor.items()
         }
-        for key, (dtype, local_shape, start, stop, pad) in leaves.items():
+        for key, leaf_metadata in leaves.items():
+            ragged_idx = None
+            if len(leaf_metadata) == 5:
+                dtype, local_shape, start, stop, pad = leaf_metadata
+            else:
+                dtype, local_shape, start, stop, pad, ragged_idx = leaf_metadata
             dtype = _STR_DTYPE_TO_DTYPE[dtype]
             # device = torch.device(device)
             local_shape = torch.Size(local_shape)
@@ -119,9 +124,10 @@ def _rebuild_tensordict_files_consolidated(
                 from torch.nested._internal.nested_tensor import NestedTensor
 
                 offsets = value
-                value = NestedTensor(
-                    nested_values, offsets=offsets, lengths=nested_lengths
-                )
+                nested_kwargs = {"offsets": offsets, "lengths": nested_lengths}
+                if ragged_idx is not None:
+                    nested_kwargs["_ragged_idx"] = ragged_idx
+                value = NestedTensor(nested_values, **nested_kwargs)
                 key = key.replace("<NJT_OFFSETS>", "")
             d[key] = value
         for k, v in metadata.items():

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -6450,7 +6450,9 @@ class TensorDictBase(MutableMapping, TensorCollection):
         flat_size = []
         start = 0
 
-        def add_single_value(value, key, metadata_dict, dtype, shape, flat_size):
+        def add_single_value(
+            value, key, metadata_dict, dtype, shape, flat_size, ragged_idx=None
+        ):
             nonlocal start
             n = value.element_size() * value.numel()
             if need_padding:
@@ -6463,14 +6465,17 @@ class TensorDictBase(MutableMapping, TensorCollection):
             # Using sum to tell dynamo to use sym_sum
             stop = sum([start, flat_size[-1]])
             if requires_metadata:
-                metadata_dict["leaves"][key] = (
+                leaf_metadata = [
                     _DTYPE_TO_STR_DTYPE[dtype],
                     list(shape),
                     # _DEVICE2STRDEVICE[device],
                     start,
                     stop,
                     pad,
-                )
+                ]
+                if ragged_idx is not None:
+                    leaf_metadata.append(ragged_idx)
+                metadata_dict["leaves"][key] = tuple(leaf_metadata)
             start = stop
 
         def assign(
@@ -6580,6 +6585,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
                         offsets.dtype,
                         offsets.shape,
                         flat_size,
+                        ragged_idx=value._ragged_idx,
                     )
 
                 else:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -9,9 +9,11 @@ import contextlib
 import functools
 import gc
 import importlib.util
+import io
 import json
 import os
 import pathlib
+import pickle
 import platform
 import re
 import sys
@@ -11141,9 +11143,12 @@ class TestLazyStackedTensorDict:
         assert tdload.is_consolidated()
         assert tdload["njt_lengths"]._lengths is not None
 
-        import io
-        import pickle
-
+    @pytest.mark.skipif(
+        TORCH_VERSION < version.parse("2.6.0"), reason="v2.6 required for this test"
+    )
+    @pytest.mark.parametrize("device", [None, *get_available_devices()])
+    @pytest.mark.parametrize("num_threads", [0, 1, 4])
+    def test_consolidate_njt_ragged_idx(self, device, num_threads):
         ragged_tensors = [torch.randn(20, 10, i, device=device) for i in range(1, 5)]
         ragged = torch.nested.as_nested_tensor(ragged_tensors, layout=torch.jagged)
         ragged_td = TensorDict({"ragged": ragged}, batch_size=[len(ragged_tensors)])

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -11144,9 +11144,7 @@ class TestLazyStackedTensorDict:
         import io
         import pickle
 
-        ragged_tensors = [
-            torch.randn(20, 10, i, device=device) for i in range(1, 5)
-        ]
+        ragged_tensors = [torch.randn(20, 10, i, device=device) for i in range(1, 5)]
         ragged = torch.nested.as_nested_tensor(ragged_tensors, layout=torch.jagged)
         ragged_td = TensorDict({"ragged": ragged}, batch_size=[len(ragged_tensors)])
         ragged_td_c = ragged_td.consolidate(num_threads=num_threads)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -11141,6 +11141,21 @@ class TestLazyStackedTensorDict:
         assert tdload.is_consolidated()
         assert tdload["njt_lengths"]._lengths is not None
 
+        import io
+        import pickle
+
+        ragged_tensors = [
+            torch.randn(20, 10, i, device=device) for i in range(1, 5)
+        ]
+        ragged = torch.nested.as_nested_tensor(ragged_tensors, layout=torch.jagged)
+        ragged_td = TensorDict({"ragged": ragged}, batch_size=[len(ragged_tensors)])
+        ragged_td_c = ragged_td.consolidate(num_threads=num_threads)
+        buffer = io.BytesIO()
+        pickle.dump(ragged_td_c, buffer)
+        buffer.seek(0)
+        ragged_td_load = pickle.load(buffer)
+        assert ragged_td_load["ragged"]._ragged_idx == ragged._ragged_idx
+
     @pytest.mark.skipif(
         not torch.cuda.is_available() and not is_npu_available(),
         reason="no cuda or npu device detected",


### PR DESCRIPTION
## Description

- The _ragged_idx of a nested tensor is lost after consolidation and reset to the default value of 1 after unpickling. This causes numerical incorrectness when the nested tensor has more than 2 dimensions and the ragged_idx is not 1.

## Motivation and Context

close #1676

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
