### PR TITLE
[Feature] GPUDirect Storage support for consolidated TensorDicts

### DIFF
--- a/docs/source/saving.rst
+++ b/docs/source/saving.rst
@@ -196,6 +196,46 @@ a memory-mapped file:
 See :meth:`~tensordict.TensorDictBase.consolidate` for the full API, including
 options like ``num_threads``, ``device``, ``pin_memory``, and ``share_memory``.
 
+GPU-direct loading and saving with GPUDirect Storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the source or destination of a consolidated tensordict is a CUDA device,
+the contiguous-buffer layout is a natural fit for NVIDIA
+`GPUDirect Storage <https://docs.nvidia.com/gpudirect-storage/>`_ (GDS): a
+single buffer registration and one ``cuFileRead`` / ``cuFileWrite`` move all
+leaves between disk and GPU, bypassing host RAM entirely.
+
+Both :meth:`~tensordict.TensorDictBase.from_consolidated` and
+:meth:`~tensordict.TensorDictBase.consolidate` accept ``use_gds=True`` to opt
+into this path:
+
+  >>> # CPU side: write a consolidated file
+  >>> td.consolidate(filename="/path/to/td.pt")
+  >>> # GPU side: load directly into CUDA memory (no host bounce)
+  >>> td_gpu = TensorDict.from_consolidated(
+  ...     "/path/to/td.pt", device="cuda", use_gds=True
+  ... )
+  >>>
+  >>> # Or symmetrically, save a CUDA-resident tensordict directly to disk
+  >>> td_gpu.consolidate(filename="/path/to/td_gds.pt", use_gds=True)
+
+``use_gds`` is **opt-in and disabled by default**. There is no silent fallback:
+any failure (missing API, ``nvidia-fs`` not loaded, unsupported filesystem,
+non-CUDA device) raises immediately.
+
+Prerequisites:
+
+- PyTorch ≥ 2.7 with cuFile bindings (Linux x86_64; not available on macOS or
+  Windows).
+- A CUDA device.
+- The ``nvidia-fs`` kernel module loaded.
+- A GDS-supported filesystem: ext4 with direct I/O, GPFS, Lustre, WekaFS, etc.
+  ``tmpfs`` does **not** qualify (no direct I/O).
+
+With ``use_gds=True``, every leaf of the returned tensordict shares a single
+CUDA storage. This already matches the behaviour of
+``from_consolidated(...).to("cuda")``.
+
 state_dict / load_state_dict
 ----------------------------
 

--- a/tensordict/_gds.py
+++ b/tensordict/_gds.py
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""GPUDirect Storage (cuFile) helpers for consolidated TensorDicts.
+
+This module provides the opt-in load and save paths used by
+``TensorDictBase.from_consolidated(..., use_gds=True)`` and
+``TensorDictBase.consolidate(filename=..., use_gds=True)``.
+
+Nothing here is imported at top level by the rest of the package. The
+public API on ``TensorDictBase`` lazily imports the helpers below only
+when ``use_gds=True`` is requested, so importing :mod:`tensordict` stays
+free on installs without ``torch.cuda.gds`` (PyTorch < 2.7) or without
+CUDA.
+"""
+from __future__ import annotations
+
+import json
+import os
+import weakref
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from tensordict.base import TensorDictBase
+
+
+# Capability probe. Cheap, no side effects. ``torch.cuda.gds`` is a
+# regular submodule on torch >= 2.7 but the underlying C++ bindings can
+# be absent on builds without cuFile support, in which case calling any
+# function in it raises RuntimeError.
+_has_torch_gds = hasattr(getattr(torch.cuda, "gds", None), "GdsFile")
+
+
+def _require_gds(device: torch.device) -> None:
+    """Validate that GDS is usable for ``device``; raise otherwise.
+
+    This only checks the API surface and the device type. Filesystem
+    support (nvidia-fs kernel module, supported FS such as ext4 with
+    direct I/O, GPFS, Lustre, WekaFS) cannot be probed without actually
+    issuing a cuFile call; the caller must catch ``RuntimeError`` from
+    ``load_storage`` / ``save_storage`` and surface it.
+    """
+    if not _has_torch_gds:
+        raise RuntimeError(
+            "use_gds=True requires torch.cuda.gds, available in PyTorch "
+            ">= 2.7. Installed torch does not expose it."
+        )
+    if not hasattr(torch._C, "_gds_register_buffer"):
+        raise RuntimeError(
+            "use_gds=True requires the cuFile C++ bindings, which are "
+            "missing from this PyTorch build."
+        )
+    if not torch.cuda.is_available():
+        raise RuntimeError("use_gds=True requires a CUDA-capable PyTorch build.")
+    if device.type != "cuda":
+        raise RuntimeError(
+            f"use_gds=True requires a CUDA device, got device={device!r}."
+        )
+
+
+def _safe_deregister(storage) -> None:
+    """Deregister a cuFile buffer, swallowing errors during teardown."""
+    try:
+        from torch.cuda.gds import gds_deregister_buffer
+
+        gds_deregister_buffer(storage)
+    except Exception:
+        # GC-time teardown; never let this escape and crash the
+        # interpreter shutdown path.
+        pass
+
+
+def _gds_unavailable_hint() -> str:
+    return (
+        " Hint: ensure the nvidia-fs kernel module is loaded and the "
+        "file lives on a GDS-supported filesystem (ext4 with direct "
+        "I/O, GPFS, Lustre, WekaFS, etc.)."
+    )
+
+
+def _load_consolidated_gds(
+    filename: str | os.PathLike, device: torch.device
+) -> "TensorDictBase":
+    """Load a consolidated TensorDict file directly into CUDA memory.
+
+    The file format is the one produced by
+    ``TensorDictBase.consolidate(filename=...)``: a contiguous data
+    region followed by a JSON metadata blob and an int64 length suffix.
+    Only the data region goes through cuFile; the small trailing JSON is
+    parsed on CPU.
+    """
+    from torch.cuda.gds import gds_register_buffer, GdsFile
+
+    from tensordict._reductions import _rebuild_tensordict_files_consolidated
+
+    _require_gds(device)
+
+    filename = str(Path(filename))
+    total_size = os.path.getsize(filename)
+
+    # Parse the trailer on CPU. It is tiny (a JSON blob plus 8 bytes).
+    file_cpu = torch.from_file(
+        filename,
+        dtype=torch.uint8,
+        size=total_size,
+        device=torch.device("cpu"),
+    )
+    metadata_size = int(file_cpu[-8:].clone().view(torch.int64).item())
+    metadata_bytes = bytes(file_cpu[-metadata_size - 8 : -8].tolist())
+    metadata = json.loads(metadata_bytes)
+    data_region_size = total_size - metadata_size - 8
+    del file_cpu
+
+    # Allocate the consolidated CUDA buffer and register it.
+    data_tensor = torch.empty(data_region_size, dtype=torch.uint8, device=device)
+    storage = data_tensor.untyped_storage()
+    gds_register_buffer(storage)
+
+    gf = None
+    try:
+        gf = GdsFile(filename, os.O_RDONLY)
+        try:
+            gf.load_storage(storage, offset=0)
+        finally:
+            del gf
+            gf = None
+    except RuntimeError as exc:
+        _safe_deregister(storage)
+        raise RuntimeError(
+            f"cuFile read failed for {filename!r}." + _gds_unavailable_hint()
+        ) from exc
+    except BaseException:
+        # Make sure we don't leak a registration on any failure path,
+        # including KeyboardInterrupt.
+        if gf is not None:
+            del gf
+        _safe_deregister(storage)
+        raise
+
+    result = _rebuild_tensordict_files_consolidated(metadata, data_tensor)
+
+    # Keep the buffer registered for the lifetime of the TensorDict.
+    # ``gds_deregister_buffer`` only unpins the cuFile mapping; the
+    # CUDA allocation itself stays valid until the storage's refcount
+    # drops.
+    weakref.finalize(result, _safe_deregister, storage)
+    return result
+
+
+def _save_consolidated_gds(
+    filename: str | os.PathLike,
+    storage,
+    metadata_bytes: bytes,
+    len_bytes: bytes,
+) -> None:
+    """Write a consolidated CUDA storage to ``filename`` via cuFile.
+
+    The data region is DMA'd out via ``cuFileWrite``; the small JSON
+    metadata trailer is appended with a plain ``open()`` write.
+
+    ``metadata_bytes`` is the UTF-8 JSON blob; ``len_bytes`` is its
+    length encoded as an int64 (8 bytes), matching the existing
+    consolidated file layout.
+    """
+    from torch.cuda.gds import gds_register_buffer, GdsFile
+
+    # The device of the storage cannot be queried via the untyped
+    # storage on all torch versions in a stable way; the caller passes
+    # a CUDA storage so we cross-check via ``storage.device``.
+    device = torch.device(storage.device)
+    _require_gds(device)
+
+    filename = str(Path(filename))
+
+    gds_register_buffer(storage)
+    gf = None
+    try:
+        gf = GdsFile(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+        try:
+            gf.save_storage(storage, offset=0)
+        finally:
+            del gf
+            gf = None
+    except RuntimeError as exc:
+        _safe_deregister(storage)
+        raise RuntimeError(
+            f"cuFile write failed for {filename!r}." + _gds_unavailable_hint()
+        ) from exc
+    except BaseException:
+        if gf is not None:
+            del gf
+        _safe_deregister(storage)
+        raise
+    else:
+        _safe_deregister(storage)
+
+    # Trailer: small CPU-side append; cuFile is not appropriate here.
+    with open(filename, "ab") as f:
+        f.write(metadata_bytes)
+        f.write(len_bytes)

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -6637,6 +6637,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         share_memory: bool = False,
         pin_memory: bool = False,
         metadata: bool = False,
+        use_gds: bool = False,
     ) -> None:
         """Consolidates the tensordict content in a single storage for fast serialization.
 
@@ -6669,6 +6670,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 Storing the metadata can be useful when one wants to control how serialization
                 is achieved, as TensorDict handles the pickling/unpickling of consolidated TDs
                 differently if the metadata is or isn't available.
+            use_gds (bool, optional): if ``True`` and ``filename`` is set, the consolidated
+                data region is written directly from CUDA memory to the file via NVIDIA
+                GPUDirect Storage (cuFile), bypassing host RAM. The TD (or ``device``) must
+                be on CUDA. Requires PyTorch ≥ 2.7 with cuFile bindings, the ``nvidia-fs``
+                kernel module, and a GDS-supported filesystem. No silent fallback: any
+                failure raises. Defaults to ``False``.
 
         .. note::
             If the tensordict is already consolidated, all arguments are ignored and ``self``
@@ -6708,18 +6715,39 @@ class TensorDictBase(MutableMapping, TensorCollection):
         )
         filesize = sum(flat_size)
         device = torch.device(device) if device is not None else None
-        if filename is None:
+
+        # GDS save bypasses the CPU-mmap'd file: we allocate the
+        # consolidated storage directly on CUDA, fill it like the
+        # filename=None path, and stream it out via cuFile at the end.
+        gds_save = use_gds and filename is not None
+        if use_gds and filename is None:
+            raise RuntimeError("use_gds=True requires a `filename` to be provided.")
+        gds_metadata_bytes: bytes | None = None
+        gds_len_bytes: bytes | None = None
+        if gds_save:
+            gds_target_device = device
+            if gds_target_device is None and self.device is not None:
+                gds_target_device = self.device
+            if gds_target_device is None or gds_target_device.type != "cuda":
+                raise RuntimeError(
+                    "use_gds=True requires a CUDA device, either via "
+                    "`device=` or on the TensorDict itself."
+                )
+            device = gds_target_device
+
+        if filename is None or gds_save:
             storage = torch.empty(
                 filesize,
                 dtype=torch.uint8,
                 device=device if device else self.device,
-                pin_memory=pin_memory,
+                pin_memory=pin_memory and not gds_save,
             )
             if share_memory and not (
                 device is not None and device.type == "cuda"
             ):  # cuda device is always shared
                 storage.share_memory_()
-        else:
+
+        if filename is not None:
             # Convert the dict to json
             try:
                 from tensordict.utils import json_dumps
@@ -6735,37 +6763,49 @@ class TensorDictBase(MutableMapping, TensorCollection):
             # Represent as a tensor
             if isinstance(metadata_dict_json, str):
                 metadata_dict_json = metadata_dict_json.encode("utf-8")
-            metadata_dict_json = torch.as_tensor(
-                bytearray(metadata_dict_json), dtype=torch.uint8
-            )
-            len_metadata = torch.tensor(
-                [metadata_dict_json.numel()], dtype=torch.int64
-            ).view(torch.uint8)
 
-            if device not in (torch.device("cpu"), None):
-                raise RuntimeError(
-                    "device and filename are mutually exclusive arguments."
+            if gds_save:
+                # Hold trailer bytes on CPU; cuFile only handles the
+                # bulk data region.
+                gds_metadata_bytes = bytes(metadata_dict_json)
+                gds_len_bytes = (
+                    torch.tensor([len(gds_metadata_bytes)], dtype=torch.int64)
+                    .view(torch.uint8)
+                    .tolist()
                 )
-            suffix = len_metadata.numel() + metadata_dict_json.numel()
-            if not use_buffer:
-                total_storage = torch.from_file(
-                    str(filename),
-                    size=filesize + suffix,
-                    dtype=torch.uint8,
-                    shared=True,
-                    # needed when device ctx differs
-                    device=torch.device("cpu"),
-                )
+                gds_len_bytes = bytes(gds_len_bytes)
             else:
-                total_storage = MemoryMappedTensor.empty(
-                    shape=(filesize + suffix,),
-                    dtype=torch.uint8,
+                metadata_dict_json = torch.as_tensor(
+                    bytearray(metadata_dict_json), dtype=torch.uint8
                 )
+                len_metadata = torch.tensor(
+                    [metadata_dict_json.numel()], dtype=torch.int64
+                ).view(torch.uint8)
 
-            total_storage[-8:] = len_metadata
-            total_storage[-8 - metadata_dict_json.numel() : -8] = metadata_dict_json
-            storage = total_storage[:-suffix]
-            # assert len(storage.untyped_storage()) == filesize
+                if device not in (torch.device("cpu"), None):
+                    raise RuntimeError(
+                        "device and filename are mutually exclusive arguments."
+                    )
+                suffix = len_metadata.numel() + metadata_dict_json.numel()
+                if not use_buffer:
+                    total_storage = torch.from_file(
+                        str(filename),
+                        size=filesize + suffix,
+                        dtype=torch.uint8,
+                        shared=True,
+                        # needed when device ctx differs
+                        device=torch.device("cpu"),
+                    )
+                else:
+                    total_storage = MemoryMappedTensor.empty(
+                        shape=(filesize + suffix,),
+                        dtype=torch.uint8,
+                    )
+
+                total_storage[-8:] = len_metadata
+                total_storage[-8 - metadata_dict_json.numel() : -8] = metadata_dict_json
+                storage = total_storage[:-suffix]
+                # assert len(storage.untyped_storage()) == filesize
 
         offsets = torch.tensor([0] + flat_size).cumsum(0).tolist()
 
@@ -6935,6 +6975,8 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
         if filename is None:
             device = self.device
+        elif gds_save:
+            device = storage.device
         elif not inplace:
             device = torch.device("cpu")
         elif self.device is not None and self.device != torch.device("cpu"):
@@ -6954,7 +6996,16 @@ class TensorDictBase(MutableMapping, TensorCollection):
         # Lock the consolidated TensorDict to prevent modifications that could break consolidation
         result.lock_()
         if filename is not None:
-            if use_buffer:
+            if gds_save:
+                from tensordict._gds import _save_consolidated_gds
+
+                _save_consolidated_gds(
+                    filename,
+                    storage.untyped_storage(),
+                    gds_metadata_bytes,
+                    gds_len_bytes,
+                )
+            elif use_buffer:
                 with open(filename, "w+b") as f:
                     f.write(total_storage._handler.buffer)
             # with open(Path(filename).with_suffix(".json"), "wb") as f:
@@ -6963,9 +7014,49 @@ class TensorDictBase(MutableMapping, TensorCollection):
         return result
 
     @classmethod
-    def from_consolidated(cls, filename):
-        # with open(Path(filename).with_suffix(".json"), "rb") as f:
-        #     metadata = json.loads(f.read())
+    def from_consolidated(
+        cls,
+        filename,
+        *,
+        device: torch.device | str | int | None = None,
+        use_gds: bool = False,
+    ):
+        """Load a tensordict from a consolidated file.
+
+        Args:
+            filename: path to a file produced by :meth:`~.consolidate` with
+                a ``filename`` argument.
+
+        Keyword Args:
+            device (torch.device, optional): device to place the loaded
+                tensordict on. With ``use_gds=False`` (default) the file is
+                first mapped on CPU and then transferred via ``.to(device)``
+                at the end. With ``use_gds=True`` the data is read directly
+                into a CUDA buffer via cuFile.
+            use_gds (bool, optional): if ``True``, the data region of the
+                consolidated file is loaded directly into CUDA memory via
+                NVIDIA GPUDirect Storage (cuFile), bypassing host RAM.
+                Requires PyTorch ≥ 2.7 with cuFile bindings, a CUDA device,
+                and a GDS-supported filesystem with the ``nvidia-fs`` kernel
+                module loaded. ``device`` must be a CUDA device. No silent
+                fallback: any failure raises. Defaults to ``False``.
+
+        .. note::
+            With ``use_gds=True``, every leaf of the returned tensordict
+            shares a single CUDA storage. This already matches the
+            behaviour of ``from_consolidated(...).to("cuda")``.
+        """
+        if use_gds:
+            if device is None:
+                raise RuntimeError(
+                    "use_gds=True requires a CUDA device to be passed via "
+                    "the `device` argument."
+                )
+            device = torch.device(device)
+            from tensordict._gds import _load_consolidated_gds
+
+            return _load_consolidated_gds(filename, device)
+
         file = torch.from_file(
             str(filename),
             dtype=torch.uint8,
@@ -6979,9 +7070,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
         from ._reductions import _rebuild_tensordict_files_consolidated
 
-        return _rebuild_tensordict_files_consolidated(
+        result = _rebuild_tensordict_files_consolidated(
             metadata, file[: -metadata_size - 8]
         )
+        if device is not None:
+            result = result.to(torch.device(device))
+        return result
 
     def is_consolidated(self):
         """Checks if a TensorDict has a consolidated storage."""

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -850,6 +850,161 @@ class TestReadWrite:
         # assert (mmap1[1].view(-1) == 0).all()
 
 
+def _gds_api_present() -> bool:
+    import torch as _torch
+
+    return hasattr(getattr(_torch.cuda, "gds", None), "GdsFile")
+
+
+def _gds_smoke() -> bool:
+    """Best-effort end-to-end probe: returns True only if a tiny GDS read works.
+
+    Tests use this as a ``pytest.mark.skipif`` condition so they skip cleanly
+    on environments without nvidia-fs or on filesystems that don't support
+    direct I/O (e.g. macOS, tmpfs).
+    """
+    if not _gds_api_present():
+        return False
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from torch.cuda.gds import gds_register_buffer, GdsFile
+    except ImportError:
+        return False
+    import tempfile
+
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as fh:
+            payload = bytes(range(256)) * 16  # 4 KiB
+            fh.write(payload)
+            path = fh.name
+        try:
+            buf = torch.empty(len(payload), dtype=torch.uint8, device="cuda")
+            storage = buf.untyped_storage()
+            gds_register_buffer(storage)
+            try:
+                gf = GdsFile(path, os.O_RDONLY)
+                try:
+                    gf.load_storage(storage, offset=0)
+                finally:
+                    del gf
+            finally:
+                from torch.cuda.gds import gds_deregister_buffer
+
+                gds_deregister_buffer(storage)
+            return bool(
+                (buf.cpu() == torch.tensor(list(payload), dtype=torch.uint8)).all()
+            )
+        finally:
+            os.unlink(path)
+    except Exception:
+        return False
+
+
+_GDS_SMOKE_OK = _gds_smoke()
+
+
+class TestGDS:
+    @staticmethod
+    def _make_td():
+        return TensorDict(
+            {
+                "a": torch.arange(16, dtype=torch.int64),
+                "b": torch.randn(3, 4),
+                "nested": TensorDict(
+                    {"c": torch.ones(2, 2, dtype=torch.float32)}, batch_size=[]
+                ),
+            },
+            batch_size=[],
+        )
+
+    def test_gds_requires_cuda_device(self, tmp_path):
+        td = self._make_td()
+        p = tmp_path / "td.pt"
+        td.consolidate(filename=str(p))
+        with pytest.raises(RuntimeError, match="CUDA"):
+            TensorDict.from_consolidated(str(p), device="cpu", use_gds=True)
+        with pytest.raises(RuntimeError, match="CUDA"):
+            TensorDict.from_consolidated(str(p), use_gds=True)
+
+    def test_gds_consolidate_requires_filename(self):
+        td = self._make_td()
+        with pytest.raises(RuntimeError, match="filename"):
+            td.consolidate(use_gds=True)
+
+    def test_gds_consolidate_requires_cuda(self, tmp_path):
+        td = self._make_td()  # cpu
+        p = tmp_path / "td.pt"
+        with pytest.raises(RuntimeError, match="CUDA"):
+            td.consolidate(filename=str(p), use_gds=True)
+
+    @pytest.mark.skipif(
+        _GDS_SMOKE_OK,
+        reason="GDS is available; this test runs only when GDS is unavailable",
+    )
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_gds_raises_when_unavailable(self, tmp_path):
+        td = self._make_td()
+        p = tmp_path / "td.pt"
+        td.consolidate(filename=str(p))
+        with pytest.raises(RuntimeError):
+            TensorDict.from_consolidated(str(p), device="cuda", use_gds=True)
+
+    @pytest.mark.skipif(not _GDS_SMOKE_OK, reason="GDS not usable in this environment")
+    def test_gds_load_roundtrip_small(self, tmp_path):
+        td = self._make_td()
+        p = tmp_path / "td.pt"
+        td.consolidate(filename=str(p))
+
+        td_gpu = TensorDict.from_consolidated(str(p), device="cuda", use_gds=True)
+        assert td_gpu.device.type == "cuda"
+        for k in [("a",), ("b",), ("nested", "c")]:
+            torch.testing.assert_close(td_gpu.get(k).cpu(), td.get(k))
+
+        # All leaves share one CUDA storage.
+        ptrs = {
+            td_gpu.get(k).untyped_storage().data_ptr()
+            for k in [("a",), ("b",), ("nested", "c")]
+        }
+        assert len(ptrs) == 1
+
+    @pytest.mark.skipif(not _GDS_SMOKE_OK, reason="GDS not usable in this environment")
+    def test_gds_save_roundtrip_small(self, tmp_path):
+        td = self._make_td().to("cuda")
+        p = tmp_path / "td_gds.pt"
+        td.consolidate(filename=str(p), use_gds=True)
+
+        td_back = TensorDict.from_consolidated(str(p))
+        for k in [("a",), ("b",), ("nested", "c")]:
+            torch.testing.assert_close(td_back.get(k), td.get(k).cpu())
+
+    @pytest.mark.skipif(not _GDS_SMOKE_OK, reason="GDS not usable in this environment")
+    def test_gds_save_then_gds_load(self, tmp_path):
+        td = self._make_td().to("cuda")
+        p = tmp_path / "td_gds.pt"
+        td.consolidate(filename=str(p), use_gds=True)
+
+        td_back = TensorDict.from_consolidated(str(p), device="cuda", use_gds=True)
+        assert td_back.device.type == "cuda"
+        for k in [("a",), ("b",), ("nested", "c")]:
+            torch.testing.assert_close(td_back.get(k), td.get(k))
+
+    @pytest.mark.skipif(not _GDS_SMOKE_OK, reason="GDS not usable in this environment")
+    def test_gds_leaf_outlives_td(self, tmp_path):
+        td = self._make_td()
+        p = tmp_path / "td.pt"
+        td.consolidate(filename=str(p))
+
+        td_gpu = TensorDict.from_consolidated(str(p), device="cuda", use_gds=True)
+        leaf = td_gpu.get("b").clone()  # detach a value
+        leaf_view = td_gpu.get("b")  # alias the registered storage
+        del td_gpu
+        gc.collect()
+        # Both the cloned leaf and the view-on-shared-storage must remain usable.
+        torch.testing.assert_close(leaf_view.cpu(), td.get("b"))
+        torch.testing.assert_close(leaf.cpu(), td.get("b"))
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)


### PR DESCRIPTION
## Summary

Adds opt-in GPUDirect Storage (NVIDIA cuFile) support to `consolidate()` and `from_consolidated()`. When a tensordict is laid out as a single contiguous storage with per-leaf offsets — which is exactly what `consolidate()` already produces — cuFile can DMA the whole payload between disk and a registered CUDA buffer without going through host RAM. One buffer registration, one `cuFileRead` / `cuFileWrite`, views are then free.

New API (both default `False`, no silent fallback):

```python
# Load: DMA file → CUDA without host bounce
td = TensorDict.from_consolidated("td.pt", device="cuda", use_gds=True)

# Save: DMA CUDA → file without host bounce
td.consolidate(filename="td.pt", use_gds=True)
```

Requires PyTorch ≥ 2.7 (cuFile bindings), a CUDA device, `nvidia-fs` kernel module loaded, and a GDS-supported filesystem (ext4 w/ direct I/O, GPFS, Lustre, WekaFS, …). Any failure raises with an actionable hint; there is no fallback in v1.

### What's in scope

- Load + save paths, synchronous (matching `torch.cuda.gds`).
- A small private `tensordict/_gds.py` with capability probe, `_require_gds`, and the load/save helpers. `torch.cuda.gds` is imported function-locally so importing tensordict stays free on installs without it.
- Buffer-lifetime management via `weakref.finalize` so the cuFile registration outlives all leaves and gets cleaned up at GC.
- Tests in `test/test_memmap.py::TestGDS` with an end-to-end smoke probe gating the round-trip tests via `pytest.mark.skipif`.
- A "GPU-direct loading and saving with GPUDirect Storage" subsection in `docs/source/saving.rst`.

### Non-goals (deferred)

- Per-leaf `.memmap` files (would require N buffer registrations).
- Async / threaded multi-file concurrency.
- Windows support.

## Test plan

- [x] `pytest test/test_memmap.py` on macOS: 563 pass, 5 GDS tests skip correctly (no CUDA).
- [x] Broader sweep: `pytest -k "consolidate or memmap"` across `test_memmap.py`, `test_compatibility.py`, `test_tensordict.py`, `test_tensorclass.py` — 583 pass, no regressions in the unchanged paths.
- [x] On an H100 node with PyTorch nightly cu128: 4 error-surface tests pass on CUDA. `test_gds_raises_when_unavailable` confirms that on a CUDA host *without* `nvidia-fs`, `use_gds=True` raises a clear cuFile error rather than silently corrupting data.
- [ ] **Needs a GDS-capable node**: the 4 round-trip tests (`test_gds_load_roundtrip_small`, `test_gds_save_roundtrip_small`, `test_gds_save_then_gds_load`, `test_gds_leaf_outlives_td`) require `nvidia-fs` loaded + supported FS. They skip cleanly otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)