### PR TITLE
[Feature] Add canonical=True kwarg to contiguous()

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -55,6 +55,7 @@ from tensordict.memmap import MemoryMappedTensor
 from tensordict.utils import (
     _as_context_manager,
     _broadcast_tensors,
+    _canonicalize_tensor,
     _check_is_flatten,
     _check_is_unflatten,
     _get_shape_from_args,
@@ -1814,8 +1815,18 @@ class LazyStackedTensorDict(TensorDictBase):
     def is_contiguous(self) -> bool:
         return False
 
-    def contiguous(self) -> Self:
-        source = {key: value.contiguous() for key, value in self.items()}
+    def contiguous(self, *, canonical: bool = False) -> Self:
+        if canonical:
+            source = {
+                key: (
+                    value.contiguous(canonical=True)
+                    if is_tensor_collection(value)
+                    else _canonicalize_tensor(value.contiguous())
+                )
+                for key, value in self.items()
+            }
+        else:
+            source = {key: value.contiguous() for key, value in self.items()}
         batch_size = self.batch_size
         device = self.device
         out = TensorDict._new_unsafe(
@@ -4214,9 +4225,16 @@ class _CustomOpTensorDict(TensorDictBase):
     def is_contiguous(self) -> bool:
         return all([value.is_contiguous() for _, value in self.items()])
 
-    def contiguous(self) -> Self:
-        def contiguous(x):
-            return x.contiguous()
+    def contiguous(self, *, canonical: bool = False) -> Self:
+        if canonical:
+
+            def contiguous(x):
+                return _canonicalize_tensor(x.contiguous())
+
+        else:
+
+            def contiguous(x):
+                return x.contiguous()
 
         return self._fast_apply(contiguous, propagate_lock=True)
 

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -61,6 +61,7 @@ from tensordict.utils import (
     _as_context_manager,
     _BatchedUninitializedBuffer,
     _BatchedUninitializedParameter,
+    _canonicalize_tensor,
     _check_inbuild,
     _clone_value,
     _create_segments_from_int,
@@ -3464,8 +3465,18 @@ class TensorDict(TensorDictBase):
         #     self._maybe_set_shared_attributes(result)
         return result
 
-    def contiguous(self) -> Self:
-        source = {key: value.contiguous() for key, value in self.items()}
+    def contiguous(self, *, canonical: bool = False) -> Self:
+        if canonical:
+            source = {
+                key: (
+                    value.contiguous(canonical=True)
+                    if is_tensor_collection(value)
+                    else _canonicalize_tensor(value.contiguous())
+                )
+                for key, value in self.items()
+            }
+        else:
+            source = {key: value.contiguous() for key, value in self.items()}
         batch_size = self.batch_size
         device = self.device
         out = self._new_unsafe(
@@ -4332,10 +4343,21 @@ class _SubTensorDict(TensorDictBase):
     def is_contiguous(self) -> bool:
         return all(value.is_contiguous() for value in self.values())
 
-    def contiguous(self) -> Self:
+    def contiguous(self, *, canonical: bool = False) -> Self:
+        if canonical:
+            source = {
+                key: (
+                    value.contiguous(canonical=True)
+                    if is_tensor_collection(value)
+                    else _canonicalize_tensor(value.contiguous())
+                )
+                for key, value in self.items()
+            }
+        else:
+            source = {key: value.contiguous() for key, value in self.items()}
         return self._new_unsafe(
             batch_size=self.batch_size,
-            source={key: value.contiguous() for key, value in self.items()},
+            source=source,
             device=self.device,
             names=self.names if self._has_names() else None,
         )

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -15863,8 +15863,20 @@ class TensorDictBase(MutableMapping, TensorCollection):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def contiguous(self) -> Self:
-        """Returns a new tensordict of the same type with contiguous values (or self if values are already contiguous)."""
+    def contiguous(self, *, canonical: bool = False) -> Self:
+        """Returns a new tensordict of the same type with contiguous values (or self if values are already contiguous).
+
+        Args:
+            canonical (bool, optional): if ``True``, every dense tensor leaf
+                whose strides do not match the canonical C-row-major strides
+                for its shape is rematerialized into a freshly allocated
+                contiguous tensor (using ``torch.contiguous_format``), even if
+                :meth:`torch.Tensor.is_contiguous` returns ``True`` (e.g.
+                because of size-1 dimensions). When ``False`` (the default),
+                the historical behavior of :meth:`torch.Tensor.contiguous` is
+                preserved. Defaults to ``False``.
+
+        """
         raise NotImplementedError
 
     @cache  # noqa: B019

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -571,9 +571,12 @@ class PersistentTensorDict(TensorDictBase):
                 td_names = list(names) + [None] * (item.ndim - self.ndim)
                 item.rename_(*td_names)
 
-    def contiguous(self):
+    def contiguous(self, *, canonical: bool = False):
         """Materializes a PersistentTensorDict on a regular TensorDict."""
-        return self.to_tensordict()
+        out = self.to_tensordict()
+        if canonical:
+            out = out.contiguous(canonical=True)
+        return out
 
     @lock_blocked
     def del_(self, key):

--- a/tensordict/store/_store.py
+++ b/tensordict/store/_store.py
@@ -1846,9 +1846,12 @@ class TensorDictStore(TensorDictBase):
         """
         return self.to_tensordict()
 
-    def contiguous(self) -> TensorDict:
+    def contiguous(self, *, canonical: bool = False) -> TensorDict:
         """Materialize into a regular TensorDict."""
-        return self.to_tensordict()
+        out = self.to_tensordict()
+        if canonical:
+            out = out.contiguous(canonical=True)
+        return out
 
     # ---- Construction ----
 
@@ -2981,8 +2984,11 @@ class _StoreStackElementView(TensorDictBase):
     def to_local(self) -> TensorDict:
         return self.to_tensordict()
 
-    def contiguous(self) -> TensorDict:
-        return self.to_tensordict()
+    def contiguous(self, *, canonical: bool = False) -> TensorDict:
+        out = self.to_tensordict()
+        if canonical:
+            out = out.contiguous(canonical=True)
+        return out
 
     def is_contiguous(self) -> bool:
         return False
@@ -4409,8 +4415,11 @@ class LazyStackedTensorDictStore(TensorDictBase):
     def to_local(self) -> TensorDict:
         return self.to_tensordict()
 
-    def contiguous(self) -> TensorDict:
-        return self.to_tensordict()
+    def contiguous(self, *, canonical: bool = False) -> TensorDict:
+        out = self.to_tensordict()
+        if canonical:
+            out = out.contiguous(canonical=True)
+        return out
 
     # ---- Construction ----
 

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -565,6 +565,35 @@ def _device(tensor: Tensor) -> torch.device:
         return tensor.device
 
 
+def _canonical_stride(shape: Sequence[int]) -> tuple[int, ...]:
+    """Returns the C-row-major (canonical) stride for a given shape."""
+    stride: list[int] = []
+    running = 1
+    for size in reversed(tuple(shape)):
+        stride.append(running)
+        running *= int(size)
+    stride.reverse()
+    return tuple(stride)
+
+
+def _canonicalize_tensor(tensor: Tensor) -> Tensor:
+    """Materializes a tensor with canonical (C-row-major) strides if needed.
+
+    Tensors whose strides already match the canonical stride for their shape
+    are returned unchanged. Otherwise a fresh contiguous copy is allocated and
+    the values are copied in.
+    """
+    if not isinstance(tensor, Tensor):
+        return tensor
+    if tensor.is_nested or tensor.layout != torch.strided:
+        return tensor
+    if tuple(tensor.stride()) == _canonical_stride(tensor.shape):
+        return tensor
+    out = torch.empty_like(tensor, memory_format=torch.contiguous_format)
+    out.copy_(tensor)
+    return out
+
+
 def _is_shared(tensor: Tensor) -> bool:
     if isinstance(tensor, Tensor):
         if torch._C._functorch.is_batchedtensor(tensor):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -4414,6 +4414,54 @@ class TestGeneric:
         assert p.grad is None
         assert linear.weight.grad is None
 
+    def test_contiguous_canonical(self):
+        # Leaf with a size-1 dim and a non-canonical stride: torch reports
+        # is_contiguous() == True even though the strides don't match the
+        # C-row-major layout for the shape.
+        non_canonical = torch.empty_strided((1, 4, 5), (5, 5, 1))
+        non_canonical.copy_(torch.arange(20).view(1, 4, 5))
+        assert non_canonical.is_contiguous()
+        assert tuple(non_canonical.stride()) != (20, 5, 1)
+        canonical = torch.randn(2, 3, 4)
+        assert tuple(canonical.stride()) == (12, 4, 1)
+        nested_leaf = torch.empty_strided((1, 4, 5), (5, 5, 1))
+        nested_leaf.copy_(torch.arange(20).view(1, 4, 5))
+
+        td = TensorDict(
+            {
+                "non_canonical": non_canonical,
+                "canonical": canonical,
+                "nested": TensorDict({"leaf": nested_leaf}, batch_size=[]),
+            },
+            batch_size=[],
+        )
+
+        # canonical=False (default) keeps the historical no-copy behaviour
+        # for tensors that already pass is_contiguous().
+        td_default = td.contiguous()
+        assert td_default["non_canonical"].data_ptr() == non_canonical.data_ptr()
+        assert tuple(td_default["non_canonical"].stride()) == (5, 5, 1)
+        assert td_default["canonical"].data_ptr() == canonical.data_ptr()
+        assert (
+            td_default["nested", "leaf"].data_ptr() == nested_leaf.data_ptr()
+        )
+
+        # canonical=True materialises the leaf whose strides do not match
+        # the canonical layout and leaves already-canonical tensors alone.
+        td_canon = td.contiguous(canonical=True)
+        assert tuple(td_canon["non_canonical"].stride()) == (20, 5, 1)
+        assert td_canon["non_canonical"].data_ptr() != non_canonical.data_ptr()
+        torch.testing.assert_close(td_canon["non_canonical"], non_canonical)
+        assert td_canon["canonical"].data_ptr() == canonical.data_ptr()
+        # Nested TensorDict leaf is also canonicalised.
+        assert tuple(td_canon["nested", "leaf"].stride()) == (20, 5, 1)
+        assert td_canon["nested", "leaf"].data_ptr() != nested_leaf.data_ptr()
+        torch.testing.assert_close(td_canon["nested", "leaf"], nested_leaf)
+        # Batch size / device / structure are preserved.
+        assert td_canon.batch_size == td.batch_size
+        assert td_canon.device == td.device
+        assert set(td_canon.keys()) == set(td.keys())
+
 
 class TestPointwiseOps:
     def test_r_ops(self):

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -4442,9 +4442,7 @@ class TestGeneric:
         assert td_default["non_canonical"].data_ptr() == non_canonical.data_ptr()
         assert tuple(td_default["non_canonical"].stride()) == (5, 5, 1)
         assert td_default["canonical"].data_ptr() == canonical.data_ptr()
-        assert (
-            td_default["nested", "leaf"].data_ptr() == nested_leaf.data_ptr()
-        )
+        assert td_default["nested", "leaf"].data_ptr() == nested_leaf.data_ptr()
 
         # canonical=True materialises the leaf whose strides do not match
         # the canonical layout and leaves already-canonical tensors alone.


### PR DESCRIPTION
## Summary

- Adds an optional `canonical: bool = False` kwarg to `TensorDictBase.contiguous` and all concrete overrides (`TensorDict`, `_SubTensorDict`, `LazyStackedTensorDict`, `_CustomOpTensorDict`, `PersistentTensorDict`, and the three `RedisStore` paths). `TensorDictParams` inherits the kwarg automatically through its `@_fallback` shim.
- When `canonical=True`, each dense tensor leaf whose strides do not match the canonical C-row-major strides for its shape is rematerialized into a fresh `torch.empty_like(t, memory_format=torch.contiguous_format)` followed by `copy_(t)`. This covers cases where `tensor.is_contiguous()` returns `True` only because of size-1 dimensions but the strides are not canonical (e.g. `torch.empty_strided((1, 4, 5), (5, 5, 1))`). Leaves whose strides are already canonical are returned unchanged.
- Default behaviour (`canonical=False`) is preserved exactly - no extra copies, no extra branches on the hot path.
- Adds two helpers in `tensordict/utils.py`: `_canonical_stride(shape)` (reversed cumulative product) and `_canonicalize_tensor(tensor)` (no-op unless strides differ from canonical).

## Test plan

- [x] New `TestGeneric.test_contiguous_canonical` in `test/test_tensordict.py` covers:
  - `torch.empty_strided((1, 4, 5), (5, 5, 1))` leaf: default `contiguous()` is no-copy (same `data_ptr`, non-canonical stride preserved); `contiguous(canonical=True)` produces stride `(20, 5, 1)` with a fresh allocation and equal values.
  - Nested TensorDict leaf with the same shape/stride pattern is canonicalised under `canonical=True`.
  - Already-canonical leaf is not copied under `canonical=True`.
  - Batch size, device, and key structure preserved.
- [x] `pytest test/test_tensordict.py` (7710 passed, 857 skipped).
- [x] `pytest test/test_typedtensordict.py` (62 passed).
- [x] `pytest test/test_nn.py` (511 passed) - confirms `TensorDictParams.contiguous(canonical=True)` works through `@_fallback`.
- [x] Manual sanity checks against `LazyStackedTensorDict` and `_SubTensorDict` confirm the new path canonicalises strides while the default path is unchanged.

Generated with Claude Code.