### PR TITLE
[BugFix] Run __post_init__ and apply field defaults under torch.compile (#1708, #1710)

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1349,21 +1349,22 @@ def _init_wrapper(
                     "dynamo doesn't support arguments when building a tensorclass, pass the keyword explicitly."
                 )
 
+        # Use `is`/isinstance instead of `in (..., dataclasses.MISSING)`:
+        # under torch.compile, Dynamo can't proxy `_MISSING_TYPE` for `==`
+        # comparisons against a tensor default value.
+        _missing_type = getattr(
+            dataclasses, "_MISSING_TYPE", type(dataclasses.MISSING)
+        )
         for key, field in type(self).__dataclass_fields__.items():
             # Only process fields that are in __expected_keys__ (excludes ClassVar fields)
             if key in self.__expected_keys__:
-                if field.default_factory not in (
-                    dataclasses.MISSING,
-                ) and not isinstance(
-                    field.default_factory,
-                    getattr(
-                        dataclasses, "_MISSING_TYPE", type(dataclasses.MISSING)
-                    ),
+                if field.default_factory is not dataclasses.MISSING and not isinstance(
+                    field.default_factory, _missing_type
                 ):
                     default = field.default_factory()
                 else:
                     default = field.default
-                if default not in (None, dataclasses.MISSING):
+                if default is not None and not isinstance(default, _missing_type):
                     kwargs.setdefault(key, default)
 
         missing_params = [p for p in required_params if p not in kwargs]

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1352,9 +1352,7 @@ def _init_wrapper(
         # Use `is`/isinstance instead of `in (..., dataclasses.MISSING)`:
         # under torch.compile, Dynamo can't proxy `_MISSING_TYPE` for `==`
         # comparisons against a tensor default value.
-        _missing_type = getattr(
-            dataclasses, "_MISSING_TYPE", type(dataclasses.MISSING)
-        )
+        _missing_type = getattr(dataclasses, "_MISSING_TYPE", type(dataclasses.MISSING))
         for key, field in type(self).__dataclass_fields__.items():
             # Only process fields that are in __expected_keys__ (excludes ClassVar fields)
             if key in self.__expected_keys__:

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1432,7 +1432,7 @@ def _init_wrapper(
                 _set = type(self).set
                 for key, value in kwargs.items():
                     _set(self, key, value)
-            if not is_compiling() and hasattr(type(self), "__post_init__"):
+            if hasattr(type(self), "__post_init__"):
                 self.__post_init__()
         if lock:
             self._tensordict.lock_()
@@ -1688,7 +1688,7 @@ def _from_tensordict(
         object.__setattr__(tc, "_non_tensordict", non_tensordict)
     # since we aren't calling the dataclass __init__, we need to manually
     # check whether a __post_init__ method has been defined and invoke it
-    if not is_compiling() and hasattr(cls, "__post_init__"):
+    if hasattr(cls, "__post_init__"):
         tc.__post_init__()
     return tc
 

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1349,26 +1349,22 @@ def _init_wrapper(
                     "dynamo doesn't support arguments when building a tensorclass, pass the keyword explicitly."
                 )
 
-        if not is_compiling():
-            for key, field in type(self).__dataclass_fields__.items():
-                # Only process fields that are in __expected_keys__ (excludes ClassVar fields)
-                if key in self.__expected_keys__:
-                    if field.default_factory not in (
-                        dataclasses.MISSING,
-                    ) and not isinstance(
-                        field.default_factory,
-                        getattr(
-                            dataclasses, "_MISSING_TYPE", type(dataclasses.MISSING)
-                        ),
-                    ):
-                        default = field.default_factory()
-                    else:
-                        default = field.default
-                    if default not in (None, dataclasses.MISSING):
-                        kwargs.setdefault(key, default)
-        else:
-            # TODO: Decide what to do here
-            pass
+        for key, field in type(self).__dataclass_fields__.items():
+            # Only process fields that are in __expected_keys__ (excludes ClassVar fields)
+            if key in self.__expected_keys__:
+                if field.default_factory not in (
+                    dataclasses.MISSING,
+                ) and not isinstance(
+                    field.default_factory,
+                    getattr(
+                        dataclasses, "_MISSING_TYPE", type(dataclasses.MISSING)
+                    ),
+                ):
+                    default = field.default_factory()
+                else:
+                    default = field.default
+                if default not in (None, dataclasses.MISSING):
+                    kwargs.setdefault(key, default)
 
         missing_params = [p for p in required_params if p not in kwargs]
         if missing_params:
@@ -1410,9 +1406,8 @@ def _init_wrapper(
             # Fields with None defaults are intentionally skipped by the
             # default-handling above, but the dataclass __init__ would
             # still assign them. Ensure every expected key is present.
-            if not is_compiling():
-                for key in self.__expected_keys__:
-                    kwargs.setdefault(key, None)
+            for key in self.__expected_keys__:
+                kwargs.setdefault(key, None)
             if tensor_only:
                 # Fast path: validate and assign directly to the
                 # underlying dict, skipping the set → _set_str →

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -71,6 +71,14 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_dynamo_code_caches():
+    # Tests in this file all exercise torch.compile; a fresh Dynamo code cache
+    # between tests keeps recompile/guard-count assertions reliable and prevents
+    # one test's frame from leaking into the next.
+    torch._dynamo.reset_code_caches()
+
+
 def test_vmap_compile():
     # Since we monkey patch vmap we need to make sure compile is happy with it
     def func(x, y):
@@ -1365,8 +1373,6 @@ class TestNN:
 
     @pytest.mark.skipif(not _v2_5, reason="requires torch 2.5 or higher")
     def test_dispatch_nontensor(self, mode):
-        torch._dynamo.reset_code_caches()
-
         # Non tensor
         x = torch.randn(3)
         y = None
@@ -1380,8 +1386,6 @@ class TestNN:
 
     @pytest.mark.skipif(not _v2_5, reason="requires torch 2.5 or higher")
     def test_dispatch_tensor(self, mode):
-        torch._dynamo.reset_code_caches()
-
         x = torch.randn(3)
         y = torch.randn(3)
         mod = Seq(
@@ -1563,7 +1567,6 @@ class TestFunctional:
 )
 class TestExport:
     def test_export_module(self):
-        torch._dynamo.reset_code_caches()
         tdm = Mod(lambda x, y: x * y, in_keys=["x", "y"], out_keys=["z"])
         x = torch.randn(3)
         y = torch.randn(3)
@@ -1571,7 +1574,6 @@ class TestExport:
         assert (out.module()(x=x, y=y) == tdm(x=x, y=y)).all()
 
     def test_export_seq(self):
-        torch._dynamo.reset_code_caches()
         tdm = Seq(
             Mod(lambda x, y: x * y, in_keys=["x", "y"], out_keys=["z"]),
             Mod(lambda z, x: z + x, in_keys=["z", "x"], out_keys=["out"]),
@@ -1596,8 +1598,6 @@ class TestExport:
         _parse_batch_size did not handle torch.SymInt (which does not subclass
         numbers.Number), causing ValueError("batch size was not specified").
         """
-        torch._dynamo.reset_code_caches()
-
         class Mod(torch.nn.Module):
             def forward(self, x: torch.Tensor, y: torch.Tensor) -> TensorDict:
                 return TensorDict({"x": x, "y": y}, batch_size=x.shape[0])
@@ -1625,8 +1625,6 @@ class TestExport:
         pytree spec, raising AsPythonConstantNotImplementedError.
         Fix: store batch_dims (int) and reconstruct batch_size from tensor shapes.
         """
-        torch._dynamo.reset_code_caches()
-
         class Mod(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> TensorDict:
                 b, t = x.shape[0], x.shape[1]
@@ -2022,19 +2020,15 @@ class TestCompileNontensor:
         return a.tensor
 
     def test_nontensor_no_device_no_batch_size(self, data):
-        torch._dynamo.reset_code_caches()
         torch.compile(self.fn_no_device_no_batch_size)(data)
 
     def test_nontensor_no_device(self, data):
-        torch._dynamo.reset_code_caches()
         torch.compile(self.fn_no_device)(data)
 
     def test_nontensor_with_device(self, data):
-        torch._dynamo.reset_code_caches()
         torch.compile(self.fn_with_device)(data)
 
     def test_nontensor_with_device_without_batch_size(self, data):
-        torch._dynamo.reset_code_caches()
         torch.compile(self.fn_with_device_without_batch_size)(data)
 
 
@@ -2046,8 +2040,6 @@ class TestTCNonTensorInit:
         label: str
 
     def test_tc_nontensor_init_fullgraph(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn(a):
             tc = self.MyTC(x=a, label="hello", batch_size=[3])
@@ -2057,8 +2049,6 @@ class TestTCNonTensorInit:
         assert result.shape == (3,)
 
     def test_tc_nontensor_init_roundtrip(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn(a):
             tc = self.MyTC(x=a, label="hello", batch_size=[3])
@@ -2069,8 +2059,6 @@ class TestTCNonTensorInit:
         torch.testing.assert_close(result, inp + 1)
 
     def test_tc_nontensor_init_with_device(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn(a):
             tc = self.MyTC(x=a, label="world", batch_size=[3], device="cpu")
@@ -2109,8 +2097,6 @@ class TestTCPostInitCompile:
     """__post_init__ must run under torch.compile to match eager semantics (gh-1708)."""
 
     def test_post_init_runs_under_compile(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
             return _PostInitTC(x=x).x
@@ -2120,8 +2106,6 @@ class TestTCPostInitCompile:
         torch.testing.assert_close(fn(inp), torch.full((3,), 2.0))
 
     def test_post_init_runs_under_compile_from_tensordict(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
             td = TensorDict(x=x, batch_size=())
@@ -2135,8 +2119,6 @@ class TestTCDefaultsCompile:
     """@tensorclass field defaults must be applied under torch.compile (gh-1710)."""
 
     def test_concrete_default_applied_under_compile(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn():
             return _ConcreteDefaultTC().cache
@@ -2145,8 +2127,6 @@ class TestTCDefaultsCompile:
         torch.testing.assert_close(fn(), torch.zeros(3))
 
     def test_default_factory_applied_under_compile(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn():
             return _FactoryDefaultTC().cache
@@ -2155,8 +2135,6 @@ class TestTCDefaultsCompile:
         torch.testing.assert_close(fn(), torch.zeros(3))
 
     def test_omitted_none_default_under_compile(self):
-        torch._dynamo.reset_code_caches()
-
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
             return _NoneDefaultTC(x=x).y
@@ -2280,8 +2258,6 @@ class TestGuardCount:
 
     def test_unbatched_clone_preserves_semantics(self):
         """Cloning an UnbatchedTensor must produce independent data."""
-        torch._dynamo.reset_code_caches()
-
         def fn(td):
             cloned = td.clone()
             return cloned
@@ -2305,8 +2281,6 @@ class TestGuardCount:
 class TestNestedCompileRegion:
     def test_nested_compile_region_td(self):
         """TensorDict can be passed through nested_compile_region (gh-1667)."""
-        torch._dynamo.reset_code_caches()
-
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import argparse
 import contextlib
+import dataclasses
 import importlib.util
 import inspect
 import platform
@@ -2118,6 +2119,49 @@ class TestTCPostInitCompile:
         compiled = torch.compile(fn)(inp)
         torch.testing.assert_close(eager, torch.full((3,), 2.0))
         torch.testing.assert_close(compiled, eager)
+
+
+class TestTCDefaultsCompile:
+    """@tensorclass field defaults must be applied under torch.compile (gh-1710)."""
+
+    def test_concrete_default_applied_under_compile(self):
+        torch._dynamo.reset_code_caches()
+
+        @tensorclass
+        class Foo:
+            cache: torch.Tensor = torch.zeros(3)
+
+        eager = Foo().cache
+        compiled = torch.compile(lambda: Foo().cache)()
+        torch.testing.assert_close(eager, torch.zeros(3))
+        torch.testing.assert_close(compiled, eager)
+
+    def test_default_factory_applied_under_compile(self):
+        torch._dynamo.reset_code_caches()
+
+        @tensorclass
+        class Foo:
+            cache: torch.Tensor = dataclasses.field(
+                default_factory=lambda: torch.zeros(3)
+            )
+
+        eager = Foo().cache
+        compiled = torch.compile(lambda: Foo().cache)()
+        torch.testing.assert_close(eager, torch.zeros(3))
+        torch.testing.assert_close(compiled, eager)
+
+    def test_omitted_none_default_under_compile(self):
+        torch._dynamo.reset_code_caches()
+
+        @tensorclass
+        class Foo:
+            x: torch.Tensor
+            y: torch.Tensor = None
+
+        eager = Foo(x=torch.ones(3)).y
+        compiled = torch.compile(lambda x: Foo(x=x).y)(torch.ones(3))
+        assert eager is None
+        assert compiled is None
 
 
 def _count_compiles(fn, *args):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -2081,44 +2081,54 @@ class TestTCNonTensorInit:
         torch.testing.assert_close(result, inp * 2)
 
 
+@tensorclass
+class _PostInitTC:
+    x: torch.Tensor
+
+    def __post_init__(self):
+        self.x = self.x * 2
+
+
+@tensorclass
+class _ConcreteDefaultTC:
+    cache: torch.Tensor = torch.zeros(3)
+
+
+@tensorclass
+class _FactoryDefaultTC:
+    cache: torch.Tensor = dataclasses.field(default_factory=lambda: torch.zeros(3))
+
+
+@tensorclass
+class _NoneDefaultTC:
+    x: torch.Tensor
+    y: torch.Tensor = None
+
+
 class TestTCPostInitCompile:
     """__post_init__ must run under torch.compile to match eager semantics (gh-1708)."""
 
     def test_post_init_runs_under_compile(self):
         torch._dynamo.reset_code_caches()
 
-        @tensorclass
-        class Foo:
-            x: torch.Tensor
-
-            def __post_init__(self):
-                self.x = self.x * 2
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            return _PostInitTC(x=x).x
 
         inp = torch.ones(3)
-        eager = Foo(x=inp).x
-        compiled = torch.compile(lambda x: Foo(x=x).x)(inp)
-        torch.testing.assert_close(eager, torch.full((3,), 2.0))
-        torch.testing.assert_close(compiled, eager)
+        torch.testing.assert_close(_PostInitTC(x=inp).x, torch.full((3,), 2.0))
+        torch.testing.assert_close(fn(inp), torch.full((3,), 2.0))
 
     def test_post_init_runs_under_compile_from_tensordict(self):
         torch._dynamo.reset_code_caches()
 
-        @tensorclass
-        class Foo:
-            x: torch.Tensor
-
-            def __post_init__(self):
-                self.x = self.x * 2
-
+        @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
             td = TensorDict(x=x, batch_size=())
-            return Foo._from_tensordict(td).x
+            return _PostInitTC._from_tensordict(td).x
 
         inp = torch.ones(3)
-        eager = fn(inp)
-        compiled = torch.compile(fn)(inp)
-        torch.testing.assert_close(eager, torch.full((3,), 2.0))
-        torch.testing.assert_close(compiled, eager)
+        torch.testing.assert_close(fn(inp), torch.full((3,), 2.0))
 
 
 class TestTCDefaultsCompile:
@@ -2127,41 +2137,33 @@ class TestTCDefaultsCompile:
     def test_concrete_default_applied_under_compile(self):
         torch._dynamo.reset_code_caches()
 
-        @tensorclass
-        class Foo:
-            cache: torch.Tensor = torch.zeros(3)
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return _ConcreteDefaultTC().cache
 
-        eager = Foo().cache
-        compiled = torch.compile(lambda: Foo().cache)()
-        torch.testing.assert_close(eager, torch.zeros(3))
-        torch.testing.assert_close(compiled, eager)
+        torch.testing.assert_close(_ConcreteDefaultTC().cache, torch.zeros(3))
+        torch.testing.assert_close(fn(), torch.zeros(3))
 
     def test_default_factory_applied_under_compile(self):
         torch._dynamo.reset_code_caches()
 
-        @tensorclass
-        class Foo:
-            cache: torch.Tensor = dataclasses.field(
-                default_factory=lambda: torch.zeros(3)
-            )
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return _FactoryDefaultTC().cache
 
-        eager = Foo().cache
-        compiled = torch.compile(lambda: Foo().cache)()
-        torch.testing.assert_close(eager, torch.zeros(3))
-        torch.testing.assert_close(compiled, eager)
+        torch.testing.assert_close(_FactoryDefaultTC().cache, torch.zeros(3))
+        torch.testing.assert_close(fn(), torch.zeros(3))
 
     def test_omitted_none_default_under_compile(self):
         torch._dynamo.reset_code_caches()
 
-        @tensorclass
-        class Foo:
-            x: torch.Tensor
-            y: torch.Tensor = None
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            return _NoneDefaultTC(x=x).y
 
-        eager = Foo(x=torch.ones(3)).y
-        compiled = torch.compile(lambda x: Foo(x=x).y)(torch.ones(3))
-        assert eager is None
-        assert compiled is None
+        inp = torch.ones(3)
+        assert _NoneDefaultTC(x=inp).y is None
+        assert fn(inp) is None
 
 
 def _count_compiles(fn, *args):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -2080,6 +2080,46 @@ class TestTCNonTensorInit:
         torch.testing.assert_close(result, inp * 2)
 
 
+class TestTCPostInitCompile:
+    """__post_init__ must run under torch.compile to match eager semantics (gh-1708)."""
+
+    def test_post_init_runs_under_compile(self):
+        torch._dynamo.reset_code_caches()
+
+        @tensorclass
+        class Foo:
+            x: torch.Tensor
+
+            def __post_init__(self):
+                self.x = self.x * 2
+
+        inp = torch.ones(3)
+        eager = Foo(x=inp).x
+        compiled = torch.compile(lambda x: Foo(x=x).x)(inp)
+        torch.testing.assert_close(eager, torch.full((3,), 2.0))
+        torch.testing.assert_close(compiled, eager)
+
+    def test_post_init_runs_under_compile_from_tensordict(self):
+        torch._dynamo.reset_code_caches()
+
+        @tensorclass
+        class Foo:
+            x: torch.Tensor
+
+            def __post_init__(self):
+                self.x = self.x * 2
+
+        def fn(x):
+            td = TensorDict(x=x, batch_size=())
+            return Foo._from_tensordict(td).x
+
+        inp = torch.ones(3)
+        eager = fn(inp)
+        compiled = torch.compile(fn)(inp)
+        torch.testing.assert_close(eager, torch.full((3,), 2.0))
+        torch.testing.assert_close(compiled, eager)
+
+
 def _count_compiles(fn, *args):
     """Compile fn, run it twice, return (frame_count_first, frame_count_second).
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1598,6 +1598,7 @@ class TestExport:
         _parse_batch_size did not handle torch.SymInt (which does not subclass
         numbers.Number), causing ValueError("batch size was not specified").
         """
+
         class Mod(torch.nn.Module):
             def forward(self, x: torch.Tensor, y: torch.Tensor) -> TensorDict:
                 return TensorDict({"x": x, "y": y}, batch_size=x.shape[0])
@@ -1625,6 +1626,7 @@ class TestExport:
         pytree spec, raising AsPythonConstantNotImplementedError.
         Fix: store batch_dims (int) and reconstruct batch_size from tensor shapes.
         """
+
         class Mod(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> TensorDict:
                 b, t = x.shape[0], x.shape[1]
@@ -2258,6 +2260,7 @@ class TestGuardCount:
 
     def test_unbatched_clone_preserves_semantics(self):
         """Cloning an UnbatchedTensor must produce independent data."""
+
         def fn(td):
             cloned = td.clone()
             return cloned
@@ -2281,6 +2284,7 @@ class TestGuardCount:
 class TestNestedCompileRegion:
     def test_nested_compile_region_td(self):
         """TensorDict can be passed through nested_compile_region (gh-1667)."""
+
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()


### PR DESCRIPTION
## Summary

Fixes #1708 and #1710. Both bugs originate from PR #1552 (the `__init__` fast-path bypass) — distinct guards in the same wrapper, gated by `not is_compiling()`, that silently skip behavior the dataclass `__init__` would otherwise have provided.

### #1708 — `__post_init__` silently skipped under compile

```python
@tensorclass
class Foo:
    x: torch.Tensor
    def __post_init__(self):
        self.x = self.x * 2

Foo(x=torch.ones(3)).x                              # tensor([2., 2., 2.])  (correct)
torch.compile(lambda x: Foo(x=x).x)(torch.ones(3))  # tensor([1., 1., 1.])  (wrong, pre-fix)
```

### #1710 — field defaults silently skipped under compile

```python
@tensorclass
class Foo:
    cache: torch.Tensor = torch.zeros(3)

Foo().cache                              # tensor([0., 0., 0.])  (correct)
torch.compile(lambda: Foo().cache)()     # KeyError: 'key "cache" not found...'  (pre-fix)
```

## Root cause

PR #1552 replaced the unconditional dataclass `__init__(self, **kwargs)` with a fast-path bypass that writes only the kwargs the caller passed. Four pieces of dataclass-construction behavior were re-added to the fast path but guarded by `not is_compiling()`:

1. `__post_init__` invocation in the bypass branch of `_init_wrapper`
2. `__post_init__` invocation in `_from_tensordict`
3. Dataclass field default / `default_factory` fill (`kwargs.setdefault(key, default)`)
4. None-fill for all expected keys

Under `torch.compile`, all four were short-circuited. (1) and (2) silently produced wrong output; (3) and (4) caused omitted-but-defaulted fields to be missing from `_tensordict`, raising `KeyError` on access.

## Fix

Drop the `not is_compiling()` half of all four guards. Also remove a dead `else: pass` branch (with stale `# TODO: Decide what to do here`) that the second guard removal made redundant. The perf motivation of #1552 is preserved — these loops only matter at construction time and only do work proportional to the number of fields.

## Test plan

Two new regression test classes in `test/test_compile.py`:

- **`TestTCPostInitCompile`** (#1708):
  - `__post_init__` runs on direct construction under compile
  - `__post_init__` runs via `_from_tensordict` under compile
- **`TestTCDefaultsCompile`** (#1710):
  - Concrete default applied under compile
  - `dataclasses.field(default_factory=...)` applied under compile
  - Omitted field with `= None` default doesn't raise under compile

Results:

- [x] 5 new regression tests pass
- [x] Full `test/test_tensorclass.py` — 144 passed, 1 skipped
- [x] Tensorclass-related `test/test_compile.py` — 68 passed, 9 skipped (CUDA), 2 xfailed (pre-existing)