### PR TITLE
[Feature] Add generator support to ProbabilisticTensorDictModule

### DIFF
--- a/tensordict/nn/probabilistic.py
+++ b/tensordict/nn/probabilistic.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import collections
+import contextlib
 import re
 import warnings
 from collections.abc import MutableSequence
 from textwrap import indent
-from typing import Any, Dict, List, OrderedDict, overload, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, OrderedDict, overload, TYPE_CHECKING
 
 import torch
 
@@ -156,6 +157,38 @@ class set_interaction_type(_DecoratorContextManager):
         _interaction_type.set_mode(self.prev)
 
 
+@contextlib.contextmanager
+def _use_generator(generator: torch.Generator | None):
+    """Temporarily route the global RNG through ``generator`` for the duration of the block.
+
+    On entry the current global RNG state (CPU and, if applicable, the relevant CUDA device)
+    is forked, the generator's state is loaded into the global RNG, and the block runs.
+    On exit, the post-sample global state is written back to ``generator`` so its stream
+    advances in place, then the original global state is restored.
+
+    No-op when ``generator`` is ``None`` or when running under ``torch.compile``: in the
+    compile case fork_rng is not traceable, so we leave the global RNG as-is.
+    """
+    if generator is None or is_compiling():
+        yield
+        return
+    device = generator.device
+    if device.type == "cuda":
+        with torch.random.fork_rng(devices=[device.index]):
+            torch.cuda.set_rng_state(generator.get_state(), device)
+            try:
+                yield
+            finally:
+                generator.set_state(torch.cuda.get_rng_state(device))
+    else:
+        with torch.random.fork_rng(devices=[]):
+            torch.set_rng_state(generator.get_state())
+            try:
+                yield
+            finally:
+                generator.set_state(torch.get_rng_state())
+
+
 class ProbabilisticTensorDictModule(TensorDictModuleBase):
     """A probabilistic TD Module.
 
@@ -268,6 +301,30 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
         n_empirical_estimate (int, optional): keyword-only argument.
             Number of samples to compute the empirical
             mean when it is not available. Defaults to 1000.
+        generator (torch.Generator, int, NestedKey, or None, optional): keyword-only argument.
+            Controls the random number generator used when sampling from the distribution
+            (relevant only for ``RANDOM`` and ``MEAN`` interaction types).
+
+            - ``None`` (default): the global PyTorch RNG is used (current behaviour).
+            - :class:`torch.Generator`: this generator is used for every sample. Its state
+              advances in place across calls, so consecutive forward passes draw distinct
+              samples. The generator must live on the same device as the distribution
+              parameters.
+            - :class:`int`: shorthand for ``torch.Generator().manual_seed(int)``; a CPU
+              generator is created at construction time and used statefully thereafter.
+            - :class:`NestedKey` (``str`` or ``tuple``): the generator is fetched from the
+              input tensordict at this key on every call. The value may be a
+              :class:`torch.Generator` (used in place, state mutates) or an integer scalar
+              (read as a stream-key, then a fresh ``next_seed`` is written back to the
+              same key after sampling, JAX-PRNG-style).
+
+            .. note:: PyTorch's :class:`~torch.distributions.Distribution` API does not
+                accept a ``generator`` argument. Internally, sampling is wrapped in
+                :func:`torch.random.fork_rng` and the global RNG state is swapped with the
+                provided generator's state for the duration of the call. This makes the
+                approach portable across all distributions (including reparameterized
+                ``rsample`` and discrete ``sample``) but is not compatible with
+                ``torch.compile`` — under compile the argument is silently ignored.
 
     Examples:
         >>> import torch
@@ -358,6 +415,7 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
         cache_dist: bool = False,
         n_empirical_estimate: int = 1000,
         num_samples: int | torch.Size | None = None,
+        generator: torch.Generator | int | NestedKey | None = None,
     ) -> None:
         super().__init__()
         distribution_kwargs = (
@@ -443,6 +501,28 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
             num_samples = torch.Size((num_samples,))
         self.num_samples = num_samples
         self._composite_lp_aggreate_at_init = composite_lp_aggregate()
+
+        # Generator: either a stateful Generator owned by this module, or a NestedKey
+        # to pull a Generator/seed from the input tensordict on every call.
+        if generator is None:
+            self._generator = None
+            self._generator_key = None
+        elif isinstance(generator, torch.Generator):
+            self._generator = generator
+            self._generator_key = None
+        elif isinstance(generator, int) and not isinstance(generator, bool):
+            owned = torch.Generator()
+            owned.manual_seed(generator)
+            self._generator = owned
+            self._generator_key = None
+        elif isinstance(generator, (str, tuple)):
+            self._generator = None
+            self._generator_key = unravel_key(generator)
+        else:
+            raise TypeError(
+                f"generator must be a torch.Generator, int, NestedKey, or None; "
+                f"got {type(generator).__name__}."
+            )
 
     def __repr__(self):
         return (
@@ -611,7 +691,12 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
 
         dist = self.get_dist(tensordict)
         if _requires_sample:
-            out_tensors = self._dist_sample(dist, interaction_type=interaction_type())
+            generator, writeback = self._resolve_generator(tensordict)
+            out_tensors = self._dist_sample(
+                dist, interaction_type=interaction_type(), generator=generator
+            )
+            if writeback is not None:
+                writeback(generator)
             if self.num_samples is not None:
                 # TODO: capture contiguous error here
                 tensordict_out = tensordict_out.expand(
@@ -669,10 +754,73 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
             # )
         return tensordict_out
 
+    def _resolve_generator(
+        self, tensordict: TensorDictBase
+    ) -> tuple[torch.Generator | None, Callable[[torch.Generator], None] | None]:
+        """Resolve the generator to use for the current call.
+
+        Returns a ``(generator, writeback)`` tuple. ``writeback`` is either ``None`` (no
+        action needed after sampling) or a callable that, given the just-used generator,
+        writes a fresh seed back to the input tensordict (stream-key form).
+        """
+        if self._generator is not None:
+            return self._generator, None
+        if self._generator_key is None:
+            return None, None
+        value = tensordict.get(self._generator_key, default=None)
+        if value is None:
+            return None, None
+        unwrapped = value.data if is_non_tensor(value) else value
+        if isinstance(unwrapped, torch.Generator):
+            return unwrapped, None
+        if isinstance(unwrapped, torch.Tensor):
+            if unwrapped.numel() != 1:
+                raise ValueError(
+                    f"Generator key {self._generator_key!r} resolved to a tensor "
+                    f"of {unwrapped.numel()} elements; expected a scalar seed."
+                )
+            seed = int(unwrapped.item())
+            device = unwrapped.device
+            seed_was_tensor = True
+        elif isinstance(unwrapped, int) and not isinstance(unwrapped, bool):
+            seed = unwrapped
+            device = self._infer_param_device(tensordict)
+            seed_was_tensor = False
+        else:
+            raise TypeError(
+                f"Generator key {self._generator_key!r} resolved to a value of type "
+                f"{type(unwrapped).__name__}; expected torch.Generator, int, or scalar Tensor."
+            )
+        local_gen = torch.Generator(device=device)
+        local_gen.manual_seed(seed)
+        key = self._generator_key
+
+        def writeback(gen: torch.Generator) -> None:
+            next_seed_t = torch.randint(
+                0, 2**62, (), generator=gen, dtype=torch.int64, device=device
+            )
+            if seed_was_tensor:
+                tensordict.set(key, next_seed_t)
+            else:
+                from tensordict.tensorclass import NonTensorData
+
+                tensordict.set(key, NonTensorData(int(next_seed_t.item())))
+
+        return local_gen, writeback
+
+    def _infer_param_device(self, tensordict: TensorDictBase) -> torch.device:
+        for k in self.in_keys:
+            v = tensordict.get(k, default=None)
+            if isinstance(v, torch.Tensor):
+                return v.device
+        return torch.device("cpu")
+
     def _dist_sample(
         self,
         dist: D.Distribution,
         interaction_type: InteractionType | None = None,
+        *,
+        generator: torch.Generator | None = None,
     ) -> tuple[Tensor, ...] | Tensor:
         if not isinstance(dist, D.Distribution):
             raise TypeError("Expected Distribution, but got {}".format(type(dist)))
@@ -751,19 +899,21 @@ class ProbabilisticTensorDictModule(TensorDictModuleBase):
                     return dist.mean
                 except NotImplementedError:
                     pass
-            if dist.has_rsample:
-                return dist.rsample((self.n_empirical_estimate,)).mean(0)
-            else:
-                return dist.sample((self.n_empirical_estimate,)).mean(0)
+            with _use_generator(generator):
+                if dist.has_rsample:
+                    return dist.rsample((self.n_empirical_estimate,)).mean(0)
+                else:
+                    return dist.sample((self.n_empirical_estimate,)).mean(0)
 
         elif interaction_type is InteractionType.RANDOM:
             num_samples = self.num_samples
             if num_samples is None:
                 num_samples = torch.Size(())
-            if dist.has_rsample:
-                return dist.rsample(num_samples)
-            else:
-                return dist.sample(num_samples)
+            with _use_generator(generator):
+                if dist.has_rsample:
+                    return dist.rsample(num_samples)
+                else:
+                    return dist.sample(num_samples)
         else:
             raise NotImplementedError(f"unknown interaction_type {interaction_type}")
 
@@ -1218,7 +1368,15 @@ class ProbabilisticTensorDictSequential(TensorDictSequential):
             ):
                 dist = tdm.get_dist(td_copy)
                 if i < len(self.module) - 1:
-                    sample = tdm._dist_sample(dist, interaction_type=interaction_type())
+                    if isinstance(tdm, ProbabilisticTensorDictModule):
+                        gen, writeback = tdm._resolve_generator(td_copy)
+                    else:
+                        gen, writeback = None, None
+                    sample = tdm._dist_sample(
+                        dist, interaction_type=interaction_type(), generator=gen
+                    )
+                    if writeback is not None:
+                        writeback(gen)
                     if tdm.num_samples not in ((), None):
                         td_copy = td_copy.expand(tdm.num_samples + td_copy.shape)
                     if isinstance(tdm, ProbabilisticTensorDictModule):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2702,6 +2702,219 @@ class TestProbabilisticTensorDictModule:
             mod.log_prob(mod(td.copy()))
             mod.log_prob_key
 
+    # ------------------------------------------------------------------
+    # generator argument: Generator object, int seed, and tensordict-key forms
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _make_normal(generator=None, default_interaction_type="random"):
+        return ProbabilisticTensorDictModule(
+            in_keys=["loc"],
+            out_keys=["sample"],
+            distribution_class=Normal,
+            distribution_kwargs={"scale": 1.0},
+            default_interaction_type=default_interaction_type,
+            generator=generator,
+        )
+
+    def test_generator_module_level_generator(self):
+        """Two actors with same-seeded Generators should produce identical samples."""
+        g1 = torch.Generator().manual_seed(0)
+        g2 = torch.Generator().manual_seed(0)
+        m1 = self._make_normal(generator=g1)
+        m2 = self._make_normal(generator=g2)
+        # Set the global RNG to a different state to make sure we're not relying on it
+        torch.manual_seed(999)
+        s1 = m1(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        s2 = m2(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert torch.equal(s1, s2)
+
+    def test_generator_advances_in_place(self):
+        """Consecutive calls advance the generator's stream."""
+        g = torch.Generator().manual_seed(0)
+        m = self._make_normal(generator=g)
+        s1 = m(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        s2 = m(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert not torch.equal(s1, s2)
+
+    def test_generator_int_seed_equivalent_to_generator(self):
+        """Module-level int seed is shorthand for Generator().manual_seed(int)."""
+        m_int = self._make_normal(generator=0)
+        m_gen = self._make_normal(generator=torch.Generator().manual_seed(0))
+        s_int = m_int(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        s_gen = m_gen(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert torch.equal(s_int, s_gen)
+
+    def test_generator_isolates_global_rng(self):
+        """Sampling with a generator must not advance the global RNG."""
+        g = torch.Generator().manual_seed(0)
+        m = self._make_normal(generator=g)
+        torch.manual_seed(1234)
+        before = torch.get_rng_state()
+        m(TensorDict(loc=torch.zeros(4)))
+        after = torch.get_rng_state()
+        assert torch.equal(before, after)
+
+    def test_generator_independent_streams(self):
+        """Two same-seeded Generators on two actors stay synchronized only if used
+        independently and identically; sampling on one must not perturb the other."""
+        g1 = torch.Generator().manual_seed(0)
+        g2 = torch.Generator().manual_seed(0)
+        m1 = self._make_normal(generator=g1)
+        m2 = self._make_normal(generator=g2)
+        # Sample once on m1, then both — m2's first sample should match m1's first.
+        s1a = m1(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        s2a = m2(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert torch.equal(s1a, s2a)
+        s1b = m1(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        s2b = m2(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert torch.equal(s1b, s2b)
+        assert not torch.equal(s1a, s1b)
+
+    def test_generator_td_key_generator_form(self):
+        """Generator passed via tensordict key works like a module-level Generator."""
+        m_key = self._make_normal(generator="rng")
+        td = TensorDict(loc=torch.zeros(4))
+        td["rng"] = NonTensorData(torch.Generator().manual_seed(0))
+        s_key = m_key(td)["sample"].clone()
+        m_ref = self._make_normal(generator=torch.Generator().manual_seed(0))
+        s_ref = m_ref(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert torch.equal(s_key, s_ref)
+
+    def test_generator_td_key_int_seed_writeback(self):
+        """Int seed in the tensordict is treated as a stream-key: each call seeds a
+        fresh Generator, samples, then writes the next seed back to the tensordict."""
+        m = self._make_normal(generator="rng")
+
+        # Two independent runs starting from the same seed must produce the same
+        # trajectory.
+        def run(initial_seed, n_steps):
+            td = TensorDict(loc=torch.zeros(4))
+            td["rng"] = NonTensorData(initial_seed)
+            samples = []
+            for _ in range(n_steps):
+                out = m(td)
+                samples.append(out["sample"].clone())
+            return samples, td["rng"]
+
+        traj_a, last_a = run(42, 3)
+        traj_b, last_b = run(42, 3)
+        for a, b in zip(traj_a, traj_b):
+            assert torch.equal(a, b)
+        assert last_a == last_b
+        # And consecutive samples in a trajectory differ.
+        assert not torch.equal(traj_a[0], traj_a[1])
+        assert not torch.equal(traj_a[1], traj_a[2])
+        # And different starting seeds give different trajectories.
+        traj_c, _ = run(43, 3)
+        assert not torch.equal(traj_a[0], traj_c[0])
+
+    def test_generator_td_key_tensor_seed(self):
+        """A scalar Tensor seed in the tensordict round-trips as a Tensor."""
+        m = self._make_normal(generator="rng")
+        td = TensorDict(loc=torch.zeros(4), rng=torch.tensor(7, dtype=torch.int64))
+        m(td)
+        assert isinstance(td["rng"], torch.Tensor)
+        assert td["rng"].dtype == torch.int64
+        assert int(td["rng"].item()) != 7  # Got advanced.
+
+    def test_generator_no_overhead_when_unset(self):
+        """generator=None must leave the global-RNG path untouched."""
+        m = self._make_normal(generator=None)
+        torch.manual_seed(0)
+        s1 = m(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        torch.manual_seed(0)
+        s2 = m(TensorDict(loc=torch.zeros(4)))["sample"].clone()
+        assert torch.equal(s1, s2)
+
+    def test_generator_invalid_type(self):
+        with pytest.raises(TypeError, match="generator must be"):
+            ProbabilisticTensorDictModule(
+                in_keys=["loc"],
+                out_keys=["sample"],
+                distribution_class=Normal,
+                distribution_kwargs={"scale": 1.0},
+                generator=1.5,
+            )
+
+    def test_generator_nested_key(self):
+        """The generator NestedKey can be a tuple."""
+        m = ProbabilisticTensorDictModule(
+            in_keys=["loc"],
+            out_keys=["sample"],
+            distribution_class=Normal,
+            distribution_kwargs={"scale": 1.0},
+            default_interaction_type="random",
+            generator=("meta", "rng"),
+        )
+        td = TensorDict(loc=torch.zeros(4))
+        td["meta", "rng"] = NonTensorData(123)
+        m(td)
+        # Stream-key was written back at the nested location.
+        assert td["meta", "rng"] != 123
+
+    def test_generator_no_op_for_mode(self):
+        """MODE doesn't sample, so the generator is irrelevant and not advanced."""
+        g = torch.Generator().manual_seed(0)
+        state_before = g.get_state().clone()
+        m = self._make_normal(generator=g, default_interaction_type="mode")
+        m(TensorDict(loc=torch.tensor([1.0, 2.0, 3.0])))
+        assert torch.equal(g.get_state(), state_before)
+
+    def test_generator_categorical_uses_sample_path(self):
+        """Discrete distributions go through dist.sample (no rsample); generator must
+        still produce reproducible results."""
+        g1 = torch.Generator().manual_seed(0)
+        g2 = torch.Generator().manual_seed(0)
+        m1 = ProbabilisticTensorDictModule(
+            in_keys={"logits": "logits"},
+            out_keys=["sample"],
+            distribution_class=Categorical,
+            default_interaction_type="random",
+            generator=g1,
+        )
+        m2 = ProbabilisticTensorDictModule(
+            in_keys={"logits": "logits"},
+            out_keys=["sample"],
+            distribution_class=Categorical,
+            default_interaction_type="random",
+            generator=g2,
+        )
+        logits = torch.zeros(8, 4)
+        s1 = m1(TensorDict(logits=logits))["sample"].clone()
+        s2 = m2(TensorDict(logits=logits))["sample"].clone()
+        assert torch.equal(s1, s2)
+
+    def test_generator_in_sequential(self):
+        """ProbabilisticActor inheritance: generator threads through Sequential."""
+        prob = ProbabilisticTensorDictModule(
+            in_keys={"loc": "loc"},
+            out_keys=["sample"],
+            distribution_class=Normal,
+            distribution_kwargs={"scale": 1.0},
+            default_interaction_type="random",
+            generator=torch.Generator().manual_seed(0),
+        )
+        seq1 = ProbabilisticTensorDictSequential(
+            TensorDictModule(lambda x: x, in_keys=["x"], out_keys=["loc"]),
+            prob,
+        )
+        prob2 = ProbabilisticTensorDictModule(
+            in_keys={"loc": "loc"},
+            out_keys=["sample"],
+            distribution_class=Normal,
+            distribution_kwargs={"scale": 1.0},
+            default_interaction_type="random",
+            generator=torch.Generator().manual_seed(0),
+        )
+        seq2 = ProbabilisticTensorDictSequential(
+            TensorDictModule(lambda x: x, in_keys=["x"], out_keys=["loc"]),
+            prob2,
+        )
+        td = TensorDict(x=torch.zeros(4))
+        s1 = seq1(td.copy())["sample"].clone()
+        s2 = seq2(td.copy())["sample"].clone()
+        assert torch.equal(s1, s2)
+
 
 class TestEnsembleModule:
     def test_init(self):


### PR DESCRIPTION
## Motivation

Closes the gap reported in [pytorch/rl#3701](https://github.com/pytorch/rl/discussions/3701): there is currently no way to make sampling from a `ProbabilisticTensorDictModule` (or `ProbabilisticActor` in TorchRL) deterministic *without* touching the global `torch.manual_seed` state. This matters whenever the agent's RNG stream needs to be isolated from the environment's — e.g. the meta-environment / paired-RNG setup discussed in *Empirical Design in Reinforcement Learning* (Patterson et al., [arXiv:2304.01315](https://arxiv.org/abs/2304.01315)).

## Change

Adds a new keyword-only `generator` argument to `ProbabilisticTensorDictModule.__init__`. Three forms are accepted:

- **`torch.Generator`** — module owns it, state advances in place across calls.
- **`int`** — shorthand for `torch.Generator().manual_seed(int)` at construction time.
- **`NestedKey`** (`str` or `tuple`) — the generator is fetched from the input tensordict at every call. The value can be:
  - a `torch.Generator` (used in place), or
  - a scalar `int` / `Tensor` — read as a stream-key, the call seeds a fresh local Generator, samples, and writes a fresh `next_seed` back to the same key (JAX-PRNG-style).

The tensordict-key form is the one motivating the original discussion: it lets the RNG ride the tensordict alongside obs/reward, so determinism survives serialization, multi-process collectors, and recursive meta-envs without any global-state coupling.

`ProbabilisticActor` and `SafeProbabilisticTensorDictSequential` in TorchRL inherit the new kwarg for free through `ProbabilisticTensorDictSequential`.

## Implementation notes

PyTorch's `Distribution.sample` / `rsample` do **not** accept a `generator=` argument (and they delegate to `torch.normal`/`torch.bernoulli`/etc., which read the global RNG). So this PR introduces a small `_use_generator` context manager that wraps each `sample` / `rsample` site:

1. `fork_rng` to save current global state.
2. Load the user's generator's state into the global RNG.
3. Run the sample.
4. Write the (advanced) global state back to the user's generator so its stream advances in place.
5. `fork_rng` exit restores original global state.

This applies uniformly to every distribution — reparameterized `rsample`, discrete `sample`, composite distributions — without monkey-patching upstream torch.

The wrapper is a no-op when `generator is None` (the default — zero overhead on the existing path) and also under `torch.compile` (since `fork_rng` isn't traceable).

## int vs Generator: when to use which

| Aspect | `int` | `torch.Generator` |
|---|---|---|
| Serialization | 8 B | ~5 KB (mt19937 state) |
| Friendly across processes / checkpoints | yes | clunky |
| Stateful across calls | needs write-back via td-key form | yes, naturally |
| Per-call cost | one `manual_seed` + one `randint` for next-key | one state copy in/out |
| Easy to log | trivially | not really |

For ordinary inner-loop sampling either is fine; for serialized state on the wire, prefer `int`; for hot loops with no checkpoint round-tripping, prefer `Generator`.

## Tests

Adds 14 tests under `TestProbabilisticTensorDictModule` in `test/test_nn.py`, covering:
- module-level Generator (same-seed reproducibility, in-place advancement, isolation from `torch.manual_seed`)
- module-level int (equivalence to `Generator().manual_seed(int)`)
- tensordict-key form with `Generator`
- tensordict-key form with int seed (stream-key write-back, reproducible trajectories, scalar-Tensor variant, nested key)
- invalid type raises `TypeError`
- MODE/DETERMINISTIC paths leave the generator untouched
- discrete (`Categorical`) `sample`-path works
- threading through `ProbabilisticTensorDictSequential`

All 42 existing tests in `TestProbabilisticTensorDictModule` plus the broader prob/composite suite (204 tests total) pass unchanged.

## Test plan

- [x] `pytest test/test_nn.py::TestProbabilisticTensorDictModule -q` → 42 passed
- [x] `pytest test/test_nn.py -k 'probabilistic or Probabilistic or Prob or prob or composite or Composite' -q` → 204 passed
- [x] `pytest test/test_compile.py -k 'prob or Prob or sample' -q` → 2 passed