### PR TITLE
[Doc] Expand TensorClass docs: bracket form, flags, advertised features

### DIFF
--- a/docs/source/reference/tc.rst
+++ b/docs/source/reference/tc.rst
@@ -3,29 +3,34 @@
 tensorclass
 ===========
 
-The ``@tensorclass`` decorator helps you build custom classes that inherit the
-behaviour from :class:`~tensordict.TensorDict` while being able to restrict
-the possible entries to a predefined set or implement custom methods for your class.
+A *tensorclass* is a dataclass-like container that inherits all of
+:class:`~tensordict.TensorDict`'s machinery — indexing, reshaping,
+``to(device)``, ``stack``/``cat``, memory-mapped serialization, ``torch.compile``
+support — while exposing your fields as typed attributes rather than string
+keys. Tensorclasses let you constrain a container to a known set of fields,
+attach custom methods, and get IDE/type-checker support out of the box.
 
-Like :class:`~tensordict.TensorDict`, ``@tensorclass`` supports nesting,
-indexing, reshaping, item assignment. It also supports tensor operations like
-``clone``, ``squeeze``, ``torch.cat``, ``split`` and many more.
-``@tensorclass`` allows non-tensor entries,
-however all the tensor operations are strictly restricted to tensor attributes.
+There are two equivalent entry points:
 
-One needs to implement their custom methods for non-tensor data.
-It is important to note that ``@tensorclass`` does not enforce strict type matching
+* :class:`~tensordict.TensorClass` — the **inheritance-based** API. Recommended
+  for new code. Static type-checkers understand it without help, and the
+  parametric form ``TensorClass["autocast", ...]`` makes the configuration
+  explicit at the class declaration site.
+* :func:`~tensordict.tensorclass` — the **decorator** form. Kept for
+  backwards-compatibility and for migrating plain ``@dataclass`` code. See
+  :ref:`tensorclass-legacy-decorator` below.
+
+Quick start
+-----------
 
 .. code-block::
 
   >>> from __future__ import annotations
-  >>> from tensordict.prototype import tensorclass
-  >>> import torch
-  >>> from torch import nn
   >>> from typing import Optional
+  >>> import torch
+  >>> from tensordict import TensorClass
   >>>
-  >>> @tensorclass
-  ... class MyData:
+  >>> class MyData(TensorClass):
   ...     floatdata: torch.Tensor
   ...     intdata: torch.Tensor
   ...     non_tensordata: str
@@ -38,7 +43,7 @@ It is important to note that ``@tensorclass`` does not enforce strict type match
   ...   floatdata=torch.randn(3, 4, 5),
   ...   intdata=torch.randint(10, (3, 4, 1)),
   ...   non_tensordata="test",
-  ...   batch_size=[3, 4]
+  ...   batch_size=[3, 4],
   ... )
   >>> print("data:", data)
   data: MyData(
@@ -50,34 +55,15 @@ It is important to note that ``@tensorclass`` does not enforce strict type match
     device=None,
     is_shared=False)
   >>> data.nested = MyData(
-  ...     floatdata = torch.randn(3, 4, 5),
+  ...     floatdata=torch.randn(3, 4, 5),
   ...     intdata=torch.randint(10, (3, 4, 1)),
   ...     non_tensordata="nested_test",
-  ...     batch_size=[3, 4]
+  ...     batch_size=[3, 4],
   ... )
-  >>> print("nested:", data)
-  nested: MyData(
-    floatdata=Tensor(shape=torch.Size([3, 4, 5]), device=cpu, dtype=torch.float32, is_shared=False),
-    intdata=Tensor(shape=torch.Size([3, 4, 1]), device=cpu, dtype=torch.int64, is_shared=False),
-    non_tensordata='test',
-    nested=MyData(
-        floatdata=Tensor(shape=torch.Size([3, 4, 5]), device=cpu, dtype=torch.float32, is_shared=False),
-        intdata=Tensor(shape=torch.Size([3, 4, 1]), device=cpu, dtype=torch.int64, is_shared=False),
-        non_tensordata='nested_test',
-        nested=None,
-        batch_size=torch.Size([3, 4]),
-        device=None,
-        is_shared=False),
-    batch_size=torch.Size([3, 4]),
-    device=None,
-    is_shared=False)
 
-As it is the case with :class:`~tensordict.TensorDict`, from v0.4 if the batch size
-is omitted it is considered as empty.
-
-If a non-empty batch-size is provided, ``@tensorclass`` supports indexing.
-Internally the tensor objects gets indexed, however the non-tensor data
-remains the same
+If the batch size is omitted it defaults to an empty shape. With a non-empty
+batch size, tensor fields are indexed elementwise and non-tensor fields are
+preserved:
 
 .. code-block::
 
@@ -98,90 +84,239 @@ remains the same
      device=None,
      is_shared=False)
 
-``@tensorclass`` also supports setting and resetting attributes, even for nested objects.
-
-.. code-block::
-
-  >>> data.non_tensordata = "test_changed"
-  >>> print("data.non_tensordata: ", repr(data.non_tensordata))
-  data.non_tensordata: 'test_changed'
-
-  >>> data.floatdata = torch.ones(3, 4, 5)
-  >>> print("data.floatdata:", data.floatdata)
-  data.floatdata: tensor([[[1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.]],
-
-        [[1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.]],
-
-        [[1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1.]]])
-
-  >>> # Changing nested tensor data
-  >>> data.nested.non_tensordata = "nested_test_changed"
-  >>> print("data.nested.non_tensordata:", repr(data.nested.non_tensordata))
-  data.nested.non_tensordata: 'nested_test_changed'
-
-``@tensorclass`` supports multiple torch operations over the shape and device
-of its content, such as `stack`, `cat`, `reshape` or `to(device)`. To get
-a full list of the supported operations, check the tensordict documentation.
-
-Here is an example:
+Tensorclasses support attribute mutation (including on nested instances), the
+usual tensor-shape operations (``stack``, ``cat``, ``reshape``, ``to(device)``,
+...), and equality. See the :class:`~tensordict.TensorDict` documentation for
+the full list of operations.
 
 .. code-block::
 
   >>> data2 = data.clone()
   >>> cat_tc = torch.cat([data, data2], 0)
-  >>> print("Concatenated data:", catted_tc)
-  Concatenated data: MyData(
-     floatdata=Tensor(shape=torch.Size([6, 4, 5]), device=cpu, dtype=torch.float32, is_shared=False),
-     intdata=Tensor(shape=torch.Size([6, 4, 1]), device=cpu, dtype=torch.int64, is_shared=False),
-     non_tensordata='test_changed',
-     nested=MyData(
-         floatdata=Tensor(shape=torch.Size([6, 4, 5]), device=cpu, dtype=torch.float32, is_shared=False),
-         intdata=Tensor(shape=torch.Size([6, 4, 1]), device=cpu, dtype=torch.int64, is_shared=False),
-         non_tensordata='nested_test_changed',
-         nested=None,
-         batch_size=torch.Size([6, 4]),
-         device=None,
-         is_shared=False),
-     batch_size=torch.Size([6, 4]),
-     device=None,
-     is_shared=False)
+  >>> assert cat_tc.batch_size == torch.Size([6, 4])
+
+Flags
+-----
+
+The behaviour of a tensorclass is controlled by a handful of mutually
+intelligible flags. They can be set in three equivalent forms — pick whichever
+reads best:
+
+.. code-block::
+
+  >>> class Foo(TensorClass["autocast"]):     # bracket form
+  ...     x: int
+  >>> class Foo(TensorClass, autocast=True):  # kwargs form
+  ...     x: int
+  >>> @tensorclass(autocast=True)             # decorator form
+  ... class Foo:
+  ...     x: int
+
+Multiple flags can be combined in the brackets:
+
+.. code-block::
+
+  >>> class Foo(TensorClass["nocast", "frozen"]):
+  ...     x: int
+
+The bracket form is the one that static type-checkers (mypy, pyright) resolve
+correctly via :meth:`~object.__class_getitem__`, so IDE completion on instance
+attributes works without further configuration.
+
+The available flags are:
+
+* ``autocast`` — coerce values back to the field's annotated type when reading.
+  Useful when a field is conceptually a scalar, string, or enum.
+* ``nocast`` — store tensor-compatible scalars (``int``, ``float``,
+  ``np.ndarray``, ...) as-is, without wrapping them in a tensor.
+* ``tensor_only`` — every field must hold a tensor (or be tensor-castable).
+  Skips the non-tensor storage path and yields measurable speed-ups on
+  attribute access — recommended for performance-critical containers (RL
+  trajectories, model I/O batches).
+* ``frozen`` — immutable instances, in the spirit of
+  ``@dataclass(frozen=True)``. Plays well with ``torch.compile`` and functional
+  code paths.
+* ``shadow`` — opt out of the check that forbids field names colliding with
+  reserved TensorDict attributes (``batch_size``, ``device``, ``data``, ...).
+
+``autocast``, ``nocast`` and ``tensor_only`` are mutually exclusive. See the
+:class:`~tensordict.TensorClass` docstring for per-flag runnable examples.
+
+.. _tensorclass-autocasting:
+
+Auto-casting
+~~~~~~~~~~~~
+
+.. warning:: Auto-casting is an experimental feature and subject to changes in
+  the future. Compatibility with python<=3.9 is limited.
+
+With ``autocast`` enabled, methods such as ``__setattr__``, ``update``,
+``update_`` and ``from_dict`` will attempt to cast type-annotated entries to
+the desired TensorDict / tensorclass instance (except in cases detailed below).
+For instance, the following code casts the ``td`` dictionary to a
+:class:`~tensordict.TensorDict` and the ``tc`` entry to a ``MyClass`` instance:
+
+    >>> class MyClass(TensorClass["autocast"]):
+    ...     tensor: torch.Tensor
+    ...     td: TensorDict
+    ...     tc: MyClass
+    ...
+    >>> obj = MyClass(
+    ...     tensor=torch.randn(()),
+    ...     td={"a": torch.randn(())},
+    ...     tc={"tensor": torch.randn(()), "td": None, "tc": None})
+    >>> assert isinstance(obj.tensor, torch.Tensor)
+    >>> assert isinstance(obj.tc, MyClass)
+    >>> assert isinstance(obj.td, TensorDict)
+
+.. note:: Type-annotated items that include a ``typing.Optional`` or
+  ``typing.Union`` will not be compatible with auto-casting, but other items in
+  the tensorclass will:
+
+    >>> class MyClass(TensorClass["autocast"]):
+    ...     tensor: torch.Tensor
+    ...     tc_autocast: MyClass = None
+    ...     tc_not_autocast: Optional[MyClass] = None
+    >>> obj = MyClass(
+    ...     tensor=torch.randn(()),
+    ...     tc_autocast={"tensor": torch.randn(())},
+    ...     tc_not_autocast={"tensor": torch.randn(())},
+    ... )
+    >>> assert isinstance(obj.tc_autocast, MyClass)
+    >>> # because the type is Optional or Union, auto-casting is disabled for
+    >>> # that variable.
+    >>> assert not isinstance(obj.tc_not_autocast, MyClass)
+
+  If at least one item in the class is annotated using the ``type0 | type1``
+  semantic, the whole class auto-casting capabilities are deactivated.
+  Because tensorclass supports non-tensor leaves, setting a dictionary in
+  these cases will lead to setting it as a plain dictionary instead of a
+  tensor collection subclass (``TensorDict`` or tensorclass).
+
+.. note:: Auto-casting isn't enabled for leaves (tensors). The reason is that
+  this feature isn't compatible with type annotations that contain the
+  ``type0 | type1`` type-hint semantics, which are widespread. Allowing
+  auto-casting on leaves would result in very similar code having drastically
+  different behaviour depending on small annotation differences.
+
+Performance with ``tensor_only``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default tensorclass attribute getter first looks in the tensor storage and
+then falls back to the non-tensor storage. ``tensor_only`` skips that fallback,
+which makes ``self.field`` a direct dict lookup. For containers that genuinely
+hold only tensors (think batched observations, actions, rewards in RL, or model
+inputs/outputs) this can save a meaningful share of per-step overhead.
+
+    >>> class TrajectoryBatch(TensorClass["tensor_only"]):
+    ...     obs: torch.Tensor
+    ...     action: torch.Tensor
+    ...     reward: torch.Tensor
+
+Non-tensor inputs that are tensor-castable (Python scalars, numpy arrays) are
+still accepted — they are converted to tensors at assignment time.
+
+Immutability with ``frozen``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``frozen=True`` makes instances immutable, mirroring ``@dataclass(frozen=True)``.
+Frozen tensorclasses are a good fit for state objects passed through
+``torch.compile`` or functional pipelines where in-place mutation would be a
+correctness hazard.
+
+    >>> class State(TensorClass["frozen"]):
+    ...     params: torch.Tensor
+    ...     step: torch.Tensor
+    >>> s = State(params=torch.zeros(3), step=torch.zeros((), dtype=torch.long))
+    >>> s.step = s.step + 1   # raises dataclasses.FrozenInstanceError
+
+``frozen`` is inherited: a non-frozen subclass cannot inherit from a frozen
+base, and vice versa.
+
+Migrating from a plain dataclass
+--------------------------------
+
+If you already have a ``@dataclass``, :func:`~tensordict.from_dataclass` will
+build a tensorclass type or instance from it without rewriting the class
+definition:
+
+.. code-block::
+
+  >>> from dataclasses import dataclass
+  >>> from tensordict import from_dataclass
+  >>>
+  >>> @dataclass
+  ... class X:
+  ...     a: int
+  ...     b: torch.Tensor
+  >>>
+  >>> XTc = from_dataclass(X, autocast=True)   # convert the type
+  >>> x_tc = from_dataclass(X(a=0, b=torch.zeros(())))  # convert an instance
+
+The same configuration flags (``autocast``, ``nocast``, ``frozen``,
+``tensor_only``, ``shadow``) are accepted.
+
+Non-tensor data: ``NonTensorData`` vs ``MetaData``
+--------------------------------------------------
+
+Tensorclasses transparently support non-tensor fields. Two wrappers carry such
+values and they differ in how they react to shape operations:
+
+* :class:`~tensordict.NonTensorData` — the default. Behaves like a regular
+  TensorDict entry under shape operations: stacking a list of
+  ``NonTensorData`` items along a new dimension keeps every value, expansion
+  broadcasts to the requested shape, indexing returns the corresponding entry.
+* :class:`~tensordict.MetaData` — broadcasts a single value across the batch.
+  Stacking ``MetaData("a")`` and ``MetaData("a")`` returns ``MetaData("a")``;
+  stacking with a different value raises. Use this for static, per-class
+  metadata (a string label, a configuration dict) that should not multiply
+  under batching.
+
+Typed ``nn.Module`` I/O
+-----------------------
+
+For modules whose inputs and outputs are tensorclasses, use
+:class:`~tensordict.nn.TensorClassModuleBase`. The generic parameters declare
+the input and output types, giving IDE completion, refactor safety, and an
+``as_td_module()`` adapter for use inside
+:class:`~tensordict.nn.TensorDictSequential` pipelines. See the
+:doc:`nn` reference for a complete example.
+
+``torch.compile`` and cudagraphs
+--------------------------------
+
+Tensorclasses are designed to compile well. A few practical notes:
+
+* Prefer ``frozen=True`` for state objects when you can — the compiler reasons
+  about immutable containers more cleanly than about mutable ones.
+* ``tensor_only=True`` containers avoid the non-tensor lookup branch and tend
+  to produce simpler graphs.
+* Avoid data-dependent shapes (``.item()`` on a tensor that controls a Python
+  branch) and prefer :func:`torch.where` over Python ``if``/``else`` on tensor
+  values.
 
 Serialization
 -------------
 
-Saving a tensorclass instance can be achieved with the `memmap` method.
-The saving strategy is as follows: tensor data will be saved using memory-mapped
-tensors, and non-tensor data that can be serialized using a json format will
-be saved as such. Other data types will be saved using :func:`~torch.save`, which
-relies on `pickle`.
+A tensorclass instance can be saved with the ``memmap`` method. Tensor data is
+written as memory-mapped tensors and JSON-serializable non-tensor data is
+written as JSON; remaining data is pickled via :func:`~torch.save`.
 
-Deserializing a `tensorclass` can be done via :meth:`~tensordict.TensorDict.load_memmap`.
-The instance created will have the same type as the one saved provided that
-the `tensorclass` is available in the working environment:
+Loading is done with :meth:`~tensordict.TensorDict.load_memmap`. The instance
+recovers its original type provided the tensorclass is importable in the
+loading process:
 
   >>> data.memmap("path/to/saved/directory")
   >>> data_loaded = TensorDict.load_memmap("path/to/saved/directory")
   >>> assert isinstance(data_loaded, type(data))
 
-
 Edge cases
 ----------
 
-``@tensorclass`` supports equality and inequality operators, even for
-nested objects. Note that the non-tensor/ meta data is not validated.
-This will return a tensor class object with boolean values for
-tensor attributes and None for non-tensor attributes
-
-Here is an example:
+Tensorclasses support equality and inequality operators, including for nested
+instances. Non-tensor / meta data is not validated by these operators; the
+returned tensorclass has boolean leaves for tensor fields and ``None`` for
+non-tensor fields.
 
 .. code-block::
 
@@ -202,15 +337,10 @@ Here is an example:
      device=None,
      is_shared=False)
 
-``@tensorclass`` supports setting an item. However, while setting an item
-the identity check of non-tensor / meta data is done instead of equality to
-avoid performance issues. User needs to make sure that the non-tensor data
-of an item matches with the object to avoid discrepancies.
-
-Here is an example:
-
-While setting an item with different ``non_tensor`` data, a :class:`UserWarning` will be
-thrown
+Item assignment performs an *identity* check on non-tensor / meta data rather
+than equality, for performance reasons. If the values differ, a
+``UserWarning`` is emitted; users are responsible for keeping non-tensor data
+in sync.
 
 .. code-block::
 
@@ -218,52 +348,31 @@ thrown
   >>> data[0] = data2[0]
   UserWarning: Meta data at 'non_tensordata' may or may not be equal, this may result in undefined behaviours
 
-Even though ``@tensorclass`` supports torch functions like :func:`~torch.cat`
-and :func:`~torch.stack`, the non-tensor / meta data is not validated.
-The torch operation is performed on the tensor data and while returning the
-output, the non-tensor / meta data of the first tensor class object is
-considered. User needs to make sure that all the list of tensor class objects
-have the same non-tensor data to avoid discrepancies
-
-Here is an example:
+``torch.cat`` / ``torch.stack`` work on tensorclasses but do not validate
+non-tensor / meta fields — the operation runs on the tensor leaves and the
+non-tensor data of the *first* instance in the list is kept. If the inputs
+disagree on a non-tensor field, the output will silently follow the first one:
 
 .. code-block::
 
   >>> data2.non_tensordata = "test_new"
   >>> stack_tc = torch.cat([data, data2], dim=0)
-  >>> print(stack_tc)
-  MyData(
-      floatdata=Tensor(shape=torch.Size([2, 3, 4, 5]), device=cpu, dtype=torch.float32, is_shared=False),
-      intdata=Tensor(shape=torch.Size([2, 3, 4, 1]), device=cpu, dtype=torch.int64, is_shared=False),
-      non_tensordata='test',
-      nested=MyData(
-          floatdata=Tensor(shape=torch.Size([2, 3, 4, 5]), device=cpu, dtype=torch.float32, is_shared=False),
-          intdata=Tensor(shape=torch.Size([2, 3, 4, 1]), device=cpu, dtype=torch.int64, is_shared=False),
-          non_tensordata='nested_test',
-          nested=None,
-          batch_size=torch.Size([2, 3, 4]),
-          device=None,
-          is_shared=False),
-      batch_size=torch.Size([2, 3, 4]),
-      device=None,
-      is_shared=False)
+  >>> assert stack_tc.non_tensordata == "test"  # data's value wins
 
-``@tensorclass`` also supports pre-allocation, you can initialize
-the object with attributes being None and later set them. Note that while
-initializing, internally the ``None`` attributes will be saved as non-tensor / meta data
-and while resetting, based on the type of the value of the attribute,
-it will be saved as either tensor data or non-tensor / meta  data
+Pre-allocation
+--------------
 
-Here is an example:
+Fields can be initialised to ``None`` and assigned later. While ``None``, the
+attribute is stored as non-tensor / meta data; on assignment the appropriate
+storage is selected based on the value's type.
 
 .. code-block::
 
-  >>> @tensorclass
-  ... class MyClass:
-  ...   X: Any
-  ...   y: Any
-
-  >>> data = MyClass(X=None, y=None, batch_size = [3,4])
+  >>> class MyClass(TensorClass):
+  ...     X: Any
+  ...     y: Any
+  >>>
+  >>> data = MyClass(X=None, y=None, batch_size=[3, 4])
   >>> data.X = torch.ones(3, 4, 5)
   >>> data.y = "testing"
   >>> print(data)
@@ -274,89 +383,47 @@ Here is an example:
      device=None,
      is_shared=False)
 
+.. _tensorclass-legacy-decorator:
+
+Legacy: the ``@tensorclass`` decorator
+--------------------------------------
+
+The :func:`~tensordict.tensorclass` decorator is the original way to declare a
+tensorclass. It is kept for backwards compatibility and remains the most
+convenient option when migrating a body of ``@dataclass`` code. New code is
+encouraged to use :class:`~tensordict.TensorClass` instead, which carries
+identical semantics with better static-type-checker support.
+
+.. code-block::
+
+  >>> from __future__ import annotations
+  >>> from typing import Optional
+  >>> from tensordict import tensorclass
+  >>> import torch
+  >>>
+  >>> @tensorclass
+  ... class MyData:
+  ...     floatdata: torch.Tensor
+  ...     intdata: torch.Tensor
+  ...     non_tensordata: str
+  ...     nested: Optional[MyData] = None
+
+All flags described above are accepted as keyword arguments to the decorator:
+``@tensorclass(autocast=True)``, ``@tensorclass(frozen=True, tensor_only=True)``,
+etc.
+
+API reference
+-------------
+
 .. autosummary::
     :toctree: generated/
     :template: td_template.rst
 
-    tensorclass
     TensorClass
+    tensorclass
     NonTensorData
     MetaData
     NonTensorStack
     TensorAttrs
     UnbatchedTensor
     from_dataclass
-
-Auto-casting
-------------
-
-.. warning:: Auto-casting is an experimental feature and subject to changes in
-  the future. Compatibility with python<=3.9 is limited.
-
-``@tensorclass`` partially supports auto-casting as an experimental feature.
-Methods such as ``__setattr__``, ``update``, ``update_`` and ``from_dict`` will
-attempt to cast type-annotated entries to the desired TensorDict / tensorclass
-instance (except in cases detailed below). For instance, following code will
-cast the `td` dictionary to a :class:`~tensordict.TensorDict` and the `tc`
-entry to a :class:`MyClass` instance:
-
-    >>> @tensorclass
-    ... class MyClass:
-    ...     tensor: torch.Tensor
-    ...     td: TensorDict
-    ...     tc: MyClass
-    ...
-    >>> obj = MyClass(
-    ...     tensor=torch.randn(()),
-    ...     td={"a": torch.randn(())},
-    ...     tc={"tensor": torch.randn(()), "td": None, "tc": None})
-    >>> assert isinstance(obj.tensor, torch.Tensor)
-    >>> assert isinstance(obj.tc, TensorDict)
-    >>> assert isinstance(obj.td, MyClass)
-
-.. note:: Type annotated items that include an ``typing.Optional`` or
-  ``typing.Union`` will not be compatible with auto-casting, but other items
-  in the tensorclass will:
-
-    >>> @tensorclass
-    ... class MyClass:
-    ...     tensor: torch.Tensor
-    ...     tc_autocast: MyClass = None
-    ...     tc_not_autocast: Optional[MyClass] = None
-    >>> obj = MyClass(
-    ...     tensor=torch.randn(()),
-    ...     tc_autocast={"tensor": torch.randn(())},
-    ...     tc_not_autocast={"tensor": torch.randn(())},
-    ... )
-    >>> assert isinstance(obj.tc_autocast, MyClass)
-    >>> # because the type is Optional or Union, auto-casting is disabled for
-    >>> # that variable.
-    >>> assert not isinstance(obj.tc_not_autocast, MyClass)
-
-  If at least one item in the class is annotated using the ``type0 | type1``
-  semantic, the whole class auto-casting capabilities are deactivated.
-  Because ``tensorclass`` supports non-tensor leaves, setting a dictionary in
-  these cases will lead to setting it as a plain dictionary instead of a
-  tensor collection subclass (``TensorDict`` or ``tensorclass``):
-
-    >>> @tensorclass
-    ... class MyClass:
-    ...     tensor: torch.Tensor
-    ...     td: TensorDict
-    ...     tc: MyClass | None
-    ...
-    >>> obj = MyClass(
-    ...     tensor=torch.randn(()),
-    ...     td={"a": torch.randn(())},
-    ...     tc={"tensor": torch.randn(()), "td": None, "tc": None})
-    >>> assert isinstance(obj.tensor, torch.Tensor)
-    >>> # tc and td have not been cast
-    >>> assert isinstance(obj.tc, dict)
-    >>> assert isinstance(obj.td, dict)
-
-.. note:: Auto-casting isn't enabled for leaves (tensors).
-  The reason for this is that this feature isn't compatible with type
-  annotations that contain the ``type0 | type1`` type hinting semantic, which
-  is widespread. Allowing auto-casting would result in very similar codes to
-  have drastically different behaviours if the type annotation differs only
-  slightly.

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -3468,10 +3468,13 @@ class _TensorClassMeta(abc.ABCMeta):
 
 
 class TensorClass(TensorCollection, metaclass=_TensorClassMeta):
-    """TensorClass is the inheritance-based version of the @tensorclass decorator.
+    """TensorClass is the inheritance-based version of the :func:`~tensordict.tensorclass` decorator.
 
-    TensorClass allows you to code dataclasses that are better type-checked and more pythonic than those built with
-    the @tensorclass decorator.
+    TensorClass lets you write dataclass-like containers that benefit from all the TensorDict
+    machinery (indexing, reshaping, ``to(device)``, ``stack``/``cat``, memmap serialization, ...)
+    while remaining pythonic and friendly to static type-checkers. It is the recommended entry
+    point for new code; the :func:`~tensordict.tensorclass` decorator is kept for backwards
+    compatibility and dataclass-style ergonomics.
 
     Examples:
         >>> from typing import Any
@@ -3495,47 +3498,119 @@ class TensorClass(TensorCollection, metaclass=_TensorClassMeta):
         batch_size (torch.Size, optional): The batch size of the TensorDict. Defaults to ``None``.
         device (torch.device, optional): The device on which the TensorDict will be created. Defaults to ``None``.
         frozen (bool, optional): If ``True``, the resulting class or instance will be immutable. Defaults to ``False``.
-        autocast (bool, optional): If ``True``, enables automatic type casting for the resulting class or instance. Defaults to ``False``.
-        nocast (bool, optional): If ``True``, disables any type casting for the resulting class or instance. Defaults to ``False``.
-        tensor_only (bool, optional): if ``True``, it is expected that all items in tensorclass will be
-            tensor instances (tensor-compatible, since non-tensor data is converted to tensors if possible).
-            This can bring significant speed-ups at the cost of flexible interactions with non-tensor data.
-            Defaults to ``False``.
-        shadow (bool, optional): Disables the validation of field names against TensorDict's reserved attributes.
-            Use with caution, as this may cause unintended consequences. Defaults to False.
+        autocast (bool, optional): If ``True``, values are coerced to the field's type annotation when
+            set (e.g. an ``int`` annotation keeps Python ints as ints rather than wrapping them in a
+            tensor). Mutually exclusive with ``nocast`` and ``tensor_only``. Defaults to ``False``.
+        nocast (bool, optional): If ``True``, tensor-compatible scalar types (``int``, ``float``,
+            ``np.ndarray``, ...) are stored as-is instead of being cast to a tensor. Mutually exclusive
+            with ``autocast`` and ``tensor_only``. Defaults to ``False``.
+        tensor_only (bool, optional): If ``True``, every field is expected to hold a tensor (or
+            tensor-compatible value, which will be cast). Lookups skip the non-tensor data path,
+            which can yield significant speed-ups at the cost of losing non-tensor support.
+            Mutually exclusive with ``autocast`` and ``nocast``. Defaults to ``False``.
+        shadow (bool, optional): Disables the validation of field names against TensorDict's reserved
+            attributes (e.g. allowing a field named ``device`` or ``batch_size``). Use with caution,
+            as this can lead to surprising behaviour. Defaults to ``False``.
 
-    You can pass boolean keyword arguments (`"autocast"`, `"nocast"`, `"frozen"`, `"tensor_only"`, `"shadow"`) in two ways: using
-        brackets or keyword arguments.
+    **The bracket form** ``TensorClass[...]`` is sugar for "build a parametrized subclass with the
+    given flags turned on". The three forms below are equivalent:
 
     Examples:
-        >>> class Foo(TensorClass["autocast"]):
+        >>> class Foo(TensorClass["autocast"]):     # bracket form
         ...     integer: int
-        >>> Foo(integer=torch.ones(())).integer
-        1
-        >>> class Foo(TensorClass, autocast=True):  # equivalent
+        >>> class Foo(TensorClass, autocast=True):  # metaclass kwargs form
         ...     integer: int
-        >>> Foo(integer=torch.ones(())).integer
-        1
-        >>> class Foo(TensorClass["nocast"]):
+        >>> @tensorclass(autocast=True)             # legacy decorator form
+        ... class Foo:
         ...     integer: int
-        >>> Foo(integer=1).integer
-        1
-        >>> class Foo(TensorClass["nocast", "frozen"]):  # multiple keywords can be used
+
+    The bracket form is usually the most readable when you stack several flags and it is the form
+    static type-checkers (mypy/pyright) understand via :meth:`~object.__class_getitem__`. The kwargs
+    form is convenient if the flag value is computed; the decorator form is best when migrating
+    plain ``@dataclass`` code.
+
+    Several flags can be combined inside the brackets:
+
+    Examples:
+        >>> class Foo(TensorClass["nocast", "frozen"]):
         ...     integer: int
-        >>> Foo(integer=1).integer
-        1
-        >>> class Foo(TensorClass, nocast=True):  # equivalent
-        ...     integer: int
-        >>> Foo(integer=1).integer
-        1
+
+    **Per-flag semantics.** The flags fall into three families — casting (``autocast``, ``nocast``,
+    ``tensor_only``, which are mutually exclusive), mutability (``frozen``) and name shadowing
+    (``shadow``).
+
+    Default behaviour (no flags) — tensor-compatible values are wrapped as tensors and non-tensor
+    values are stored as :class:`~tensordict.NonTensorData`:
+
         >>> class Foo(TensorClass):
-        ...     integer: int
-        >>> Foo(integer=1).integer
+        ...     x: int
+        >>> Foo(x=1).x
         tensor(1)
 
-    .. warning:: TensorClass itself is not decorated as a tensorclass, but subclasses will be.
-        This is because we cannot anticipate if the frozen argument will be set, and if it is, it may
-        conflict with the parent class (a subclass cannot be frozen if the parent class isn't).
+    ``autocast`` — coerce values back to the field's annotated type when reading them. Useful when
+    a field is conceptually a scalar/string/enum but should still travel through the TensorDict
+    machinery as a leaf:
+
+        >>> class Foo(TensorClass["autocast"]):
+        ...     x: int
+        >>> Foo(x=torch.ones(())).x
+        1
+
+    ``nocast`` — opt out of tensor casting entirely; tensor-compatible scalars are stored as-is:
+
+        >>> class Foo(TensorClass["nocast"]):
+        ...     x: int
+        >>> Foo(x=1).x
+        1
+
+    ``tensor_only`` — the strict, fast path. Every field must be (or convert to) a tensor; the
+    non-tensor storage is bypassed, which makes attribute access cheaper. Reach for this on
+    performance-sensitive containers (e.g. RL trajectories, batched model I/O) where you control
+    every field:
+
+        >>> class Foo(TensorClass["tensor_only"]):
+        ...     x: torch.Tensor
+
+    ``frozen`` — make the class immutable, mirroring ``@dataclass(frozen=True)``. Frozen instances
+    play well with ``torch.compile`` and functional code paths where in-place mutation would be a
+    foot-gun. Note that ``frozen`` propagates to subclasses: a non-frozen subclass cannot inherit
+    from a frozen base, and vice versa.
+
+        >>> class Foo(TensorClass["frozen"]):
+        ...     x: torch.Tensor
+        >>> foo = Foo(x=torch.zeros(3))
+        >>> foo.x = torch.ones(3)  # raises FrozenInstanceError
+
+    ``shadow`` — by default, field names that collide with TensorDict's reserved attributes
+    (``batch_size``, ``device``, ``names``, ``data``, ...) raise an ``AttributeError`` at class
+    construction. ``shadow=True`` opts out of that check so you can use those names anyway:
+
+        >>> class Foo(TensorClass["shadow"]):
+        ...     data: torch.Tensor
+
+    **Subclassing.** A parametrized class is just a class — you can subclass it and stack more
+    flags:
+
+        >>> class Base(TensorClass["autocast"]):
+        ...     x: int
+        >>> class Sub(Base, frozen=True):   # autocast inherited, frozen added
+        ...     y: float
+
+    **Type-checking.** ``TensorClass[...]`` is implemented via :meth:`~object.__class_getitem__`,
+    so mypy and pyright resolve it to the (parametrized) class itself rather than to a generic
+    parameter. Annotated fields propagate as expected and editors offer attribute completion on
+    instances.
+
+    .. note:: ``TensorClass`` itself is *not* decorated as a tensorclass — the dataclass machinery
+        only fires on subclasses. This is intentional: we cannot anticipate whether ``frozen`` will
+        be requested, and a non-frozen base cannot have a frozen subclass.
+
+    .. seealso::
+
+        - :func:`~tensordict.tensorclass` for the decorator form.
+        - :func:`~tensordict.from_dataclass` to migrate an existing ``@dataclass`` to a tensorclass.
+        - :class:`~tensordict.nn.TensorClassModuleBase` for typed ``nn.Module`` I/O backed by
+          tensorclasses.
 
     """
 


### PR DESCRIPTION
## Summary

A user flagged that the docs for the parametric form `TensorClass[smth]` are sparse. This PR fixes that and uses the opportunity to surface several tensorclass features that were previously buried.

- **`TensorClass` class docstring** — explains the bracket form as syntactic sugar for "build a parametrized subclass via `__class_getitem__`", shows the three equivalent forms (brackets / kwargs / decorator) with a recommendation for each, and adds a per-flag deep dive (`autocast`, `nocast`, `tensor_only`, `frozen`, `shadow`) with runnable before/after examples. Also notes mutual exclusivity rules, subclassing behavior of parametrized classes, and static-type-checker support. New `.. seealso::` block cross-links `@tensorclass`, `from_dataclass`, and `TensorClassModuleBase`.

- **`docs/source/reference/tc.rst`** — restructured to lead with `TensorClass` (modern API); `@tensorclass` is demoted to a "Legacy" section near the end. New sections: **Flags** (overview + three-form equivalence), **Performance with `tensor_only`**, **Immutability with `frozen`**, **Migrating from a plain dataclass** (`from_dataclass`), **Non-tensor data: `NonTensorData` vs `MetaData`**, **Typed `nn.Module` I/O** (cross-link to `TensorClassModuleBase`), **`torch.compile` and cudagraphs**. Existing sections (Auto-casting deep-dive, Serialization, Edge cases, Pre-allocation) preserved with light adaptation.

## Test plan

- [ ] `cd docs && make html` builds cleanly
- [ ] Rendered page for `tc.rst` shows the new section order and the cross-references resolve
- [ ] `help(TensorClass)` shows the expanded docstring
- [ ] Spot-check the runnable `>>>` examples for each flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)