### PR TITLE
[Compile] Always materialize `_td_dim_names` on TensorDict instance

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -306,6 +306,14 @@ class TensorDict(TensorDictBase):
                     f"sub-type or a dictionary, found type(source)={type(source)}."
                 )
             self._batch_size = self._parse_batch_size(source, batch_size)
+            # Always materialize _td_dim_names on the instance so its presence
+            # in self.__dict__ is invariant for Dynamo. Without this, a TD
+            # constructed inside a compiled region (where the branch below is
+            # skipped) would only have the class-level default, while a sibling
+            # TD coming from _new_unsafe would have an instance attribute, and
+            # Dynamo would recompile on the difference
+            # (`not ___dict_contains('_td_dim_names', __dict__)` guard).
+            self._td_dim_names = None
             # TODO: this breaks when stacking tensorclasses with dynamo
             if not is_compiling():
                 self._set_names(names)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -2277,6 +2277,57 @@ class TestGuardCount:
             ut_clone.data_ptr() != ut_orig.data_ptr()
         ), "clone() must produce independent data"
 
+    def test_td_dim_names_always_on_instance(self):
+        """`_td_dim_names` must always live in instance ``__dict__``.
+
+        A TD constructed via the public ``TensorDict(...)`` constructor
+        inside a compiled region (the hot path in torchrl env stepping,
+        where the env builds a fresh ``next`` TD on every step) must end
+        up with ``_td_dim_names`` in its instance ``__dict__``. Otherwise,
+        when that TD flows back into a compiled region on the next
+        iteration, Dynamo recompiles on
+        ``not ___dict_contains('_td_dim_names', __dict__)``.
+        """
+
+        def make_inside_compile(seed):
+            return TensorDict(
+                {"a": seed + 1, "b": seed + 2},
+                batch_size=seed.shape[:1],
+            )
+
+        seed = torch.randn(4)
+        compiled = torch.compile(make_inside_compile, fullgraph=True, backend="eager")
+        td_from_compile = compiled(seed)
+
+        # The TD that came out of compile must have _td_dim_names on its
+        # instance dict, exactly like a TD built in eager mode.
+        td_from_eager = TensorDict(
+            {"a": seed + 1, "b": seed + 2},
+            batch_size=seed.shape[:1],
+        )
+        assert (
+            "_td_dim_names" in td_from_compile.__dict__
+        ), "_td_dim_names must live on instance dict (got from compile-time __init__)"
+        assert "_td_dim_names" in td_from_eager.__dict__
+
+        # And then feeding that compile-built TD back into a compiled
+        # function must not trigger a recompile relative to the eager TD.
+        def use_td(td):
+            return td["a"] + td["b"]
+
+        torch._dynamo.reset_code_caches()
+        cnt = CompileCounterWithBackend("eager")
+        compiled_use = torch.compile(use_td, backend=cnt)
+        compiled_use(td_from_eager)
+        first = cnt.frame_count
+        compiled_use(td_from_compile)
+        second = cnt.frame_count
+        assert first == 1, f"Expected 1 compile frame, got {first}"
+        assert second == 1, (
+            "Mixing eager-built and compile-built TDs recompiled: "
+            f"{second} frames"
+        )
+
 
 class TestNestedCompileRegion:
     def test_nested_compile_region_td(self):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -2324,8 +2324,7 @@ class TestGuardCount:
         second = cnt.frame_count
         assert first == 1, f"Expected 1 compile frame, got {first}"
         assert second == 1, (
-            "Mixing eager-built and compile-built TDs recompiled: "
-            f"{second} frames"
+            "Mixing eager-built and compile-built TDs recompiled: " f"{second} frames"
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1715
* #1714
* __->__ #1713

A TensorDict built via the public ``TensorDict(...)`` constructor inside a
compiled region skipped ``_set_names`` (guarded on ``not is_compiling()``)
and so never wrote ``_td_dim_names`` to ``self.__dict__``. A sibling TD
coming from ``_new_unsafe`` always did. When both kinds flowed through
the same compiled function, Dynamo specialized on
``not ___dict_contains('_td_dim_names', __dict__)`` and recompiled.

Set ``self._td_dim_names = None`` unconditionally before the
``_set_names`` branch in ``TensorDict.__init__`` so the attribute is
always on the instance, matching ``_new_unsafe``. No behavior change in
eager mode (``_set_names`` overwrites it).

Adds a guard-count test asserting that a TD built inside a compiled
function and a TD built eagerly do not produce different recompiles when
fed into the same compiled function.

Authored with Claude.

Co-authored-by: Cursor <cursoragent@cursor.com>