### PR TITLE
[Refactor] Split store byte range helpers

### DIFF
--- a/tensordict/store/_store.py
+++ b/tensordict/store/_store.py
@@ -56,74 +56,20 @@ else:
 # Separator used for nested key paths in Redis keys
 _KEY_SEP = "."
 
-# Lua scripts executed server-side to batch byte-range operations into a
-# single round-trip per key.  Each script takes ONE Redis key and a flat
-# argument list encoding the byte ranges.
-
-# GETRANGES: ARGV = [offset1, length1, offset2, length2, ...]
-# Returns the *concatenated* bytes from all ranges.
-_LUA_GETRANGES = """\
-local key = KEYS[1]
-local parts = {}
-for i = 1, #ARGV, 2 do
-    local off = tonumber(ARGV[i])
-    local len = tonumber(ARGV[i + 1])
-    parts[#parts + 1] = redis.call('GETRANGE', key, off, off + len - 1)
-end
-return table.concat(parts)
-"""
-
-# SETRANGES: ARGV = [offset1, data1, offset2, data2, ...]
-# Applies all SETRANGEs atomically; returns "OK".
-_LUA_SETRANGES = """\
-local key = KEYS[1]
-for i = 1, #ARGV, 2 do
-    redis.call('SETRANGE', key, tonumber(ARGV[i]), ARGV[i + 1])
-end
-return redis.status_reply('OK')
-"""
-
-
-def _dtype_to_str(dtype: torch.dtype) -> str:
-    """Convert a torch.dtype to its string representation."""
-    return str(dtype)
-
-
-def _str_to_dtype(s: str) -> torch.dtype:
-    """Convert a string representation back to a torch.dtype."""
-    # e.g. "torch.float32" -> torch.float32
-    return getattr(torch, s.split(".")[-1])
-
-
-def _tensor_to_bytes(tensor: torch.Tensor) -> bytes:
-    """Serialize a tensor to raw bytes.
-
-    The tensor is made contiguous and moved to CPU before serialization.
-    Uses NumPy's ``tobytes()`` which is an optimised C-level memcpy.
-    """
-    return tensor.detach().contiguous().cpu().numpy().tobytes()
-
-
-def _bytes_to_tensor(
-    data: bytes,
-    shape: list[int],
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    """Deserialize raw bytes to a tensor using torch.frombuffer.
-
-    Returns an owned, writable tensor backed by a ``bytearray`` copy.
-    """
-    return torch.frombuffer(bytearray(data), dtype=dtype).reshape(shape)
-
-
-def _decode_meta(raw_meta: dict) -> dict[str, str]:
-    """Decode a Redis hash response (bytes keys/values) to a ``{str: str}`` dict."""
-    return {
-        k.decode() if isinstance(k, bytes) else k: (
-            v.decode() if isinstance(v, bytes) else v
-        )
-        for k, v in raw_meta.items()
-    }
+from tensordict.store._utils import (
+    _bytes_to_tensor,
+    _compute_byte_ranges,
+    _compute_covering_range,
+    _decode_meta,
+    _dtype_to_str,
+    _get_local_idx,
+    _getitem_result_shape,
+    _is_scattered_index,
+    _LUA_GETRANGES,
+    _LUA_SETRANGES,
+    _str_to_dtype,
+    _tensor_to_bytes,
+)
 
 
 def _resolve_tensorclass(
@@ -153,183 +99,6 @@ def _resolve_tensorclass(
     module_path, _, class_name = class_path.rpartition(".")
     mod = importlib.import_module(module_path)
     return getattr(mod, class_name)
-
-
-def _compute_byte_ranges(
-    shape: list[int],
-    dtype: torch.dtype,
-    idx,
-) -> list[tuple[int, int]] | None:
-    """Compute per-row ``(byte_offset, byte_length)`` pairs for the write path.
-
-    Returns ``None`` when *idx* is an unsupported type, signalling that the
-    caller should fall back to a full read-modify-write.
-
-    Every index type (int, slice, list, tensor, bool) returns one
-    ``(offset, row_size)`` entry per selected row.  This is the canonical
-    decomposition used by the ``SETRANGES`` Lua script.
-    """
-    # Unwrap 1-element tuples produced by _SubTensorDict
-    if isinstance(idx, tuple):
-        if len(idx) == 1:
-            idx = idx[0]
-        else:
-            return None  # multi-dim tuple: fall back
-
-    # Ellipsis selects everything along the first dim
-    if idx is Ellipsis:
-        idx = slice(None)
-
-    elem_size = torch.tensor([], dtype=dtype).element_size()
-    row_size = elem_size
-    for s in shape[1:]:
-        row_size *= s
-
-    if isinstance(idx, int):
-        pos = idx % shape[0]
-        return [(pos * row_size, row_size)]
-
-    if isinstance(idx, (slice, range)):
-        positions = range(*idx.indices(shape[0])) if isinstance(idx, slice) else idx
-        if len(positions) == 0:
-            return []
-        # Contiguous step-1: single covering range
-        if positions.step == 1:
-            return [(positions[0] * row_size, len(positions) * row_size)]
-        return [(p * row_size, row_size) for p in positions]
-
-    if isinstance(idx, list):
-        return [(int(p) * row_size, row_size) for p in idx]
-
-    if isinstance(idx, torch.Tensor):
-        if idx.dtype == torch.bool:
-            positions = idx.nonzero(as_tuple=False).squeeze(-1).tolist()
-        else:
-            positions = idx.reshape(-1).tolist()
-        return [(int(p) * row_size, row_size) for p in positions]
-
-    return None  # unsupported index type
-
-
-def _compute_covering_range(
-    shape: list[int],
-    dtype: torch.dtype,
-    idx,
-) -> tuple[int, int] | None:
-    """Compute a single ``(byte_offset, byte_length)`` for the read path.
-
-    For **int** and **slice** (any step), returns one covering range.
-    Returns ``None`` for all other index types (scatter, unsupported).
-    """
-    if isinstance(idx, tuple):
-        idx = idx[0] if len(idx) == 1 else None
-    if idx is None:
-        return None
-    if idx is Ellipsis:
-        idx = slice(None)
-
-    elem_size = torch.tensor([], dtype=dtype).element_size()
-    row_size = elem_size
-    for s in shape[1:]:
-        row_size *= s
-
-    if isinstance(idx, int):
-        pos = idx % shape[0]
-        return (pos * row_size, row_size)
-
-    if isinstance(idx, (slice, range)):
-        positions = range(*idx.indices(shape[0])) if isinstance(idx, slice) else idx
-        if len(positions) == 0:
-            return (0, 0)
-        start = positions[0]
-        stop = positions[-1] + 1
-        return (start * row_size, (stop - start) * row_size)
-
-    return None
-
-
-def _get_local_idx(idx, shape_0: int):
-    """Return a local post-index to apply after fetching a covering range.
-
-    For **int** and **step-1 slices** returns ``None`` (the fetched bytes
-    match the result shape exactly).
-
-    For **step > 1 slices** returns a ``slice(None, None, step)`` to stride
-    the covering range.
-
-    For tensor / list / bool returns ``None`` — the Lua path fetches exactly
-    the needed rows so no post-processing is required.
-    """
-    if isinstance(idx, tuple):
-        idx = idx[0] if len(idx) == 1 else idx
-    if idx is Ellipsis:
-        return None
-    if isinstance(idx, int):
-        return None
-    if isinstance(idx, (slice, range)):
-        positions = range(*idx.indices(shape_0)) if isinstance(idx, slice) else idx
-        if len(positions) == 0 or positions.step == 1:
-            return None
-        return slice(None, None, positions.step)
-    # tensor / list / bool — Lua fetches exact rows
-    return None
-
-
-def _is_scattered_index(idx) -> bool:
-    """Return True when *idx* is tensor / list / bool (scattered, use Lua)."""
-    if isinstance(idx, tuple):
-        idx = idx[0] if len(idx) == 1 else idx
-    if idx is Ellipsis:
-        return False
-    if isinstance(idx, (int, slice, range)):
-        return False
-    if isinstance(idx, (list, torch.Tensor)):
-        return True
-    return False
-
-
-def _getitem_result_shape(
-    shape: list[int],
-    idx,
-) -> list[int]:
-    """Compute the result shape of ``tensor[idx]`` without creating a tensor.
-
-    Only handles first-dimension indexing (same cases as ``_compute_byte_ranges``).
-    """
-    if isinstance(idx, tuple):
-        if len(idx) == 1:
-            idx = idx[0]
-        else:
-            # Multi-dim: not handled, let caller use torch logic
-            return list(torch.zeros(shape)[idx].shape)
-
-    if idx is Ellipsis:
-        idx = slice(None)
-
-    rest = list(shape[1:])
-
-    if isinstance(idx, int):
-        return rest
-
-    if isinstance(idx, slice):
-        n = len(range(*idx.indices(shape[0])))
-        return [n] + rest
-
-    if isinstance(idx, range):
-        return [len(idx)] + rest
-
-    if isinstance(idx, list):
-        return [len(idx)] + rest
-
-    if isinstance(idx, torch.Tensor):
-        if idx.dtype == torch.bool:
-            n = int(idx.sum().item())
-        else:
-            n = idx.numel()
-        return [n] + rest
-
-    # Fallback
-    return list(torch.zeros(shape)[idx].shape)
 
 
 class _StoreTDKeysView(_TensorDictKeysView):

--- a/tensordict/store/_utils.py
+++ b/tensordict/store/_utils.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+
+__all__ = [
+    "_LUA_GETRANGES",
+    "_LUA_SETRANGES",
+    "_bytes_to_tensor",
+    "_compute_byte_ranges",
+    "_compute_covering_range",
+    "_decode_meta",
+    "_dtype_to_str",
+    "_get_local_idx",
+    "_getitem_result_shape",
+    "_is_scattered_index",
+    "_str_to_dtype",
+    "_tensor_to_bytes",
+]
+
+# Lua scripts executed server-side to batch byte-range operations into a
+# single round-trip per key. Each script takes ONE Redis key and a flat
+# argument list encoding the byte ranges.
+
+# GETRANGES: ARGV = [offset1, length1, offset2, length2, ...]
+# Returns the *concatenated* bytes from all ranges.
+_LUA_GETRANGES = """\
+local key = KEYS[1]
+local parts = {}
+for i = 1, #ARGV, 2 do
+    local off = tonumber(ARGV[i])
+    local len = tonumber(ARGV[i + 1])
+    parts[#parts + 1] = redis.call('GETRANGE', key, off, off + len - 1)
+end
+return table.concat(parts)
+"""
+
+# SETRANGES: ARGV = [offset1, data1, offset2, data2, ...]
+# Applies all SETRANGEs atomically; returns "OK".
+_LUA_SETRANGES = """\
+local key = KEYS[1]
+for i = 1, #ARGV, 2 do
+    redis.call('SETRANGE', key, tonumber(ARGV[i]), ARGV[i + 1])
+end
+return redis.status_reply('OK')
+"""
+
+
+def _dtype_to_str(dtype: torch.dtype) -> str:
+    """Convert a torch.dtype to its string representation."""
+    return str(dtype)
+
+
+def _str_to_dtype(s: str) -> torch.dtype:
+    """Convert a string representation back to a torch.dtype."""
+    return getattr(torch, s.split(".")[-1])
+
+
+def _tensor_to_bytes(tensor: torch.Tensor) -> bytes:
+    """Serialize a tensor to raw bytes."""
+    return tensor.detach().contiguous().cpu().numpy().tobytes()
+
+
+def _bytes_to_tensor(
+    data: bytes,
+    shape: list[int],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Deserialize raw bytes to a tensor using torch.frombuffer."""
+    return torch.frombuffer(bytearray(data), dtype=dtype).reshape(shape)
+
+
+def _decode_meta(raw_meta: dict) -> dict[str, str]:
+    """Decode a Redis hash response to a ``{str: str}`` dict."""
+    return {
+        k.decode() if isinstance(k, bytes) else k: (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in raw_meta.items()
+    }
+
+
+def _compute_byte_ranges(
+    shape: list[int],
+    dtype: torch.dtype,
+    idx,
+) -> list[tuple[int, int]] | None:
+    """Compute per-row ``(byte_offset, byte_length)`` pairs for the write path."""
+    if isinstance(idx, tuple):
+        if len(idx) == 1:
+            idx = idx[0]
+        else:
+            return None
+
+    if idx is Ellipsis:
+        idx = slice(None)
+
+    elem_size = torch.tensor([], dtype=dtype).element_size()
+    row_size = elem_size
+    for s in shape[1:]:
+        row_size *= s
+
+    if isinstance(idx, int):
+        pos = idx % shape[0]
+        return [(pos * row_size, row_size)]
+
+    if isinstance(idx, (slice, range)):
+        positions = range(*idx.indices(shape[0])) if isinstance(idx, slice) else idx
+        if len(positions) == 0:
+            return []
+        if positions.step == 1:
+            return [(positions[0] * row_size, len(positions) * row_size)]
+        return [(p * row_size, row_size) for p in positions]
+
+    if isinstance(idx, list):
+        return [(int(p) * row_size, row_size) for p in idx]
+
+    if isinstance(idx, torch.Tensor):
+        if idx.dtype == torch.bool:
+            positions = idx.nonzero(as_tuple=False).squeeze(-1).tolist()
+        else:
+            positions = idx.reshape(-1).tolist()
+        return [(int(p) * row_size, row_size) for p in positions]
+
+    return None
+
+
+def _compute_covering_range(
+    shape: list[int],
+    dtype: torch.dtype,
+    idx,
+) -> tuple[int, int] | None:
+    """Compute a single ``(byte_offset, byte_length)`` for the read path."""
+    if isinstance(idx, tuple):
+        idx = idx[0] if len(idx) == 1 else None
+    if idx is None:
+        return None
+    if idx is Ellipsis:
+        idx = slice(None)
+
+    elem_size = torch.tensor([], dtype=dtype).element_size()
+    row_size = elem_size
+    for s in shape[1:]:
+        row_size *= s
+
+    if isinstance(idx, int):
+        pos = idx % shape[0]
+        return (pos * row_size, row_size)
+
+    if isinstance(idx, (slice, range)):
+        positions = range(*idx.indices(shape[0])) if isinstance(idx, slice) else idx
+        if len(positions) == 0:
+            return (0, 0)
+        start = positions[0]
+        stop = positions[-1] + 1
+        return (start * row_size, (stop - start) * row_size)
+
+    return None
+
+
+def _get_local_idx(idx, shape_0: int):
+    """Return a local post-index to apply after fetching a covering range."""
+    if isinstance(idx, tuple):
+        idx = idx[0] if len(idx) == 1 else idx
+    if idx is Ellipsis:
+        return None
+    if isinstance(idx, int):
+        return None
+    if isinstance(idx, (slice, range)):
+        positions = range(*idx.indices(shape_0)) if isinstance(idx, slice) else idx
+        if len(positions) == 0 or positions.step == 1:
+            return None
+        return slice(None, None, positions.step)
+    return None
+
+
+def _is_scattered_index(idx) -> bool:
+    """Return True when *idx* is tensor / list / bool."""
+    if isinstance(idx, tuple):
+        idx = idx[0] if len(idx) == 1 else idx
+    if idx is Ellipsis:
+        return False
+    if isinstance(idx, (int, slice, range)):
+        return False
+    if isinstance(idx, (list, torch.Tensor)):
+        return True
+    return False
+
+
+def _getitem_result_shape(
+    shape: list[int],
+    idx,
+) -> list[int]:
+    """Compute the result shape of ``tensor[idx]`` without creating a tensor."""
+    if isinstance(idx, tuple):
+        if len(idx) == 1:
+            idx = idx[0]
+        else:
+            return list(torch.zeros(shape)[idx].shape)
+
+    if idx is Ellipsis:
+        idx = slice(None)
+
+    rest = list(shape[1:])
+
+    if isinstance(idx, int):
+        return rest
+
+    if isinstance(idx, slice):
+        n = len(range(*idx.indices(shape[0])))
+        return [n] + rest
+
+    if isinstance(idx, range):
+        return [len(idx)] + rest
+
+    if isinstance(idx, list):
+        return [len(idx)] + rest
+
+    if isinstance(idx, torch.Tensor):
+        if idx.dtype == torch.bool:
+            n = int(idx.sum().item())
+        else:
+            n = idx.numel()
+        return [n] + rest
+
+    return list(torch.zeros(shape)[idx].shape)
+
+
+for _name in __all__:
+    _obj = globals()[_name]
+    if callable(_obj):
+        _obj.__module__ = "tensordict.store._store"

--- a/test/test_store_utils_split.py
+++ b/test/test_store_utils_split.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import torch
+
+
+def test_store_helper_import_paths_are_preserved():
+    store_module = importlib.import_module("tensordict.store._store")
+    helper_module = importlib.import_module("tensordict.store._utils")
+
+    for name in helper_module.__all__:
+        assert getattr(store_module, name) is getattr(helper_module, name)
+
+    assert store_module._tensor_to_bytes.__module__ == "tensordict.store._store"
+
+
+def test_store_byte_range_helpers():
+    helper_module = importlib.import_module("tensordict.store._utils")
+
+    assert helper_module._compute_byte_ranges([5, 2], torch.float32, 1) == [(8, 8)]
+    assert helper_module._compute_byte_ranges([5, 2], torch.float32, slice(1, 4)) == [
+        (8, 24)
+    ]
+    assert helper_module._compute_covering_range(
+        [5, 2], torch.float32, slice(1, 5, 2)
+    ) == (8, 24)
+    assert helper_module._get_local_idx(slice(1, 5, 2), 5) == slice(None, None, 2)
+    assert helper_module._is_scattered_index(torch.tensor([1, 3]))
+    assert helper_module._getitem_result_shape([5, 2], torch.tensor([1, 3])) == [2, 2]
+
+
+def test_store_tensor_byte_roundtrip():
+    helper_module = importlib.import_module("tensordict.store._utils")
+    tensor = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+
+    data = helper_module._tensor_to_bytes(tensor)
+    restored = helper_module._bytes_to_tensor(data, [3, 2], torch.float32)
+
+    assert torch.equal(restored, tensor)


### PR DESCRIPTION
## Summary
- move TensorDictStore byte/range/index helper functions and Lua scripts into `tensordict.store._utils`
- keep `tensordict.store._store` re-exporting the private helper names
- preserve helper `__module__` values as `tensordict.store._store`
- add Redis-free tests for import identity, byte range helpers, and tensor byte round trips

## BC notes
- private imports from `tensordict.store._store` remain valid
- public store classes and top-level `tensordict.store` exports are unchanged

## Test plan
- `python -m pytest test/test_store_utils_split.py -q`
- `python -m compileall -q tensordict/store/_store.py tensordict/store/_utils.py`
- import smoke test for `TensorDictStore`, `LazyStackedTensorDictStore`, and `_compute_byte_ranges` module paths

I did not run the Redis-backed `test/test_store.py` suite locally because no Redis server is running on `localhost:6379`.