### PR TITLE
[Feature] Accept **kwargs in update() and update_()

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -3092,19 +3092,41 @@ class LazyStackedTensorDict(TensorDictBase):
     @lock_blocked
     def update(
         self,
-        input_dict_or_td: T,
+        input_dict_or_td: T | None = None,
         clone: bool = False,
+        inplace: bool = False,
         *,
         keys_to_update: Sequence[NestedKey] | None = None,
         non_blocking: bool = False,
         is_leaf: Callable[[Type], bool] | None = None,
         update_batch_size: bool = False,
+        ignore_lock: bool = False,
         **kwargs: Any,
     ) -> Self:
         # This implementation of update is compatible with exclusive keys
         # as well as vmapped lazy stacks.
         # We iterate over the tensordicts rather than iterating over the keys,
         # which requires stacking and unbinding but is also not robust to missing keys.
+        if kwargs:
+            if input_dict_or_td is None:
+                input_dict_or_td = kwargs
+            elif isinstance(input_dict_or_td, dict):
+                input_dict_or_td = {**input_dict_or_td, **kwargs}
+            else:
+                self.update(
+                    input_dict_or_td,
+                    clone=clone,
+                    inplace=inplace,
+                    keys_to_update=keys_to_update,
+                    non_blocking=non_blocking,
+                    is_leaf=is_leaf,
+                    update_batch_size=update_batch_size,
+                    ignore_lock=ignore_lock,
+                )
+                input_dict_or_td = kwargs
+            kwargs = {}
+        elif input_dict_or_td is None:
+            return self
         if input_dict_or_td is self:
             # no op
             return self
@@ -3157,11 +3179,12 @@ class LazyStackedTensorDict(TensorDictBase):
                 td_dest.update(
                     td_source,
                     clone=clone,
+                    inplace=inplace,
                     keys_to_update=keys_to_update,
                     non_blocking=non_blocking,
                     is_leaf=is_leaf,
                     update_batch_size=update_batch_size,
-                    **kwargs,
+                    ignore_lock=ignore_lock,
                 )
             return self
 
@@ -3185,11 +3208,12 @@ class LazyStackedTensorDict(TensorDictBase):
                 return self.update(
                     input_dict_or_td.to_lazystack(self.stack_dim),
                     clone=clone,
+                    inplace=inplace,
                     keys_to_update=keys_to_update,
                     non_blocking=non_blocking,
                     is_leaf=is_leaf,
                     update_batch_size=update_batch_size,
-                    **kwargs,
+                    ignore_lock=ignore_lock,
                 )
             # if the batch-size does not permit unbinding, let's first try to reset the batch-size.
             input_dict_or_td = input_dict_or_td.copy()
@@ -3209,10 +3233,12 @@ class LazyStackedTensorDict(TensorDictBase):
             td_dest.update(
                 td_source,
                 clone=clone,
+                inplace=inplace,
                 keys_to_update=keys_to_update,
+                non_blocking=non_blocking,
                 is_leaf=is_leaf,
                 update_batch_size=update_batch_size,
-                **kwargs,
+                ignore_lock=ignore_lock,
             )
         if self.hook_out is not None:
             self_upd = self.hook_out(self_upd)
@@ -3222,12 +3248,30 @@ class LazyStackedTensorDict(TensorDictBase):
 
     def update_(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | TensorDictBase,
+        input_dict_or_td: dict[str, CompatibleType] | TensorDictBase | None = None,
         clone: bool = False,
         *,
         non_blocking: bool = False,
         **kwargs: Any,
     ) -> Self:
+        # Extract reserved kwargs that aren't user key-value pairs.
+        keys_to_update = kwargs.pop("keys_to_update", None)
+        if kwargs:
+            if input_dict_or_td is None:
+                input_dict_or_td = kwargs
+            elif isinstance(input_dict_or_td, dict):
+                input_dict_or_td = {**input_dict_or_td, **kwargs}
+            else:
+                self.update_(
+                    input_dict_or_td,
+                    clone=clone,
+                    non_blocking=non_blocking,
+                    keys_to_update=keys_to_update,
+                )
+                input_dict_or_td = kwargs
+            kwargs = {}
+        elif input_dict_or_td is None:
+            return self
         if input_dict_or_td is self:
             # no op
             return self
@@ -3244,7 +3288,12 @@ class LazyStackedTensorDict(TensorDictBase):
         for td_dest, td_source in _zip_strict(
             self.tensordicts, input_dict_or_td.unbind(self.stack_dim)
         ):
-            td_dest.update_(td_source, clone=clone, non_blocking=non_blocking, **kwargs)
+            td_dest.update_(
+                td_source,
+                clone=clone,
+                non_blocking=non_blocking,
+                keys_to_update=keys_to_update,
+            )
         return self
 
     def update_at_(

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -4017,7 +4017,7 @@ class _SubTensorDict(TensorDictBase):
     @lock_blocked
     def update(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | TensorCollection,
+        input_dict_or_td: dict[str, CompatibleType] | TensorCollection | None = None,
         clone: bool = False,
         inplace: bool = False,
         *,
@@ -4028,6 +4028,25 @@ class _SubTensorDict(TensorDictBase):
         ignore_lock: bool = False,
         **kwargs,
     ) -> _SubTensorDict:
+        if kwargs:
+            if input_dict_or_td is None:
+                input_dict_or_td = kwargs
+            elif isinstance(input_dict_or_td, dict):
+                input_dict_or_td = {**input_dict_or_td, **kwargs}
+            else:
+                self.update(
+                    input_dict_or_td,
+                    clone=clone,
+                    inplace=inplace,
+                    non_blocking=non_blocking,
+                    keys_to_update=keys_to_update,
+                    is_leaf=is_leaf,
+                    update_batch_size=update_batch_size,
+                    ignore_lock=ignore_lock,
+                )
+                input_dict_or_td = kwargs
+        elif input_dict_or_td is None:
+            return self
         if input_dict_or_td is self:
             # no op
             return self
@@ -4109,12 +4128,28 @@ class _SubTensorDict(TensorDictBase):
 
     def update_(
         self,
-        input_dict: dict[str, CompatibleType] | TensorCollection,
+        input_dict: dict[str, CompatibleType] | TensorCollection | None = None,
         clone: bool = False,
         *,
         non_blocking: bool = False,
         keys_to_update: Sequence[NestedKey] | None = None,
+        **kwargs,
     ) -> _SubTensorDict:
+        if kwargs:
+            if input_dict is None:
+                input_dict = kwargs
+            elif isinstance(input_dict, dict):
+                input_dict = {**input_dict, **kwargs}
+            else:
+                self.update_(
+                    input_dict,
+                    clone=clone,
+                    non_blocking=non_blocking,
+                    keys_to_update=keys_to_update,
+                )
+                input_dict = kwargs
+        elif input_dict is None:
+            return self
         return self.update_at_(
             input_dict,
             idx=self.idx,

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -8120,7 +8120,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
     @lock_blocked
     def update(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | T,
+        input_dict_or_td: dict[str, CompatibleType] | T | None = None,
         clone: bool = False,
         inplace: bool = False,
         *,
@@ -8129,6 +8129,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         is_leaf: Callable[[Type], bool] | None = None,
         update_batch_size: bool = False,
         ignore_lock: bool = False,
+        **kwargs,
     ) -> Self:
         """Updates the TensorDict with values from either a dictionary or another TensorDict.
 
@@ -8136,8 +8137,8 @@ class TensorDictBase(MutableMapping, TensorCollection):
             such blocks hoping to catch and patch errors that occur during the execution.
 
         Args:
-            input_dict_or_td (TensorDictBase or dict): input data to be written
-                in self.
+            input_dict_or_td (TensorDictBase or dict, optional): input data to be written
+                in self. If ``None``, only the keyword arguments are used.
             clone (bool, optional): whether the tensors in the input (
                 tensor) dict should be cloned before being set.
                 Defaults to ``False``.
@@ -8175,10 +8176,20 @@ class TensorDictBase(MutableMapping, TensorCollection):
             ignore_lock (bool, optional): if ``True``, any tensordict can be updated regardless of its locked status.
                 Defaults to `False`.
 
+            **kwargs: additional key-value pairs to write into ``self`` as top-level entries. When both
+                ``input_dict_or_td`` and ``kwargs`` are provided, kwargs win on key conflict.
+
         .. note:: When updating a :class:`~tensordict.LazyStackedTensorDict` with N elements with another
             :class:`~tensordict.LazyStackedTensorDict` with M elements, with M > N, along the stack dimension,
             the ``update`` method will append copies of the extra tensordicts to the dest (self) lazy stack.
             This allows users to rely on ``update`` to increment lazy stacks progressively.
+
+        .. note:: Keyword arguments are treated as top-level keys only. Nested structures still work when
+            the kwarg value is itself a dict or tensor collection (e.g. ``td.update(outer={"inner": val})``).
+            For deeper tuple keys, use the positional dict form: ``td.update({("a", "b"): val})``.
+            Keys whose names collide with reserved parameters (``clone``, ``inplace``, ``non_blocking``,
+            ``keys_to_update``, ``is_leaf``, ``update_batch_size``, ``ignore_lock``) must be passed through
+            the positional dict form.
 
         Returns:
             self
@@ -8193,8 +8204,30 @@ class TensorDictBase(MutableMapping, TensorCollection):
             >>> other_td = other_td.clone().zero_()
             >>> td.update(other_td)
             >>> assert td['a'] is not other_td['a']
+            >>> # keyword form for top-level entries
+            >>> td.update(monkey=torch.zeros(3))
+            >>> assert (td["monkey"] == 0).all()
 
         """
+        if kwargs:
+            if input_dict_or_td is None:
+                input_dict_or_td = kwargs
+            elif isinstance(input_dict_or_td, dict):
+                input_dict_or_td = {**input_dict_or_td, **kwargs}
+            else:
+                self.update(
+                    input_dict_or_td,
+                    clone=clone,
+                    inplace=inplace,
+                    non_blocking=non_blocking,
+                    keys_to_update=keys_to_update,
+                    is_leaf=is_leaf,
+                    update_batch_size=update_batch_size,
+                    ignore_lock=ignore_lock,
+                )
+                input_dict_or_td = kwargs
+        elif input_dict_or_td is None:
+            return self
         batch_size_changed = False
         if input_dict_or_td is self:
             # no op
@@ -8367,19 +8400,20 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
     def update_(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | T,
+        input_dict_or_td: dict[str, CompatibleType] | T | None = None,
         clone: bool = False,
         *,
         non_blocking: bool = False,
         keys_to_update: Sequence[NestedKey] | None = None,
+        **kwargs,
     ) -> Self:
         """Updates the TensorDict in-place with values from either a dictionary or another TensorDict.
 
         Unlike :meth:`~.update`, this function will throw an error if the key is unknown to ``self``.
 
         Args:
-            input_dict_or_td (TensorDictBase or dict): input data to be written
-                in self.
+            input_dict_or_td (TensorDictBase or dict, optional): input data to be written
+                in self. If ``None``, only the keyword arguments are used.
             clone (bool, optional): whether the tensors in the input (
                 tensor) dict should be cloned before being set. Defaults to ``False``.
 
@@ -8391,6 +8425,14 @@ class TensorDictBase(MutableMapping, TensorCollection):
             non_blocking (bool, optional): if ``True`` and this copy is between
                 different devices, the copy may occur asynchronously with respect
                 to the host.
+            **kwargs: additional key-value pairs to write into ``self`` as top-level entries. As with the
+                positional form, any key that does not already exist in ``self`` raises :class:`KeyError`.
+                When both ``input_dict_or_td`` and ``kwargs`` are provided, kwargs win on key conflict.
+
+        .. note:: Keyword arguments are treated as top-level keys only. Nested structures still work when
+            the kwarg value is itself a dict or tensor collection. Keys whose names collide with reserved
+            parameters (``clone``, ``non_blocking``, ``keys_to_update``) must be passed through the positional
+            dict form.
 
         Returns:
             self
@@ -8404,8 +8446,26 @@ class TensorDictBase(MutableMapping, TensorCollection):
             >>> assert td['a'] is not other_td['a']
             >>> assert (td['a'] == other_td['a']).all()
             >>> assert (td['a'] == 0).all()
+            >>> # keyword form for top-level entries (key must already exist)
+            >>> td.update_(a=torch.ones(3))
+            >>> assert (td["a"] == 1).all()
 
         """
+        if kwargs:
+            if input_dict_or_td is None:
+                input_dict_or_td = kwargs
+            elif isinstance(input_dict_or_td, dict):
+                input_dict_or_td = {**input_dict_or_td, **kwargs}
+            else:
+                self.update_(
+                    input_dict_or_td,
+                    clone=clone,
+                    non_blocking=non_blocking,
+                    keys_to_update=keys_to_update,
+                )
+                input_dict_or_td = kwargs
+        elif input_dict_or_td is None:
+            return self
         if input_dict_or_td is self:
             # no op
             return self

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -2062,7 +2062,7 @@ def _wrap_method(self, attr, func, nowarn=False):
 
 def _update(
     self,
-    input_dict_or_td: dict[str, CompatibleType] | T,
+    input_dict_or_td: dict[str, CompatibleType] | T | None = None,
     clone: bool = False,
     inplace: bool = False,
     *,
@@ -2071,7 +2071,28 @@ def _update(
     update_batch_size: bool = False,
     ignore_lock: bool = False,
     is_leaf: Callable[[Type], bool] | None = None,
+    **kwargs,
 ):
+    if kwargs:
+        if input_dict_or_td is None:
+            input_dict_or_td = kwargs
+        elif isinstance(input_dict_or_td, dict):
+            input_dict_or_td = {**input_dict_or_td, **kwargs}
+        else:
+            _update(
+                self,
+                input_dict_or_td,
+                clone=clone,
+                inplace=inplace,
+                keys_to_update=keys_to_update,
+                non_blocking=non_blocking,
+                update_batch_size=update_batch_size,
+                ignore_lock=ignore_lock,
+                is_leaf=is_leaf,
+            )
+            input_dict_or_td = kwargs
+    elif input_dict_or_td is None:
+        return self
     if is_leaf is None:
         is_leaf = _is_leaf_nontensor
     if isinstance(input_dict_or_td, dict):
@@ -2117,13 +2138,31 @@ def _update(
 
 def _update_(
     self,
-    input_dict_or_td: dict[str, CompatibleType] | T,
+    input_dict_or_td: dict[str, CompatibleType] | T | None = None,
     clone: bool = False,
     inplace: bool = False,
     *,
     keys_to_update: Sequence[NestedKey] | None = None,
     non_blocking: bool = False,
+    **kwargs,
 ):
+    if kwargs:
+        if input_dict_or_td is None:
+            input_dict_or_td = kwargs
+        elif isinstance(input_dict_or_td, dict):
+            input_dict_or_td = {**input_dict_or_td, **kwargs}
+        else:
+            _update_(
+                self,
+                input_dict_or_td,
+                clone=clone,
+                inplace=inplace,
+                keys_to_update=keys_to_update,
+                non_blocking=non_blocking,
+            )
+            input_dict_or_td = kwargs
+    elif input_dict_or_td is None:
+        return self
     if isinstance(input_dict_or_td, dict):
         input_dict_or_td = type(self).from_dict(
             input_dict_or_td, batch_size=self.batch_size

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -3705,7 +3705,7 @@ class NonTensorDataBase(TensorClass):
 
     def update(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | T,
+        input_dict_or_td: dict[str, CompatibleType] | T | None = None,
         clone: bool = False,
         inplace: bool = False,
         *,
@@ -3714,7 +3714,16 @@ class NonTensorDataBase(TensorClass):
         is_leaf: Callable[[Type], bool] | None = None,
         update_batch_size: bool = False,
         ignore_lock: bool = False,
+        **kwargs,
     ) -> T:
+        if kwargs:
+            raise TypeError(
+                f"{type(self).__name__}.update() does not accept keyword-argument "
+                "entries; pass another NonTensorDataBase instance as the positional "
+                "argument."
+            )
+        if input_dict_or_td is None:
+            return self
         return self._update(
             input_dict_or_td=input_dict_or_td,
             clone=clone,
@@ -3804,12 +3813,21 @@ class NonTensorDataBase(TensorClass):
 
     def update_(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | T,
+        input_dict_or_td: dict[str, CompatibleType] | T | None = None,
         clone: bool = False,
         *,
         non_blocking: bool = False,
         keys_to_update: Sequence[NestedKey] | None = None,
+        **kwargs,
     ) -> T:
+        if kwargs:
+            raise TypeError(
+                f"{type(self).__name__}.update_() does not accept keyword-argument "
+                "entries; pass another NonTensorDataBase instance as the positional "
+                "argument."
+            )
+        if input_dict_or_td is None:
+            return self
         return self._update_(
             input_dict_or_td=input_dict_or_td,
             clone=clone,
@@ -4824,7 +4842,7 @@ class NonTensorStack(LazyStackedTensorDict):
 
     def update(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | T,
+        input_dict_or_td: dict[str, CompatibleType] | T | None = None,
         clone: bool = False,
         inplace: bool = False,
         *,
@@ -4833,7 +4851,15 @@ class NonTensorStack(LazyStackedTensorDict):
         is_leaf: Callable[[Type], bool] | None = None,
         update_batch_size: bool = False,
         ignore_lock: bool = False,
+        **kwargs,
     ) -> T:
+        if kwargs:
+            raise TypeError(
+                f"{type(self).__name__}.update() does not accept keyword-argument "
+                "entries; pass a compatible tensor collection as the positional argument."
+            )
+        if input_dict_or_td is None:
+            return self
         return self._update(
             input_dict_or_td=input_dict_or_td,
             clone=clone,
@@ -4846,12 +4872,20 @@ class NonTensorStack(LazyStackedTensorDict):
 
     def update_(
         self,
-        input_dict_or_td: dict[str, CompatibleType] | T,
+        input_dict_or_td: dict[str, CompatibleType] | T | None = None,
         clone: bool = False,
         *,
         non_blocking: bool = False,
         keys_to_update: Sequence[NestedKey] | None = None,
+        **kwargs,
     ) -> T:
+        if kwargs:
+            raise TypeError(
+                f"{type(self).__name__}.update_() does not accept keyword-argument "
+                "entries; pass a compatible tensor collection as the positional argument."
+            )
+        if input_dict_or_td is None:
+            return self
         return self._update(
             input_dict_or_td=input_dict_or_td,
             clone=clone,

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -2025,6 +2025,31 @@ class TestTensorClass:
         assert (data0.y.X == 1).all()
         assert data0.y.z == "test_tensorclass1"
 
+    def test_update_kwargs(self):
+        @tensorclass
+        class TC:
+            a: torch.Tensor
+            b: torch.Tensor
+
+        tc = TC(a=torch.zeros(3), b=torch.zeros(3), batch_size=[3])
+        tc.update(a=torch.ones(3))
+        assert (tc.a == 1).all()
+
+        tc.update_(b=torch.ones(3) * 2)
+        assert (tc.b == 2).all()
+
+        # merge: positional + kwargs, kwargs win
+        tc2 = TC(a=torch.zeros(3), b=torch.zeros(3), batch_size=[3])
+        other = TC(a=torch.ones(3) * 5, b=torch.ones(3) * 7, batch_size=[3])
+        tc2.update(other, b=torch.ones(3) * 9)
+        assert (tc2.a == 5).all()
+        assert (tc2.b == 9).all()
+
+        # empty call is a no-op
+        tc3 = TC(a=torch.zeros(3), b=torch.zeros(3), batch_size=[3])
+        assert tc3.update() is tc3
+        assert tc3.update_() is tc3
+
     def test_replace(self):
         @tensorclass
         class MyDataNested:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -4196,7 +4196,9 @@ class TestGeneric:
 
         # update: positional TensorDict + kwargs both applied, kwargs win on conflict
         td = TensorDict({"a": torch.zeros(3), "b": torch.zeros(3)}, batch_size=[3])
-        other = TensorDict({"a": torch.ones(3) * 2, "b": torch.ones(3) * 5}, batch_size=[3])
+        other = TensorDict(
+            {"a": torch.ones(3) * 2, "b": torch.ones(3) * 5}, batch_size=[3]
+        )
         td.update(other, b=torch.ones(3) * 9)
         assert (td["a"] == 2).all()
         assert (td["b"] == 9).all()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -4177,6 +4177,76 @@ class TestGeneric:
         td_source = TensorDict(a=0)
         td_dest.update_(td_source)
 
+    def test_update_kwargs(self):
+        # update: kwargs create new keys
+        td = TensorDict({"a": torch.zeros(3)}, batch_size=[3])
+        td.update(b=torch.ones(3))
+        assert "b" in td.keys()
+        assert (td["b"] == 1).all()
+
+        # update: kwargs overwrite existing keys
+        td.update(a=torch.ones(3))
+        assert (td["a"] == 1).all()
+
+        # update: positional + kwargs, kwargs win on conflict
+        td = TensorDict({"a": torch.zeros(3)}, batch_size=[3])
+        td.update({"a": torch.ones(3) * 2, "b": torch.ones(3) * 3}, a=torch.ones(3) * 7)
+        assert (td["a"] == 7).all()
+        assert (td["b"] == 3).all()
+
+        # update: positional TensorDict + kwargs both applied, kwargs win on conflict
+        td = TensorDict({"a": torch.zeros(3), "b": torch.zeros(3)}, batch_size=[3])
+        other = TensorDict({"a": torch.ones(3) * 2, "b": torch.ones(3) * 5}, batch_size=[3])
+        td.update(other, b=torch.ones(3) * 9)
+        assert (td["a"] == 2).all()
+        assert (td["b"] == 9).all()
+
+        # update: nested dict value via kwarg still recurses
+        td = TensorDict({}, batch_size=[3])
+        td.update(outer={"inner": torch.ones(3)})
+        assert (td["outer", "inner"] == 1).all()
+
+        # update: empty call is a no-op and returns self
+        td = TensorDict({"a": torch.zeros(3)}, batch_size=[3])
+        assert td.update() is td
+        assert set(td.keys()) == {"a"}
+
+        # update_: kwargs on existing key updates in place
+        td = TensorDict({"a": torch.zeros(3)}, batch_size=[3])
+        a_ref = td["a"]
+        td.update_(a=torch.ones(3))
+        assert td["a"] is a_ref
+        assert (td["a"] == 1).all()
+
+        # update_: kwargs on missing key raises KeyError
+        td = TensorDict({"a": torch.zeros(3)}, batch_size=[3])
+        with pytest.raises(KeyError, match="was not found"):
+            td.update_(b=torch.ones(3))
+
+        # update_: empty call is a no-op
+        td = TensorDict({"a": torch.zeros(3)}, batch_size=[3])
+        assert td.update_() is td
+
+        # update_: positional + kwargs, kwargs applied (must exist)
+        td = TensorDict({"a": torch.zeros(3), "b": torch.zeros(3)}, batch_size=[3])
+        td.update_({"a": torch.ones(3)}, b=torch.ones(3) * 2)
+        assert (td["a"] == 1).all()
+        assert (td["b"] == 2).all()
+
+    def test_update_kwargs_lazy_stack(self):
+        td = LazyStackedTensorDict.lazy_stack(
+            [TensorDict({"a": torch.zeros(())}, batch_size=[]) for _ in range(3)]
+        )
+        td.update(b=torch.ones(3))
+        assert "b" in td.keys()
+        assert (td["b"] == 1).all()
+
+        td.update_(a=torch.ones(3))
+        assert (td["a"] == 1).all()
+
+        with pytest.raises(KeyError, match="was not found"):
+            td.update_(c=torch.ones(3))
+
     @set_capture_non_tensor_stack(False)
     @pytest.mark.parametrize("flip", [False, True])
     def test_update_batch_size(self, flip):


### PR DESCRIPTION
## Summary
- Adds `**kwargs` support to `TensorDictBase.update()` and `TensorDictBase.update_()` so users can write `td.update(monkey=val)` as a terser alternative to `td.update({"monkey": val})`.
- Mirrors the existing `replace()` merge semantics: when both a positional dict/TD and kwargs are provided, kwargs win on key conflict. The positional argument becomes optional; an empty call is a no-op.
- `update_()` preserves its existing contract — keys not already present in `self` raise `KeyError`.
- Kwargs are top-level only (Python identifier restriction). Nested structures still work naturally when the kwarg value is itself a dict or tensor collection: `td.update(outer={"inner": val})`. For deeper tuple keys, use the positional dict form.
- Overrides in `_SubTensorDict` and `LazyStackedTensorDict` accept and forward kwargs consistently. `NonTensorDataBase` and `NonTensorStack` reject kwargs with a clear `TypeError` since they don't represent dict-style containers at the root.

## Test plan
- [x] New `test_update_kwargs` and `test_update_kwargs_lazy_stack` cover: kwargs create new keys, kwargs overwrite existing keys, positional+kwargs merging (with kwargs winning), nested dict values as kwarg values, empty-call no-op, `update_` on existing/missing keys (KeyError), and LazyStackedTensorDict variant.
- [x] Full `test_tensordict.py` suite passes (7604 tests, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)