### PR TITLE
[BugFix] Fix dynamic-shape export (#1003): handle scalar SymInt in _parse_batch_size and store batch_dims in pytree context

### DIFF
--- a/tensordict/_pytree.py
+++ b/tensordict/_pytree.py
@@ -93,7 +93,11 @@ def _tensordict_flatten(d: TensorDict) -> Tuple[List[Any], Context]:
         values = []
     return values, {
         "keys": keys,
-        "batch_size": d.batch_size,
+        # Store batch_dims (int) rather than batch_size (torch.Size that may
+        # contain SymInts during torch.export with dynamic shapes). The unflatten
+        # reconstructs the actual batch_size from tensor shapes at that point.
+        # See: https://github.com/pytorch/tensordict/issues/1003
+        "batch_dims": len(d.batch_size),
         "names": d.names if d._has_names() else None,
         "device": d.device,
         "constructor": _constructor(type(d)),
@@ -119,38 +123,49 @@ def _tensordict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]
             if all(val.device == device for val in values if hasattr(val, "device"))
             else None
         )
-    batch_size = context["batch_size"]
+    # Support both old contexts (batch_size key) and new contexts (batch_dims key).
+    # The new batch_dims form avoids storing SymInts in the pytree context, which
+    # would fail serialization during torch.export with dynamic shapes.
+    if "batch_dims" in context:
+        batch_dims = context["batch_dims"]
+        if any(tensor is None for tensor in values):
+            return
+        shapes = [_shape(v) for v in values if hasattr(v, "shape")]
+        batch_size = shapes[0][:batch_dims] if shapes else torch.Size([0] * batch_dims)
+    else:
+        # Legacy path: batch_size stored directly (may contain SymInts in old code).
+        batch_size = context["batch_size"]
+        batch_dims = len(batch_size)
+        if any(tensor is None for tensor in values):
+            return
+        shapes = [_shape(v) for v in values if hasattr(v, "shape")]
+        if shapes and any(s[:batch_dims] != batch_size for s in shapes):
+            # Values have different leading dims than the original batch_size.
+            # This happens when torch.func transforms (jacrev, jacfwd, hessian)
+            # create basis vectors with extra leading dimensions. We infer a new
+            # batch_size from the common prefix of all value shapes, capped at
+            # batch_dims + 1 to include at most one extra (basis) dimension.
+            #
+            # NOTE: when tensors have no feature dimensions (ndim == batch_dims),
+            # the basis leading dim can coincidentally equal a batch dim, making
+            # it impossible to detect the mismatch here. In that case, the
+            # TensorDict should be created with batch_size=[] or the tensors
+            # should be given at least one feature dimension (e.g. via unsqueeze).
+            min_dims = min(len(s) for s in shapes)
+            max_prefix_len = min(min_dims, batch_dims + 1)
+            common_dims = 0
+            for i in range(max_prefix_len):
+                if all(s[i] == shapes[0][i] for s in shapes):
+                    common_dims = i + 1
+                else:
+                    break
+            batch_size = torch.Size(shapes[0][:common_dims])
+            context["names"] = None
     names = context["names"]
     keys = context["keys"]
     constructor = context["constructor"]
     non_tensor_items = context["non_tensor_data"]
     cls = context["cls"]
-    batch_dims = len(batch_size)
-    if any(tensor is None for tensor in values):
-        return
-    shapes = [_shape(v) for v in values if hasattr(v, "shape")]
-    if shapes and any(s[:batch_dims] != batch_size for s in shapes):
-        # Values have different leading dims than the original batch_size.
-        # This happens when torch.func transforms (jacrev, jacfwd, hessian)
-        # create basis vectors with extra leading dimensions. We infer a new
-        # batch_size from the common prefix of all value shapes, capped at
-        # batch_dims + 1 to include at most one extra (basis) dimension.
-        #
-        # NOTE: when tensors have no feature dimensions (ndim == batch_dims),
-        # the basis leading dim can coincidentally equal a batch dim, making
-        # it impossible to detect the mismatch here. In that case, the
-        # TensorDict should be created with batch_size=[] or the tensors
-        # should be given at least one feature dimension (e.g. via unsqueeze).
-        min_dims = min(len(s) for s in shapes)
-        max_prefix_len = min(min_dims, batch_dims + 1)
-        common_dims = 0
-        for i in range(max_prefix_len):
-            if all(s[i] == shapes[0][i] for s in shapes):
-                common_dims = i + 1
-            else:
-                break
-        batch_size = torch.Size(shapes[0][:common_dims])
-        names = None
     return constructor(
         cls=cls,
         keys=keys,

--- a/tensordict/_pytree.py
+++ b/tensordict/_pytree.py
@@ -10,7 +10,7 @@ from tensordict._lazy import LazyStackedTensorDict
 from tensordict._td import _SubTensorDict, TensorDict, TensorDictBase
 from tensordict.base import _NESTED_TENSORS_AS_LISTS
 from tensordict.persistent import PersistentTensorDict
-from tensordict.utils import _shape, implement_for
+from tensordict.utils import _shape, implement_for, is_compiling
 
 try:
     from torch.utils._pytree import Context, MappingKey, register_pytree_node
@@ -91,19 +91,26 @@ def _tensordict_flatten(d: TensorDict) -> Tuple[List[Any], Context]:
     else:
         keys = []
         values = []
-    return values, {
+    context = {
         "keys": keys,
-        # Store batch_dims (int) rather than batch_size (torch.Size that may
-        # contain SymInts during torch.export with dynamic shapes). The unflatten
-        # reconstructs the actual batch_size from tensor shapes at that point.
-        # See: https://github.com/pytorch/tensordict/issues/1003
-        "batch_dims": len(d.batch_size),
         "names": d.names if d._has_names() else None,
         "device": d.device,
         "constructor": _constructor(type(d)),
         "non_tensor_data": d.non_tensor_items(),
         "cls": type(d),
     }
+    if is_compiling():
+        # During torch.export with dynamic shapes, batch_size may contain SymInts.
+        # torch.export cannot serialize SymInts in the output pytree spec
+        # (as_python_constant raises). Store batch_dims (int) instead and
+        # reconstruct batch_size from tensor shapes in _tensordict_unflatten.
+        # See: https://github.com/pytorch/tensordict/issues/1003
+        context["batch_dims"] = len(d.batch_size)
+    else:
+        # Eager path: store batch_size directly so that torch.func transforms
+        # (jacrev, jacfwd, hessian) can detect basis-vector shape mismatches.
+        context["batch_size"] = d.batch_size
+    return values, context
 
 
 def _lazy_tensordict_flatten(d: LazyStackedTensorDict) -> Tuple[List[Any], Context]:
@@ -123,22 +130,18 @@ def _tensordict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]
             if all(val.device == device for val in values if hasattr(val, "device"))
             else None
         )
-    # Support both old contexts (batch_size key) and new contexts (batch_dims key).
-    # The new batch_dims form avoids storing SymInts in the pytree context, which
-    # would fail serialization during torch.export with dynamic shapes.
+    if any(tensor is None for tensor in values):
+        return
+    shapes = [_shape(v) for v in values if hasattr(v, "shape")]
     if "batch_dims" in context:
+        # Compilation path (torch.export): batch_size was not stored because it
+        # may contain SymInts which torch.export cannot serialize. Reconstruct
+        # from the leading batch_dims dimensions of the actual tensor shapes.
         batch_dims = context["batch_dims"]
-        if any(tensor is None for tensor in values):
-            return
-        shapes = [_shape(v) for v in values if hasattr(v, "shape")]
         batch_size = shapes[0][:batch_dims] if shapes else torch.Size([0] * batch_dims)
     else:
-        # Legacy path: batch_size stored directly (may contain SymInts in old code).
         batch_size = context["batch_size"]
         batch_dims = len(batch_size)
-        if any(tensor is None for tensor in values):
-            return
-        shapes = [_shape(v) for v in values if hasattr(v, "shape")]
         if shapes and any(s[:batch_dims] != batch_size for s in shapes):
             # Values have different leading dims than the original batch_size.
             # This happens when torch.func transforms (jacrev, jacfwd, hessian)

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2355,7 +2355,10 @@ class TensorDict(TensorDictBase):
                 return torch.Size(tuple(batch_size))
             if batch_size is None:
                 return torch.Size([])
-            elif isinstance(batch_size, Number):
+            elif isinstance(batch_size, (Number, torch.SymInt)):
+                # torch.SymInt does not subclass Number but must be handled the
+                # same way during compilation (e.g. batch_size=x.shape[0]).
+                # See: https://github.com/pytorch/tensordict/issues/1003
                 return torch.Size([batch_size])
             elif isinstance(source, TensorDictBase):
                 return source.batch_size

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1588,6 +1588,38 @@ class TestExport:
     # Currently only works with strict=False, because export fails to see that
     #  the params in the module have changed and are not 'meta' anymore => this
     #  is symptomatic of export failing to see the functional call
+    def test_export_dynamic_batch_size(self):
+        """TensorDict with dynamic batch_size is exportable with dynamic shapes.
+
+        Regression test for https://github.com/pytorch/tensordict/issues/1003.
+        Previously, _tensordict_flatten stored batch_size (a torch.Size that may
+        contain SymInts) in the pytree context. torch.export cannot serialize
+        SymInts in the output pytree spec, causing AsPythonConstantNotImplementedError.
+
+        Fix: store batch_dims (int) and reconstruct batch_size from tensor shapes
+        in _tensordict_unflatten.
+        """
+        torch._dynamo.reset_code_caches()
+
+        class Mod(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> TensorDict:
+                b, t = x.shape[0], x.shape[1]
+                return TensorDict({"x": x, "y": x * 2}, batch_size=[b, t])
+
+        m = Mod()
+        inp = torch.randn(2, 6, 8)
+        m(inp)  # eager run
+
+        batch_dim = torch.export.Dim("batch", min=1)
+        ep = torch.export.export(
+            m, args=(inp,), dynamic_shapes=({0: batch_dim},), strict=True
+        )
+
+        # Verify the exported program runs correctly with a different batch size
+        out = ep.module()(torch.randn(4, 6, 8))
+        assert out.batch_size == torch.Size([4, 6])
+        torch.testing.assert_close(out["y"], out["x"] * 2)
+
     @pytest.mark.parametrize("strict", [False])  # , True])
     @pytest.mark.skipif(not _v2_7, reason="Requires PT>=2.7")
     def test_export_with_td_params(self, strict):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1592,30 +1592,50 @@ class TestExport:
         """TensorDict with dynamic batch_size is exportable with dynamic shapes.
 
         Regression test for https://github.com/pytorch/tensordict/issues/1003.
-        Previously, _tensordict_flatten stored batch_size (a torch.Size that may
-        contain SymInts) in the pytree context. torch.export cannot serialize
-        SymInts in the output pytree spec, causing AsPythonConstantNotImplementedError.
+        Two bugs prevented export:
 
-        Fix: store batch_dims (int) and reconstruct batch_size from tensor shapes
-        in _tensordict_unflatten.
+        1. _parse_batch_size did not handle scalar SymInt (e.g. batch_size=x.shape[0]),
+           raising ValueError("batch size was not specified").
+
+        2. _tensordict_flatten stored batch_size (torch.Size that may contain SymInts)
+           in the pytree context. torch.export cannot serialize SymInts in the output
+           pytree spec, raising AsPythonConstantNotImplementedError.
         """
         torch._dynamo.reset_code_caches()
 
-        class Mod(torch.nn.Module):
+        # Case 1: scalar SymInt batch_size (original issue repro, strict=False)
+        class ModScalar(torch.nn.Module):
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> TensorDict:
+                return TensorDict({"x": x, "y": y}, batch_size=x.shape[0])
+
+        m = ModScalar()
+        x, y = torch.zeros(2, 100), torch.zeros(2, 100)
+        ep = torch.export.export(
+            m,
+            args=(x, y),
+            strict=False,
+            dynamic_shapes={
+                "x": {0: torch.export.Dim("batch"), 1: torch.export.Dim("time")},
+                "y": {0: torch.export.Dim("batch"), 1: torch.export.Dim("time")},
+            },
+        )
+        out = ep.module()(torch.zeros(5, 100), torch.zeros(5, 100))
+        assert out.batch_size == torch.Size([5])
+
+        # Case 2: multi-dim SymInt batch_size (strict=True)
+        class ModMultiDim(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> TensorDict:
                 b, t = x.shape[0], x.shape[1]
                 return TensorDict({"x": x, "y": x * 2}, batch_size=[b, t])
 
-        m = Mod()
+        m = ModMultiDim()
         inp = torch.randn(2, 6, 8)
-        m(inp)  # eager run
-
-        batch_dim = torch.export.Dim("batch", min=1)
         ep = torch.export.export(
-            m, args=(inp,), dynamic_shapes=({0: batch_dim},), strict=True
+            m,
+            args=(inp,),
+            dynamic_shapes=({0: torch.export.Dim("batch", min=1)},),
+            strict=True,
         )
-
-        # Verify the exported program runs correctly with a different batch size
         out = ep.module()(torch.randn(4, 6, 8))
         assert out.batch_size == torch.Size([4, 6])
         torch.testing.assert_close(out["y"], out["x"] * 2)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1588,27 +1588,20 @@ class TestExport:
     # Currently only works with strict=False, because export fails to see that
     #  the params in the module have changed and are not 'meta' anymore => this
     #  is symptomatic of export failing to see the functional call
-    def test_export_dynamic_batch_size(self):
-        """TensorDict with dynamic batch_size is exportable with dynamic shapes.
+    def test_export_dynamic_batch_size_scalar(self):
+        """Scalar SymInt batch_size (x.shape[0]) is accepted during export.
 
         Regression test for https://github.com/pytorch/tensordict/issues/1003.
-        Two bugs prevented export:
-
-        1. _parse_batch_size did not handle scalar SymInt (e.g. batch_size=x.shape[0]),
-           raising ValueError("batch size was not specified").
-
-        2. _tensordict_flatten stored batch_size (torch.Size that may contain SymInts)
-           in the pytree context. torch.export cannot serialize SymInts in the output
-           pytree spec, raising AsPythonConstantNotImplementedError.
+        _parse_batch_size did not handle torch.SymInt (which does not subclass
+        numbers.Number), causing ValueError("batch size was not specified").
         """
         torch._dynamo.reset_code_caches()
 
-        # Case 1: scalar SymInt batch_size (original issue repro, strict=False)
-        class ModScalar(torch.nn.Module):
+        class Mod(torch.nn.Module):
             def forward(self, x: torch.Tensor, y: torch.Tensor) -> TensorDict:
                 return TensorDict({"x": x, "y": y}, batch_size=x.shape[0])
 
-        m = ModScalar()
+        m = Mod()
         x, y = torch.zeros(2, 100), torch.zeros(2, 100)
         ep = torch.export.export(
             m,
@@ -1622,13 +1615,23 @@ class TestExport:
         out = ep.module()(torch.zeros(5, 100), torch.zeros(5, 100))
         assert out.batch_size == torch.Size([5])
 
-        # Case 2: multi-dim SymInt batch_size (strict=True)
-        class ModMultiDim(torch.nn.Module):
+    def test_export_dynamic_batch_size_multi_dim(self):
+        """Multi-dim SymInt batch_size ([b, t]) is serializable in pytree context.
+
+        Regression test for https://github.com/pytorch/tensordict/issues/1003.
+        _tensordict_flatten stored batch_size (torch.Size that may contain SymInts)
+        in the pytree context. torch.export cannot serialize SymInts in the output
+        pytree spec, raising AsPythonConstantNotImplementedError.
+        Fix: store batch_dims (int) and reconstruct batch_size from tensor shapes.
+        """
+        torch._dynamo.reset_code_caches()
+
+        class Mod(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> TensorDict:
                 b, t = x.shape[0], x.shape[1]
                 return TensorDict({"x": x, "y": x * 2}, batch_size=[b, t])
 
-        m = ModMultiDim()
+        m = Mod()
         inp = torch.randn(2, 6, 8)
         ep = torch.export.export(
             m,


### PR DESCRIPTION
Fixes #1003.

## Problem

`torch.export.export()` with `dynamic_shapes` failed for any module that constructs a `TensorDict` with an input-dependent `batch_size`. Two independent bugs caused this:

**Bug 1 — `_parse_batch_size` rejects scalar `SymInt`** (`_td.py`)

When `batch_size=x.shape[0]` is passed during compilation, `batch_size` is a `torch.SymInt`. The `is_compiling()` path checks `isinstance(batch_size, Number)`, but `torch.SymInt` does not subclass `numbers.Number`, so the value falls through to `raise ValueError()`:

```
ValueError: batch size was not specified when creating the TensorDict instance
```

**Bug 2 — `_tensordict_flatten` stores `batch_size` (may contain `SymInt`) in the pytree context** (`_pytree.py`)

When the exported module returns a `TensorDict`, `torch.export` serializes the output pytree spec. The context stored `batch_size: torch.Size` which may contain `SymInt` values. `torch.export` calls `as_python_constant()` on every context item — `SymInt` is not a Python constant, raising:

```
AsPythonConstantNotImplementedError: SymNodeVariable() is not a constant
```

## Fix

**`tensordict/_td.py`**: extend the `Number` check in `_parse_batch_size` to also accept `torch.SymInt`:

```python
elif isinstance(batch_size, (Number, torch.SymInt)):
    return torch.Size([batch_size])
```

**`tensordict/_pytree.py`**: store `batch_dims: int` (the count, always a Python constant) in the pytree context instead of `batch_size`. In `_tensordict_unflatten`, reconstruct `batch_size` from the leading dimensions of the actual tensor shapes. The existing jacrev/jacfwd basis-vector mismatch logic is preserved via a backward-compatible `"batch_size"` legacy path.

## Tests

Two new tests added to `TestExport` in `test/test_compile.py`:

- `test_export_dynamic_batch_size_scalar`: covers `batch_size=x.shape[0]` (scalar `SymInt`, `strict=False`) — the original issue repro
- `test_export_dynamic_batch_size_multi_dim`: covers `batch_size=[b, t]` (multi-dim `SymInt`, `strict=True`) — the pytree serialization fix

Both tests fail on unpatched code and pass after the fix. The full `TestExport` suite (5 tests) passes in a clean venv.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md)
- [x] Tests added for both bug fixes
- [x] Black + flake8 clean
- [x] Links to issue #1003