### PR TITLE
[Compile] Drop frozenset - dict_keys dynamo workaround

### DIFF
--- a/tensordict/typedtensordict.py
+++ b/tensordict/typedtensordict.py
@@ -179,19 +179,13 @@ def _make_init(cls: type) -> Callable:
                 lock=lock,
             )
             return
-        # NOTE: the natural spelling here is ``required_keys - kwargs.keys()``
-        # and ``kwargs.keys() - expected_keys``, but torch.compile / Dynamo
-        # cannot trace ``frozenset.__sub__(dict_keys)`` and raises
-        # ``Unsupported: unsupported operand type(s) for __sub__``.
-        # We use set comprehensions as a compile-friendly workaround.
-        # See TODO/dynamo_frozenset_sub.md for a repro.
-        missing = {k for k in required_keys if k not in kwargs}
+        missing = required_keys - kwargs.keys()
         if missing:
             missing_str = ", ".join(sorted(missing))
             raise TypeError(
                 f"{type(self).__name__}() missing required field(s): {missing_str}"
             )
-        extra = {k for k in kwargs if k not in expected_keys}
+        extra = kwargs.keys() - expected_keys
         if extra:
             extra_str = ", ".join(sorted(extra))
             raise TypeError(

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -880,13 +880,6 @@ class TestTTDImprovements:
     See the corresponding ``TODO/*.md`` files for upstream context.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Dynamo cannot trace frozenset.__sub__(dict_keys). "
-            "See TODO/dynamo_frozenset_sub.md"
-        ),
-    )
     def test_frozenset_sub_dict_keys(self):
         """frozenset - dict.keys() should be traceable by Dynamo."""
         required = frozenset({"a", "b"})


### PR DESCRIPTION
## Summary

- Restore the natural `required_keys - kwargs.keys()` / `kwargs.keys() - expected_keys` spelling in `TypedTensorDict._make_init`, replacing the set-comprehension workaround that existed because Dynamo could not trace `frozenset.__sub__(dict_keys)`.
- Drop the `xfail(strict=True)` marker on `test_compile.py::TestTTDImprovements::test_frozenset_sub_dict_keys`. Recent torch nightly (and stable) trace this pattern natively, which made the canary XPASS and was the signal to revert the workaround.

The xfail marker is the project's documented mechanism for tracking upstream Dynamo limitations: when the test XPASSes, the workaround can be removed. This PR does exactly that.

## Test plan

- [ ] CI `test-cpu (3.10/3.11/3.12/3.13)` green (these were red on PR #1699 due to the XPASS).
- [ ] CI `test-stable-cpu (3.10)` and `test-stable-gpu (3.10, 12.6)` green.
- [ ] CI `tests-silicon (3.10)` green.
- [ ] No other tests regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)