### PR TITLE
[Feature] Add inplace=True to pad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,29 @@ House rules for LLM-driven contributions to `tensordict`. Sits on top of
   introducing parallel dict-like types.
 - Use `NestedKey` semantics for keys.
 
+## In-place conventions
+
+Two distinct flavors of in-place operations, both supported but with
+different contracts. Don't conflate them, and don't add an underscore
+method for an op that can't honor the same-storage contract.
+
+- **`method_` (trailing underscore)** — writes into the **same leaf
+  tensor storage**; `data_ptr()` is preserved for every leaf. Only
+  appropriate when the op doesn't change shape/dtype/layout (e.g.
+  `add_`, `mul_`, `masked_fill_`). Mirrors PyTorch's own convention.
+- **`method(inplace=True)`** — preserves the **TensorDict object
+  identity and key set**; individual leaf storages may be replaced
+  with freshly allocated tensors. The contract is "no extra
+  TD-shaped allocation" plus "release each old leaf as its
+  replacement is written" so peak memory stays close to ``1x``
+  instead of ``2x``. The only meaningful flavor of in-place for
+  shape-changing ops (e.g. `pad`, `repeat`, `gather`).
+
+Shape-changing ops therefore get ``inplace=True`` only — never an
+underscore variant, because they can't keep the same storage. See
+`docs/source/overview.rst` (section "In-place conventions") for the
+user-facing version.
+
 ## `torch.compile` / cudagraphs
 
 Strongly encouraged — many downstream projects compile through us. Prefer

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -95,6 +95,32 @@ a few characters (notice that indexing the nth leading dimensions with tree_map 
 One can also use the set method with ``inplace=True`` or the :meth:`~tensordict.TensorDict.set_` method to do inplace updates of the contents.
 The former is a fault-tolerant version of the latter: if no matching key is found, it will write a new one.
 
+In-place conventions
+~~~~~~~~~~~~~~~~~~~~
+
+Throughout the library, two related-but-distinct flavors of in-place
+operation are used:
+
+- A trailing-underscore method (``method_``, for example
+  :meth:`~tensordict.TensorDict.add_`, :meth:`~tensordict.TensorDict.mul_`,
+  :meth:`~tensordict.TensorDict.masked_fill_`) writes into the **same
+  underlying tensor storage** for every leaf. Each leaf's ``data_ptr`` is
+  preserved. This mirrors PyTorch's own convention and is only available
+  when the operation can be performed without changing a tensor's shape,
+  dtype, or layout.
+- An ``inplace=True`` keyword (for example
+  :meth:`~tensordict.TensorDict.pad`, :meth:`~tensordict.TensorDict.update`,
+  :meth:`~tensordict.TensorDict.apply`) preserves the **tensordict's
+  object identity and key set**, but individual leaf storages may be
+  replaced with freshly allocated tensors. The guarantee is "no extra
+  tensordict-shaped allocation", and the implementation will release each
+  old leaf storage as soon as its replacement is written so that peak
+  memory stays close to ``1x`` rather than ``2x``. This is the only
+  meaningful flavor of in-place for shape-changing operations.
+
+In short: ``method_`` keeps the bytes; ``inplace=True`` keeps the
+container.
+
 The contents of the TensorDict can now be manipulated collectively.
 For example, to place all of the contents onto a particular device one can simply do
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4575,6 +4575,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         pad_size: Sequence[int],
         value: float = 0.0,
         inplace: bool = False,
+        safe: bool = True,
     ) -> Self:
         """Pads this tensordict along the batch dimensions with a constant value.
 
@@ -4592,6 +4593,16 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 tensors themselves are still freshly allocated because
                 padding necessarily grows shapes. Defaults to ``False``.
 
+                .. warning::
+                    If ``inplace=True`` and a later leaf's pad fails (e.g.
+                    OOM), the tensordict is left in an inconsistent state.
+                    ``safe=True`` (the default) catches the user-error class
+                    of failures before any mutation occurs.
+            safe (bool, optional): If ``True``, validate that the operation
+                would succeed for every leaf before any mutation occurs. Set
+                to ``False`` to skip the pre-flight walk when the inputs are
+                known to be valid. Defaults to ``True``.
+
         Returns:
             The padded tensordict. When ``inplace=True`` this is ``self``.
 
@@ -4608,7 +4619,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         """
         from tensordict.functional import pad as _pad
 
-        return _pad(self, pad_size, value=value, inplace=inplace)
+        return _pad(self, pad_size, value=value, inplace=inplace, safe=safe)
 
     def copy(self) -> Self:
         """Return a shallow copy of the tensordict (ie, copies the structure but not the data).

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -4570,6 +4570,46 @@ class TensorDictBase(MutableMapping, TensorCollection):
     def _repeat(self, *repeats: int) -> Self:
         raise NotImplementedError
 
+    def pad(
+        self,
+        pad_size: Sequence[int],
+        value: float = 0.0,
+        inplace: bool = False,
+    ) -> Self:
+        """Pads this tensordict along the batch dimensions with a constant value.
+
+        Args:
+            pad_size (Sequence[int]): The padding size, applied to the batch
+                dimensions starting from the first. For a tensordict of
+                ``ndim`` batch dimensions, ``pad_size`` is a sequence of even
+                length up to ``2 * ndim`` formatted as
+                ``(dim0_left, dim0_right, dim1_left, dim1_right, ...)``.
+            value (float, optional): The fill value. Defaults to ``0.0``.
+            inplace (bool, optional): If ``True``, this tensordict's object
+                identity and key set are preserved; each leaf storage is
+                replaced by its padded counterpart one leaf at a time, keeping
+                peak memory close to ``1x`` instead of ``2x``. The leaf
+                tensors themselves are still freshly allocated because
+                padding necessarily grows shapes. Defaults to ``False``.
+
+        Returns:
+            The padded tensordict. When ``inplace=True`` this is ``self``.
+
+        Examples:
+            >>> import torch
+            >>> from tensordict import TensorDict
+            >>> td = TensorDict({"a": torch.zeros(3, 4)}, batch_size=[3, 4])
+            >>> td.pad([0, 0, 0, 1]).batch_size
+            torch.Size([3, 5])
+            >>> td.pad([0, 0, 0, 1], inplace=True) is td
+            True
+            >>> td.batch_size
+            torch.Size([3, 5])
+        """
+        from tensordict.functional import pad as _pad
+
+        return _pad(self, pad_size, value=value, inplace=inplace)
+
     def copy(self) -> Self:
         """Return a shallow copy of the tensordict (ie, copies the structure but not the data).
 

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -29,8 +29,13 @@ from tensordict.utils import (
 )
 
 
-def pad(tensordict: T, pad_size: Sequence[int], value: float = 0.0) -> T:
-    """Pads all tensors in a tensordict along the batch dimensions with a constant value, returning a new tensordict.
+def pad(
+    tensordict: T,
+    pad_size: Sequence[int],
+    value: float = 0.0,
+    inplace: bool = False,
+) -> T:
+    """Pads all tensors in a tensordict along the batch dimensions with a constant value.
 
     Args:
          tensordict (TensorDict): The tensordict to pad
@@ -42,9 +47,24 @@ def pad(tensordict: T, pad_size: Sequence[int], value: float = 0.0) -> T:
             (padding_left, padding_right, padding_top, padding_bottom) and so on.
             pad_size must be even and less than or equal to twice the number of batch dimensions.
          value (float, optional): The fill value to pad by, default 0.0
+         inplace (bool, optional): If ``True``, the input tensordict's identity
+            and key set are preserved, and each leaf's storage is replaced by
+            its padded counterpart one at a time. This keeps peak memory close
+            to the size of the tensordict itself rather than 2x (the case when
+            a fresh tensordict is allocated alongside the original). The leaf
+            tensors themselves are still freshly allocated (``pad`` necessarily
+            grows shapes), so this is not a same-storage operation. Defaults to
+            ``False``.
+
+            On :class:`~tensordict.LazyStackedTensorDict`, ``inplace=True`` pads
+            each constituent tensordict along the non-stack dimensions in place
+            and grows the stack along the stack dimension by appending or
+            prepending zero-filled copies of the edge constituents; the lazy
+            stack's identity is preserved.
 
     Returns:
-        A new TensorDict padded along the batch dimensions
+        The padded tensordict. When ``inplace=True`` this is the same object as
+        the input; otherwise a new tensordict.
 
     Examples:
         >>> from tensordict import TensorDict, pad
@@ -69,6 +89,9 @@ def pad(tensordict: T, pad_size: Sequence[int], value: float = 0.0) -> T:
     if len(pad_size) % 2:
         raise RuntimeError("pad_size must have an even number of dimensions")
 
+    if inplace and isinstance(tensordict, LazyStackedTensorDict):
+        return _pad_lazy_stack_inplace(tensordict, pad_size, value)
+
     new_batch_size = list(tensordict.batch_size)
     for i in range(len(pad_size)):
         new_batch_size[i // 2] += pad_size[i]
@@ -77,27 +100,108 @@ def pad(tensordict: T, pad_size: Sequence[int], value: float = 0.0) -> T:
     for i in range(0, len(reverse_pad), 2):
         reverse_pad[i], reverse_pad[i + 1] = reverse_pad[i + 1], reverse_pad[i]
 
-    out = TensorDict._new_unsafe(
-        {},
-        torch.Size(new_batch_size),
-        device=tensordict.device,
-    )
-    for key, tensor in tensordict.items():
+    if inplace:
+        out = tensordict
+    else:
+        out = TensorDict._new_unsafe(
+            {},
+            torch.Size(new_batch_size),
+            device=tensordict.device,
+        )
+
+    # Snapshot keys so mid-iteration rebinds on `out is tensordict` don't
+    # invalidate the iterator under inplace=True.
+    keys = list(tensordict.keys())
+    for key in keys:
+        tensor = tensordict._get_str(key, default=None)
+        if tensor is None:
+            continue
+
         if _is_unbatched(tensor):
-            out._set_str(key, tensor, validated=True, inplace=False)
+            if not inplace:
+                out._set_str(key, tensor, validated=True, inplace=False)
+            continue
+
+        if _is_tensor_collection(type(tensor)):
+            padded = pad(tensor, pad_size, value, inplace=inplace)
+            if not inplace:
+                out._set_str(key, padded, validated=True, inplace=False)
             continue
 
         cur_pad = reverse_pad
         if len(pad_size) < len(_shape(tensor)) * 2:
             cur_pad = [0] * (len(_shape(tensor)) * 2 - len(pad_size)) + reverse_pad
 
-        if _is_tensor_collection(type(tensor)):
-            padded = pad(tensor, pad_size, value)
-        else:
-            padded = torch.nn.functional.pad(tensor, cur_pad, value=value)
-        out.set(key, padded)
+        padded = torch.nn.functional.pad(tensor, cur_pad, value=value)
+        # Drop the local ref to the old tensor before rebinding the dict
+        # entry: with no other refs, the _set_str overwrite drops the old
+        # storage's refcount to 0 and the allocator can reuse the block
+        # for the next leaf's pad.
+        del tensor
+        out._set_str(key, padded, validated=True, inplace=False)
+
+    if inplace:
+        # Leaves now all match new_batch_size; flip the dict's advertised
+        # size via the low-level path so we skip the redundant shape check
+        # in `_batch_size_setter`.
+        out._change_batch_size(torch.Size(new_batch_size))
 
     return out
+
+
+def _pad_lazy_stack_inplace(
+    tensordict: LazyStackedTensorDict,
+    pad_size: Sequence[int],
+    value: float,
+) -> LazyStackedTensorDict:
+    """In-place pad for a LazyStackedTensorDict.
+
+    Pads each constituent along the non-stack dimensions in place, then grows
+    the stack dimension by appending/prepending zero-filled copies of the edge
+    constituents. The lazy stack's identity is preserved.
+    """
+    stack_dim = tensordict.stack_dim
+    pairs = [
+        (pad_size[2 * i], pad_size[2 * i + 1]) for i in range(len(pad_size) // 2)
+    ]
+
+    if stack_dim < len(pairs):
+        left, right = pairs[stack_dim]
+        non_stack_pairs = pairs[:stack_dim] + pairs[stack_dim + 1 :]
+    else:
+        left, right = 0, 0
+        non_stack_pairs = pairs
+
+    constituent_pad_size: list[int] = [p for pair in non_stack_pairs for p in pair]
+
+    if constituent_pad_size and any(p != 0 for p in constituent_pad_size):
+        for td_i in tensordict.tensordicts:
+            pad(td_i, constituent_pad_size, value, inplace=True)
+
+    if (left > 0 or right > 0) and not tensordict.tensordicts:
+        raise RuntimeError(
+            "Cannot pad along the stack dimension of an empty LazyStackedTensorDict: "
+            "no template constituent is available to fill the new slots."
+        )
+
+    if right > 0:
+        template = tensordict.tensordicts[-1]
+        new_pads = [
+            template.apply(lambda t: torch.full_like(t, value)) for _ in range(right)
+        ]
+        tensordict.tensordicts.extend(new_pads)
+    if left > 0:
+        template = tensordict.tensordicts[0]
+        new_pads = [
+            template.apply(lambda t: torch.full_like(t, value)) for _ in range(left)
+        ]
+        tensordict.tensordicts[:0] = new_pads
+
+    new_batch_size = list(tensordict.batch_size)
+    for i, (l, r) in enumerate(pairs):
+        new_batch_size[i] += l + r
+    tensordict._change_batch_size(torch.Size(new_batch_size))
+    return tensordict
 
 
 def pad_sequence(

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -173,8 +173,7 @@ def pad(
 
 
 def _pad_preflight(tensordict: TensorDictBase, pad_size: Sequence[int]) -> None:
-    """Validate that ``pad(tensordict, pad_size, ...)`` would succeed for every
-    leaf without mutating anything.
+    """Validate that ``pad(tensordict, pad_size, ...)`` would succeed for every leaf without mutating anything.
 
     Walks the tensordict recursively (including ``LazyStackedTensorDict``
     constituents) and checks the per-leaf preconditions of

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -186,16 +186,13 @@ def _pad_preflight(tensordict: TensorDictBase, pad_size: Sequence[int]) -> None:
     if isinstance(tensordict, LazyStackedTensorDict):
         stack_dim = tensordict.stack_dim
         pairs = [
-            (pad_size[2 * i], pad_size[2 * i + 1])
-            for i in range(len(pad_size) // 2)
+            (pad_size[2 * i], pad_size[2 * i + 1]) for i in range(len(pad_size) // 2)
         ]
         if stack_dim < len(pairs):
             non_stack_pairs = pairs[:stack_dim] + pairs[stack_dim + 1 :]
         else:
             non_stack_pairs = pairs
-        constituent_pad_size: list[int] = [
-            p for pair in non_stack_pairs for p in pair
-        ]
+        constituent_pad_size: list[int] = [p for pair in non_stack_pairs for p in pair]
         if constituent_pad_size and any(p != 0 for p in constituent_pad_size):
             for td_i in tensordict.tensordicts:
                 _pad_preflight(td_i, constituent_pad_size)
@@ -243,9 +240,7 @@ def _pad_lazy_stack_inplace(
     constituents. The lazy stack's identity is preserved.
     """
     stack_dim = tensordict.stack_dim
-    pairs = [
-        (pad_size[2 * i], pad_size[2 * i + 1]) for i in range(len(pad_size) // 2)
-    ]
+    pairs = [(pad_size[2 * i], pad_size[2 * i + 1]) for i in range(len(pad_size) // 2)]
 
     if stack_dim < len(pairs):
         left, right = pairs[stack_dim]

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -34,6 +34,7 @@ def pad(
     pad_size: Sequence[int],
     value: float = 0.0,
     inplace: bool = False,
+    safe: bool = True,
 ) -> T:
     """Pads all tensors in a tensordict along the batch dimensions with a constant value.
 
@@ -62,6 +63,25 @@ def pad(
             prepending zero-filled copies of the edge constituents; the lazy
             stack's identity is preserved.
 
+            .. warning::
+                If ``inplace=True`` and the operation fails partway through
+                (for example an out-of-memory error during a leaf's padding),
+                the tensordict is left in an inconsistent state: some leaves
+                will have the new shape and others the old, and the
+                ``batch_size`` will not have been updated. Restoring the
+                original state would require keeping every old leaf alive
+                until the whole pass succeeded, which would defeat the 1x
+                memory contract. Use ``safe=True`` (the default) to catch
+                the realistic user-error class of failures before any
+                mutation happens.
+         safe (bool, optional): If ``True``, validate that the operation
+            would succeed for every leaf before any mutation occurs. This
+            catches errors such as negative pad widths that exceed a leaf's
+            dimension size, leaves that are not paddable, etc., raising
+            before any in-place rebind. Set to ``False`` to skip the
+            pre-flight walk for a small speedup when the inputs are known
+            to be valid. Defaults to ``True``.
+
     Returns:
         The padded tensordict. When ``inplace=True`` this is the same object as
         the input; otherwise a new tensordict.
@@ -88,6 +108,9 @@ def pad(
 
     if len(pad_size) % 2:
         raise RuntimeError("pad_size must have an even number of dimensions")
+
+    if safe:
+        _pad_preflight(tensordict, pad_size)
 
     if inplace and isinstance(tensordict, LazyStackedTensorDict):
         return _pad_lazy_stack_inplace(tensordict, pad_size, value)
@@ -123,7 +146,7 @@ def pad(
             continue
 
         if _is_tensor_collection(type(tensor)):
-            padded = pad(tensor, pad_size, value, inplace=inplace)
+            padded = pad(tensor, pad_size, value, inplace=inplace, safe=False)
             if not inplace:
                 out._set_str(key, padded, validated=True, inplace=False)
             continue
@@ -147,6 +170,65 @@ def pad(
         out._change_batch_size(torch.Size(new_batch_size))
 
     return out
+
+
+def _pad_preflight(tensordict: TensorDictBase, pad_size: Sequence[int]) -> None:
+    """Validate that ``pad(tensordict, pad_size, ...)`` would succeed for every
+    leaf without mutating anything.
+
+    Walks the tensordict recursively (including ``LazyStackedTensorDict``
+    constituents) and checks the per-leaf preconditions of
+    ``torch.nn.functional.pad``: that each leaf has enough dimensions for the
+    requested ``pad_size`` and that the resulting size on every padded dim is
+    non-negative. Catches the realistic user-error class of failures before
+    ``inplace=True`` has rebound any leaf.
+    """
+    if isinstance(tensordict, LazyStackedTensorDict):
+        stack_dim = tensordict.stack_dim
+        pairs = [
+            (pad_size[2 * i], pad_size[2 * i + 1])
+            for i in range(len(pad_size) // 2)
+        ]
+        if stack_dim < len(pairs):
+            non_stack_pairs = pairs[:stack_dim] + pairs[stack_dim + 1 :]
+        else:
+            non_stack_pairs = pairs
+        constituent_pad_size: list[int] = [
+            p for pair in non_stack_pairs for p in pair
+        ]
+        if constituent_pad_size and any(p != 0 for p in constituent_pad_size):
+            for td_i in tensordict.tensordicts:
+                _pad_preflight(td_i, constituent_pad_size)
+        return
+
+    reverse_pad = list(pad_size[::-1])
+    for i in range(0, len(reverse_pad), 2):
+        reverse_pad[i], reverse_pad[i + 1] = reverse_pad[i + 1], reverse_pad[i]
+
+    for key in tensordict.keys():
+        tensor = tensordict._get_str(key, default=None)
+        if tensor is None or _is_unbatched(tensor):
+            continue
+        if _is_tensor_collection(type(tensor)):
+            _pad_preflight(tensor, pad_size)
+            continue
+        shape = _shape(tensor)
+        if len(pad_size) > 2 * len(shape):
+            raise RuntimeError(
+                f"pad_size of length {len(pad_size)} is too long for leaf "
+                f"{key!r} with shape {tuple(shape)}."
+            )
+        cur_pad = reverse_pad
+        if len(pad_size) < len(shape) * 2:
+            cur_pad = [0] * (len(shape) * 2 - len(pad_size)) + reverse_pad
+        for i in range(0, len(cur_pad), 2):
+            dim = len(shape) - 1 - (i // 2)
+            left, right = cur_pad[i], cur_pad[i + 1]
+            if shape[dim] + left + right < 0:
+                raise RuntimeError(
+                    f"Pad ({left}, {right}) on dim {dim} of leaf {key!r} "
+                    f"(size {shape[dim]}) would produce a negative output size."
+                )
 
 
 def _pad_lazy_stack_inplace(
@@ -176,7 +258,7 @@ def _pad_lazy_stack_inplace(
 
     if constituent_pad_size and any(p != 0 for p in constituent_pad_size):
         for td_i in tensordict.tensordicts:
-            pad(td_i, constituent_pad_size, value, inplace=True)
+            pad(td_i, constituent_pad_size, value, inplace=True, safe=False)
 
     if (left > 0 or right > 0) and not tensordict.tensordicts:
         raise RuntimeError(

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -500,6 +500,7 @@ _FALLBACK_METHOD_FROM_TD = [
     "new_tensor",
     "new_zeros",
     "norm",
+    "pad",
     "permute",
     "pin_memory",
     "pin_memory_",

--- a/tensordict/tensorclass.pyi
+++ b/tensordict/tensorclass.pyi
@@ -774,6 +774,13 @@ class TensorClass:
     def moveaxis(
         self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
     ) -> Self: ...
+    def pad(
+        self,
+        pad_size: Sequence[int],
+        value: float = 0.0,
+        inplace: bool = False,
+        safe: bool = True,
+    ) -> Self: ...
     @overload
     def permute(self, *dims: int) -> Self: ...
     @overload

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2397,6 +2397,48 @@ class TestGeneric:
         for key in ref.keys(include_nested=True, leaves_only=True):
             assert torch.equal(out[key], ref[key]), key
 
+    def test_pad_safe_catches_bad_pad_before_mutation(self):
+        td = TensorDict(
+            {"a": torch.ones(3, 4), "b": torch.zeros(3, 4, 2)},
+            batch_size=[3, 4],
+        )
+        old_a = td["a"]
+        old_b = td["b"]
+        # Pad would crop more than the source dim — safe=True raises before
+        # any leaf is rebound.
+        with pytest.raises(RuntimeError, match="negative output size"):
+            td.pad([-10, 0, 0, 0], inplace=True, safe=True)
+        assert td["a"] is old_a
+        assert td["b"] is old_b
+        assert td.batch_size == torch.Size([3, 4])
+
+    def test_pad_safe_default_is_true(self):
+        td = TensorDict({"a": torch.ones(3, 4)}, batch_size=[3, 4])
+        old_a = td["a"]
+        with pytest.raises(RuntimeError, match="negative output size"):
+            td.pad([-10, 0, 0, 0], inplace=True)
+        assert td["a"] is old_a
+
+    def test_pad_safe_false_skips_check(self):
+        td = TensorDict({"a": torch.ones(3, 4)}, batch_size=[3, 4])
+        # With safe=False, the pre-flight is skipped; torch's own pad call
+        # raises mid-loop. The TD ends up inconsistent here, but the
+        # underlying torch error is surfaced rather than ours.
+        with pytest.raises(RuntimeError):
+            td.pad([-10, 0, 0, 0], inplace=True, safe=False)
+
+    def test_pad_safe_lazy_stack(self):
+        td_a = TensorDict({"x": torch.ones(4)}, batch_size=[4])
+        td_b = TensorDict({"x": torch.ones(4) * 2}, batch_size=[4])
+        lst = lazy_stack([td_a, td_b], dim=0)
+        snapshots = [t["x"] for t in lst.tensordicts]
+        with pytest.raises(RuntimeError, match="negative output size"):
+            lst.pad([0, 0, -10, 0], inplace=True)
+        # Constituents untouched.
+        for t, snap in zip(lst.tensordicts, snapshots):
+            assert t["x"] is snap
+        assert lst.batch_size == torch.Size([2, 4])
+
     def test_pad_inplace_tensorclass(self):
         @tensorclass
         class _Sample:

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2295,9 +2295,7 @@ class TestGeneric:
             {
                 "a": torch.ones(3, 4, 1),
                 "b": torch.zeros(3, 4, 1, 1),
-                "nested": TensorDict(
-                    {"c": torch.ones(3, 4, 2)}, batch_size=[3, 4]
-                ),
+                "nested": TensorDict({"c": torch.ones(3, 4, 2)}, batch_size=[3, 4]),
             },
             batch_size=[3, 4],
         )
@@ -2445,9 +2443,7 @@ class TestGeneric:
             a: torch.Tensor
             b: torch.Tensor
 
-        s = _Sample(
-            a=torch.ones(3, 4), b=torch.zeros(3, 4, 2), batch_size=[3, 4]
-        )
+        s = _Sample(a=torch.ones(3, 4), b=torch.zeros(3, 4, 2), batch_size=[3, 4])
         inner = s._tensordict
         out = s.pad([0, 1, 0, 2], value=0.0, inplace=True)
         # The tensorclass wrap returns a fresh tensorclass instance bound

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2290,6 +2290,134 @@ class TestGeneric:
         assert torch.equal(padded_td["a"], expected_a)
         padded_td._check_batch_size()
 
+    def test_pad_inplace_identity_and_shapes(self):
+        td = TensorDict(
+            {
+                "a": torch.ones(3, 4, 1),
+                "b": torch.zeros(3, 4, 1, 1),
+                "nested": TensorDict(
+                    {"c": torch.ones(3, 4, 2)}, batch_size=[3, 4]
+                ),
+            },
+            batch_size=[3, 4],
+        )
+        td_id = id(td)
+        nested_id = id(td["nested"])
+        out = td.pad([0, 1, 0, 2], value=0.0, inplace=True)
+        assert out is td
+        assert id(out) == td_id
+        # Nested TD identity is preserved when inplace=True.
+        assert id(out["nested"]) == nested_id
+        assert out.batch_size == torch.Size([4, 6])
+        assert out["a"].shape == (4, 6, 1)
+        assert out["b"].shape == (4, 6, 1, 1)
+        assert out["nested"].batch_size == torch.Size([4, 6])
+        assert out["nested", "c"].shape == (4, 6, 2)
+        out._check_batch_size()
+
+    def test_pad_inplace_matches_functional(self):
+        def _build():
+            return TensorDict(
+                {
+                    "a": torch.arange(3 * 4).view(3, 4).float(),
+                    "b": torch.arange(3 * 4 * 5).view(3, 4, 5).float(),
+                    "nested": TensorDict(
+                        {"c": torch.arange(3 * 4 * 2).view(3, 4, 2).float()},
+                        batch_size=[3, 4],
+                    ),
+                },
+                batch_size=[3, 4],
+            )
+
+        for pad_size in [[0, 1, 0, 2], [1, 0, 0, 2], [1, 0, 2, 1]]:
+            td_f = _build()
+            td_i = _build()
+            ref = pad(td_f, pad_size, value=7.0)
+            out = pad(td_i, pad_size, value=7.0, inplace=True)
+            assert out is td_i
+            assert out.batch_size == ref.batch_size
+            assert set(out.keys()) == set(ref.keys())
+            for key in ref.keys(include_nested=True, leaves_only=True):
+                assert torch.equal(out[key], ref[key]), key
+
+    def test_pad_inplace_releases_old_storage(self):
+        td = TensorDict(
+            {"a": torch.zeros(8, 16, 32), "b": torch.ones(8, 16)},
+            batch_size=[8, 16],
+        )
+        old_a = td["a"]
+        old_b = td["b"]
+        ref_a = weakref.ref(old_a)
+        ref_b = weakref.ref(old_b)
+        del old_a, old_b
+        td.pad([0, 0, 0, 1], inplace=True)
+        gc.collect()
+        # The original leaf tensors must no longer be referenced anywhere
+        # once their padded replacements have been written back; this is
+        # what gives inplace=True its 1x memory profile.
+        assert ref_a() is None
+        assert ref_b() is None
+
+    def test_pad_inplace_lazy_stack_non_stack_dim(self):
+        td_a = TensorDict({"x": torch.ones(4)}, batch_size=[4])
+        td_b = TensorDict({"x": torch.ones(4) * 2}, batch_size=[4])
+        lst = lazy_stack([td_a, td_b], dim=0)
+        constituent_ids = [id(t) for t in lst.tensordicts]
+        out = lst.pad([0, 0, 0, 1], value=0.0, inplace=True)
+        assert out is lst
+        assert out.batch_size == torch.Size([2, 5])
+        # Constituents are the same objects; they were padded in place.
+        assert [id(t) for t in out.tensordicts] == constituent_ids
+        assert out.tensordicts[0]["x"].shape == (5,)
+        assert out.tensordicts[0]["x"][-1].item() == 0.0
+        assert out.tensordicts[1]["x"][-1].item() == 0.0
+
+    def test_pad_inplace_lazy_stack_stack_dim(self):
+        td_a = TensorDict({"x": torch.ones(4)}, batch_size=[4])
+        td_b = TensorDict({"x": torch.ones(4) * 2}, batch_size=[4])
+        lst = lazy_stack([td_a, td_b], dim=0)
+        out = lst.pad([0, 1, 0, 0], value=9.0, inplace=True)
+        assert out is lst
+        assert out.batch_size == torch.Size([3, 4])
+        assert len(out.tensordicts) == 3
+        assert out.tensordicts[-1]["x"].tolist() == [9.0, 9.0, 9.0, 9.0]
+        # Existing constituents preserved.
+        assert torch.equal(out.tensordicts[0]["x"], torch.ones(4))
+        assert torch.equal(out.tensordicts[1]["x"], torch.ones(4) * 2)
+
+    def test_pad_inplace_lazy_stack_both_dims(self):
+        td_a = TensorDict({"x": torch.ones(4)}, batch_size=[4])
+        td_b = TensorDict({"x": torch.ones(4) * 2}, batch_size=[4])
+        lst_inplace = lazy_stack([td_a.clone(), td_b.clone()], dim=0)
+        lst_ref = lazy_stack([td_a.clone(), td_b.clone()], dim=0)
+        ref = pad(lst_ref, [1, 0, 0, 2], value=3.0)
+        out = pad(lst_inplace, [1, 0, 0, 2], value=3.0, inplace=True)
+        assert out is lst_inplace
+        assert out.batch_size == ref.batch_size
+        for key in ref.keys(include_nested=True, leaves_only=True):
+            assert torch.equal(out[key], ref[key]), key
+
+    def test_pad_inplace_tensorclass(self):
+        @tensorclass
+        class _Sample:
+            a: torch.Tensor
+            b: torch.Tensor
+
+        s = _Sample(
+            a=torch.ones(3, 4), b=torch.zeros(3, 4, 2), batch_size=[3, 4]
+        )
+        inner = s._tensordict
+        out = s.pad([0, 1, 0, 2], value=0.0, inplace=True)
+        # The tensorclass wrap returns a fresh tensorclass instance bound
+        # to the same (mutated) inner tensordict; the 1x-memory guarantee
+        # lives on the inner TD which is preserved.
+        assert out._tensordict is inner
+        assert s._tensordict is inner
+        assert s.batch_size == torch.Size([4, 6])
+        assert out.batch_size == torch.Size([4, 6])
+        assert out.a.shape == (4, 6)
+        assert out.b.shape == (4, 6, 2)
+
     def test_pad_sequence_nontensor(self):
         d1 = TensorDict({"a": torch.tensor([1, 1]), "b": "asd"})
         d2 = TensorDict({"a": torch.tensor([2]), "b": "efg"})


### PR DESCRIPTION
## Summary

- Adds `inplace=True` to `tensordict.pad` so it pads each leaf in-place inside the input tensordict and releases each old storage as soon as the replacement is written. Peak memory for `td = pad(td, ...)`-style usage drops from ~2x the leaves to ~1x.
- Exposes `pad` as a method on `TensorDictBase` (and registers it on `tensorclass`).
- `LazyStackedTensorDict` is handled by padding each constituent along the non-stack dims in place and growing the stack dim by appending/prepending zero-filled copies of the edge constituents — so the lazy stack's identity is preserved even though its `batch_size` setter forbids resizing.
- Documents the project's `method_` (same-storage) vs `inplace=True` (same-container) convention in `CLAUDE.md` and `docs/source/overview.rst`, and the tensorclass dispatch list registers `pad` so the fallback warning is no longer triggered.

The motivation: `pad(td, ...)` currently builds a fresh tensordict via `TensorDict._new_unsafe({}, new_batch_size, ...)` and populates it leaf-by-leaf, holding the original `td` alive for the duration of the call. Common usage is `td = pad(td, ...)` where the caller wants the original released, but the function-local reference keeps it alive until return — peak ~2x. With `inplace=True` the rebind happens inside the input, so each old leaf is freed before the next leaf's pad allocates.

## Test plan

- [x] `pytest test/test_tensordict.py -k pad` — 58 passed, 1 unrelated skip
- [x] `pytest test/test_tensordict.py::TestGeneric` — 279 passed
- [x] New tests cover: object identity preservation, leaf-for-leaf equivalence with the non-inplace path, weak-ref-based check that old leaf storages are released, lazy stack pad along non-stack dim, lazy stack pad along the stack dim, lazy stack pad along both, tensorclass dispatch.
- [x] Manual smoke (in docstring example): `td.pad([0, 0, 0, 1], inplace=True) is td` returns `True`.

## Follow-ups (not in this PR)

Other shape-changing ops with the same 2x-memory profile — candidates for the same `inplace=True` treatment in future PRs: `gather` (already has `out=`), `repeat` / `repeat_interleave`, `roll`, `reshape` / `flatten` / `unflatten` (only when the underlying call materializes a copy), `contiguous`, `where`. None warrant an underscore variant, since they all change shape/dtype/layout.