### PR TITLE
[CI] Declare issues:write on Self-assign workflow

### DIFF
--- a/.github/workflows/selfassign.yml
+++ b/.github/workflows/selfassign.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   one:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # assign user to the commented issue
     if: >-
       (github.event.comment.body == '#take' ||
        github.event.comment.body == '#self-assign')


### PR DESCRIPTION
The `Self-assign` workflow triggers on `issue_comment` (the elevated-context trigger that runs with the default-branch GITHUB_TOKEN grant). Right now it doesn't declare a `permissions:` block, so the token gets whatever the repo default is.

The job makes exactly one API call:

  POST /repos/{owner}/{repo}/issues/{number}/assignees

which needs `issues: write`. This patch pins the job to that minimum:

  permissions:
    issues: write

The style matches `lint.yml`, `test-linux.yml`, and the other hardened workflows here, all of which declare per-job permissions blocks (typically `id-token: write` + `contents: read` for the reusable-test callers).

With explicit `issues: write`:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- if any hypothetical future addition to this workflow tried to push to the repo, it would fail rather than silently succeed

No behavioural change. The self-assign curl call continues to use `GITHUB_TOKEN` with the same effective scope.