### PR TITLE
[Deprecation] Default memmap robust_key to True

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2965,7 +2965,7 @@ class LazyStackedTensorDict(TensorDictBase):
         inplace=True,
         like=False,
         share_non_tensor,
-        robust_key: bool = False,
+        robust_key: bool = True,
         existsok,
     ) -> Self:
         if prefix is not None:
@@ -3022,7 +3022,7 @@ class LazyStackedTensorDict(TensorDictBase):
         device: torch.device | None = None,
         *,
         out=None,
-        robust_key: bool = False,
+        robust_key: bool = True,
         **kwargs,
     ) -> LazyStackedTensorDict:
         tensordicts = []

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -3204,7 +3204,7 @@ class TensorDict(TensorDictBase):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         if not self.is_memmap():
             raise RuntimeError(
@@ -3260,7 +3260,7 @@ class TensorDict(TensorDictBase):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         if not self.is_memmap():
             raise RuntimeError(
@@ -3320,7 +3320,7 @@ class TensorDict(TensorDictBase):
         *,
         copy_data: bool = True,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         if not self.is_memmap():
             raise RuntimeError(
@@ -4632,7 +4632,7 @@ class _SubTensorDict(TensorDictBase):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         raise RuntimeError(
             "Making a memory-mapped tensor after instantiation isn't currently allowed for _SubTensorDict."

--- a/tensordict/_td_functions.py
+++ b/tensordict/_td_functions.py
@@ -123,7 +123,7 @@ def load(
     non_blocking: bool = False,
     *,
     out: TensorCollection | None = None,
-    robust_key: bool | None = None,
+    robust_key: bool | None = True,
 ) -> "Self":
     """Loads a tensordict from disk."""
     return load_memmap(
@@ -141,7 +141,7 @@ def load_memmap(
     non_blocking: bool = False,
     *,
     out: TensorCollection | None = None,
-    robust_key: bool | None = None,
+    robust_key: bool | None = True,
 ) -> "Self":
     """Loads a memory-mapped tensordict from disk."""
     return _tensordict_cls().load_memmap(
@@ -161,7 +161,7 @@ def save(
     num_threads: int = 0,
     return_early: bool = False,
     share_non_tensor: bool = False,
-    robust_key: bool | None = None,
+    robust_key: bool | None = True,
 ) -> None:
     """Saves the tensordict to disk."""
     return data.memmap(
@@ -182,7 +182,7 @@ def memmap(
     num_threads: int = 0,
     return_early: bool = False,
     share_non_tensor: bool = False,
-    robust_key: bool | None = None,
+    robust_key: bool | None = True,
 ) -> "Self":
     """Writes all tensors onto memory-mapped tensors in a new tensordict."""
     return data.memmap(

--- a/tensordict/_tensorcollection.pyi
+++ b/tensordict/_tensorcollection.pyi
@@ -822,7 +822,7 @@ class TensorCollection:
         return_early: bool = False,
         share_non_tensor: bool = False,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def make_memmap(
         self,
@@ -830,7 +830,7 @@ class TensorCollection:
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor: ...
     def make_memmap_from_storage(
         self,
@@ -839,7 +839,7 @@ class TensorCollection:
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor: ...
     def make_memmap_from_tensor(
         self,
@@ -847,7 +847,7 @@ class TensorCollection:
         tensor: torch.Tensor,
         *,
         copy_data: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor: ...
     def save(
         self,
@@ -857,7 +857,7 @@ class TensorCollection:
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def dumps(
         self,
@@ -867,7 +867,7 @@ class TensorCollection:
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def memmap(
         self,
@@ -878,7 +878,7 @@ class TensorCollection:
         return_early: bool = False,
         share_non_tensor: bool = False,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def memmap_like(
         self,
@@ -889,14 +889,14 @@ class TensorCollection:
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     @classmethod
     def load(
-        cls, prefix: str | Path, *args, robust_key: bool | None = None, **kwargs
+        cls, prefix: str | Path, *args, robust_key: bool | None = True, **kwargs
     ) -> Self: ...
     def load_(
-        self, prefix: str | Path, *args, robust_key: bool | None = None, **kwargs
+        self, prefix: str | Path, *args, robust_key: bool | None = True, **kwargs
     ): ...
     @classmethod
     def load_memmap(
@@ -906,9 +906,9 @@ class TensorCollection:
         non_blocking: bool = False,
         *,
         out: TensorCollection | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
-    def load_memmap_(self, prefix: str | Path, robust_key: bool | None = None): ...
+    def load_memmap_(self, prefix: str | Path, robust_key: bool | None = True): ...
     def memmap_refresh_(self): ...
     def entry_class(self, key: NestedKey) -> type: ...
     def set(

--- a/tensordict/_utils_key_json.py
+++ b/tensordict/_utils_key_json.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
-import warnings
 
 __all__ = [
     "_decode_key_from_filesystem",
@@ -44,31 +43,16 @@ def _encode_key_for_filesystem(key: str, *, robust: bool = True) -> str:
 
 
 def _get_robust_key_setting_with_warning(key: str, robust_key) -> bool:
-    """Handle the robust_key parameter with smart deprecation warning."""
-    if robust_key is not None:
-        return robust_key
-
-    robust_encoded = _encode_key_for_filesystem(key, robust=True)
-    legacy_encoded = _encode_key_for_filesystem(key, robust=False)
-
-    if robust_encoded != legacy_encoded:
-        warnings.warn(
-            f"The key '{key}' contains characters that will be handled differently "
-            f"in TensorDict v0.12 for better cross-platform support. "
-            f"To opt into the new behavior now, use `robust_key=True`. "
-            f"To suppress this warning and keep the current behavior, use `robust_key=False`. "
-            f"See https://github.com/pytorch/tensordict/issues/1440 for details.",
-            FutureWarning,
-            stacklevel=3,
-        )
-
-    return False
+    """Handle the robust_key parameter after the robust default migration."""
+    if robust_key is None:
+        return True
+    return robust_key
 
 
 def _get_robust_key_setting(robust_key) -> bool:
     """Handle the robust_key parameter without key-specific logic."""
     if robust_key is None:
-        return False
+        return True
     return robust_key
 
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -7198,7 +7198,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         return_early: bool = False,
         share_non_tensor: bool = False,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self:
         """Writes all tensors onto a corresponding memory-mapped Tensor, in-place.
 
@@ -7225,11 +7225,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 errors. Defaults to ``False``.
             existsok (bool, optional): if ``False``, an exception will be raised if a tensor already
                 exists in the same path. Defaults to ``True``.
-            robust_key (bool, optional): if ``True``, uses robust key encoding that safely
+            robust_key (bool, optional): if ``True`` (default), uses robust key encoding that safely
                 handles keys with path separators and special characters. If ``False``,
-                uses legacy behavior (keys used as-is). If ``None`` (default), emits a
-                deprecation warning and falls back to legacy behavior. Will default to
-                ``True`` in v0.12.
+                uses legacy behavior (keys used as-is). If ``None``, uses the default
+                robust behavior.
 
         The TensorDict is then locked, meaning that any writing operations that
         isn't in-place will throw an exception (eg, rename, set or remove an
@@ -7289,7 +7288,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         """Creates an empty memory-mapped tensor given a shape and possibly a dtype.
 
@@ -7306,11 +7305,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
         Keyword arguments:
             dtype (torch.dtype, optional): the dtype of the new tensor.
-            robust_key (bool, optional): if ``True``, uses robust key encoding that safely
+            robust_key (bool, optional): if ``True`` (default), uses robust key encoding that safely
                 handles keys with path separators and special characters. If ``False``,
-                uses legacy behavior (keys used as-is). If ``None`` (default), emits a
-                deprecation warning and falls back to legacy behavior. Will default to
-                ``True`` in v0.12.
+                uses legacy behavior (keys used as-is). If ``None``, uses the default
+                robust behavior.
 
         Returns:
             A new memory mapped tensor.
@@ -7326,7 +7324,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         """Creates an empty memory-mapped tensor given a storage, a shape and possibly a dtype.
 
@@ -7348,11 +7346,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
         Keyword arguments:
             dtype (torch.dtype, optional): the dtype of the new tensor.
-            robust_key (bool, optional): if ``True``, uses robust key encoding that safely
+            robust_key (bool, optional): if ``True`` (default), uses robust key encoding that safely
                 handles keys with path separators and special characters. If ``False``,
-                uses legacy behavior (keys used as-is). If ``None`` (default), emits a
-                deprecation warning and falls back to legacy behavior. Will default to
-                ``True`` in v0.12.
+                uses legacy behavior (keys used as-is). If ``None``, uses the default
+                robust behavior.
 
         Returns:
             A new memory mapped tensor with the given storage.
@@ -7367,7 +7364,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         tensor: torch.Tensor,
         *,
         copy_data: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         """Creates an empty memory-mapped tensor given a tensor.
 
@@ -7385,11 +7382,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
         Keyword arguments:
             copy_data (bool, optionaL): if ``False``, the new tensor will share the metadata of the input such as
                 shape and dtype, but the content will be empty. Defaults to ``True``.
-            robust_key (bool, optional): if ``True``, uses robust key encoding that safely
+            robust_key (bool, optional): if ``True`` (default), uses robust key encoding that safely
                 handles keys with path separators and special characters. If ``False``,
-                uses legacy behavior (keys used as-is). If ``None`` (default), emits a
-                deprecation warning and falls back to legacy behavior. Will default to
-                ``True`` in v0.12.
+                uses legacy behavior (keys used as-is). If ``None``, uses the default
+                robust behavior.
 
         Returns:
             A new memory mapped tensor with the given storage.
@@ -7405,7 +7401,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self:
         """Saves the tensordict to disk.
 
@@ -7431,7 +7427,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         return_early: bool = False,
         share_non_tensor: bool = False,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self:
         """Writes all tensors onto a corresponding memory-mapped Tensor in a new tensordict.
 
@@ -7457,11 +7453,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 errors. Defaults to ``False``.
             existsok (bool, optional): if ``False``, an exception will be raised if a tensor already
                 exists in the same path. Defaults to ``True``.
-            robust_key (bool, optional): if ``True``, uses robust key encoding that safely
+            robust_key (bool, optional): if ``True`` (default), uses robust key encoding that safely
                 handles keys with path separators and special characters. If ``False``,
-                uses legacy behavior (keys used as-is). If ``None`` (default), emits a
-                deprecation warning and falls back to legacy behavior. Will default to
-                ``True`` in v0.12.
+                uses legacy behavior (keys used as-is). If ``None``, uses the default
+                robust behavior.
 
         The TensorDict is then locked, meaning that any writing operations that
         isn't in-place will throw an exception (eg, rename, set or remove an
@@ -7526,7 +7521,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self:
         """Creates a contentless Memory-mapped tensordict with the same shapes as the original one.
 
@@ -7552,11 +7547,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 errors. Defaults to ``False``.
             existsok (bool, optional): if ``False``, an exception will be raised if a tensor already
                 exists in the same path. Defaults to ``True``.
-            robust_key (bool, optional): if ``True``, uses robust key encoding that safely
+            robust_key (bool, optional): if ``True`` (default), uses robust key encoding that safely
                 handles keys with path separators and special characters. If ``False``,
-                uses legacy behavior (keys used as-is). If ``None`` (default), emits a
-                deprecation warning and falls back to legacy behavior. Will default to
-                ``True`` in v0.12.
+                uses legacy behavior (keys used as-is). If ``None``, uses the default
+                robust behavior.
 
         The TensorDict is then locked, meaning that any writing operations that
         isn't in-place will throw an exception (eg, rename, set or remove an
@@ -7657,7 +7651,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         non_blocking: bool = False,
         *,
         out: TensorDictBase | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self:
         """Loads a memory-mapped tensordict from disk.
 
@@ -7674,10 +7668,9 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 called after loading tensors on device. Defaults to ``False``.
             out (TensorDictBase, optional): optional tensordict where the data
                 should be written.
-            robust_key (bool, optional): if ``True``, expects robust key encoding was used
+            robust_key (bool, optional): if ``True`` (default), expects robust key encoding was used
                 when saving and decodes filenames accordingly. If ``False``, uses legacy
-                behavior. If ``None`` (default), emits a deprecation warning and falls
-                back to legacy behavior. Will default to ``True`` in v0.12.
+                behavior. If ``None``, uses the default robust behavior.
 
         Examples:
             >>> from tensordict import TensorDict
@@ -7765,7 +7758,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
     def load_memmap_(
         self,
         prefix: str | Path,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ):
         """Loads the content of a memory-mapped tensordict within the tensordict where ``load_memmap_`` is called.
 

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -708,7 +708,7 @@ class PersistentTensorDict(TensorDictBase):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         raise RuntimeError(
             "Making a memory-mapped tensor after instantiation isn't allowed for persistent tensordicts."
@@ -722,7 +722,7 @@ class PersistentTensorDict(TensorDictBase):
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         raise RuntimeError(
             "Making a memory-mapped tensor after instantiation isn't allowed for persistent tensordicts."
@@ -735,7 +735,7 @@ class PersistentTensorDict(TensorDictBase):
         tensor: torch.Tensor,
         *,
         copy_data: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor:
         raise RuntimeError(
             "Making a memory-mapped tensor after instantiation isn't allowed for persistent tensordicts."

--- a/tensordict/store/_store.py
+++ b/tensordict/store/_store.py
@@ -2585,19 +2585,19 @@ class TensorDictStore(TensorDictBase):
             "Call `to_tensordict()` or `to_local()` first."
         )
 
-    def make_memmap(self, key, shape, *, dtype=None, robust_key=None):
+    def make_memmap(self, key, shape, *, dtype=None, robust_key=True):
         raise RuntimeError(
             f"Cannot make memory-mapped tensor on a {type(self).__name__}."
         )
 
     def make_memmap_from_storage(
-        self, key, storage, shape, *, dtype=None, robust_key=None
+        self, key, storage, shape, *, dtype=None, robust_key=True
     ):
         raise RuntimeError(
             f"Cannot make memory-mapped tensor on a {type(self).__name__}."
         )
 
-    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=None):
+    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=True):
         raise RuntimeError(
             f"Cannot make memory-mapped tensor on a {type(self).__name__}."
         )
@@ -3130,15 +3130,15 @@ class _StoreStackElementView(TensorDictBase):
     def _memmap_(self, **kw):
         raise RuntimeError(f"Cannot call memmap on a {type(self).__name__}.")
 
-    def make_memmap(self, key, shape, *, dtype=None, robust_key=None):
+    def make_memmap(self, key, shape, *, dtype=None, robust_key=True):
         raise RuntimeError(f"Cannot make memmap on a {type(self).__name__}.")
 
     def make_memmap_from_storage(
-        self, key, storage, shape, *, dtype=None, robust_key=None
+        self, key, storage, shape, *, dtype=None, robust_key=True
     ):
         raise RuntimeError(f"Cannot make memmap on a {type(self).__name__}.")
 
-    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=None):
+    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=True):
         raise RuntimeError(f"Cannot make memmap on a {type(self).__name__}.")
 
     def memmap_(self, prefix=None, copy_existing=False, num_threads=0):
@@ -4888,19 +4888,19 @@ class LazyStackedTensorDictStore(TensorDictBase):
     ):
         raise RuntimeError(f"Cannot call memmap on a {type(self).__name__} in-place.")
 
-    def make_memmap(self, key, shape, *, dtype=None, robust_key=None):
+    def make_memmap(self, key, shape, *, dtype=None, robust_key=True):
         raise RuntimeError(
             f"Cannot make memory-mapped tensor on a {type(self).__name__}."
         )
 
     def make_memmap_from_storage(
-        self, key, storage, shape, *, dtype=None, robust_key=None
+        self, key, storage, shape, *, dtype=None, robust_key=True
     ):
         raise RuntimeError(
             f"Cannot make memory-mapped tensor on a {type(self).__name__}."
         )
 
-    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=None):
+    def make_memmap_from_tensor(self, key, tensor, *, copy_data=True, robust_key=True):
         raise RuntimeError(
             f"Cannot make memory-mapped tensor on a {type(self).__name__}."
         )

--- a/tensordict/tensorclass.pyi
+++ b/tensordict/tensorclass.pyi
@@ -874,7 +874,7 @@ class TensorClass:
         return_early: bool = False,
         share_non_tensor: bool = False,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def make_memmap(
         self,
@@ -882,7 +882,7 @@ class TensorClass:
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor: ...
     def make_memmap_from_storage(
         self,
@@ -891,7 +891,7 @@ class TensorClass:
         shape: torch.Size | torch.Tensor,
         *,
         dtype: torch.dtype | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor: ...
     def make_memmap_from_tensor(
         self,
@@ -899,7 +899,7 @@ class TensorClass:
         tensor: torch.Tensor,
         *,
         copy_data: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> MemoryMappedTensor: ...
     def save(
         self,
@@ -909,7 +909,7 @@ class TensorClass:
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def dumps(
         self,
@@ -919,7 +919,7 @@ class TensorClass:
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def memmap(
         self,
@@ -930,7 +930,7 @@ class TensorClass:
         return_early: bool = False,
         share_non_tensor: bool = False,
         existsok: bool = True,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def memmap_like(
         self,
@@ -941,7 +941,7 @@ class TensorClass:
         num_threads: int = 0,
         return_early: bool = False,
         share_non_tensor: bool = False,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     @classmethod
     def load(cls, prefix: str | Path, *args, **kwargs) -> Self: ...
@@ -954,10 +954,10 @@ class TensorClass:
         non_blocking: bool = False,
         *,
         out: TensorCollection | None = None,
-        robust_key: bool | None = None,
+        robust_key: bool | None = True,
     ) -> Self: ...
     def load_memmap_(
-        self, prefix: str | Path, robust_key: bool | None = None
+        self, prefix: str | Path, robust_key: bool | None = True
     ) -> Self: ...
     def memmap_refresh_(self) -> Self: ...
     def entry_class(self, key: NestedKey) -> type: ...

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -15771,63 +15771,43 @@ class TestMemmap:
         assert "normal_key" in td_loaded
         assert_allclose_td(td, td_loaded)
 
-    def test_memmap_robust_key_deprecation_warning_smart(self, tmpdir):
-        """Test that robust_key=None only warns for problematic keys."""
+    def test_memmap_robust_key_default_no_warning(self, tmpdir):
+        """Test that robust_key=None uses robust encoding without warnings."""
         import warnings
 
-        # Normal key should NOT warn
         td_normal = TensorDict({"normal_key": torch.randn(3, 4)})
+        td_pathlike = TensorDict({"a/b/c": torch.randn(3, 4)})
 
         with warnings.catch_warnings():
-            warnings.simplefilter("error")  # Turn warnings into errors
-            # This should NOT raise any warning
+            warnings.simplefilter("error")
             td_normal.memmap(tmpdir / "normal", robust_key=None)
             TensorDict.load_memmap(tmpdir / "normal", robust_key=None)
 
-        # Path-like key SHOULD warn
-        td_pathlike = TensorDict({"a/b/c": torch.randn(3, 4)})
+            td_pathlike.memmap(tmpdir / "pathlike", robust_key=None)
+            td_loaded = TensorDict.load_memmap(tmpdir / "pathlike", robust_key=None)
 
-        with pytest.warns(
-            FutureWarning, match="contains characters that will be handled differently"
-        ):
-            # This should fail because legacy behavior can't handle path-like keys
-            # but the warning should be emitted first
-            try:
-                td_pathlike.memmap(tmpdir / "pathlike", robust_key=None)
-            except RuntimeError:
-                pass  # Expected to fail with legacy behavior
+        assert "a/b/c" in td_loaded
+        assert_allclose_td(td_pathlike, td_loaded)
 
-    def test_memmap_robust_key_warning_only_when_different(self, tmpdir):
-        """Test warning is only emitted when robust encoding differs from legacy."""
+    def test_memmap_robust_key_default_for_problematic_keys(self, tmpdir):
+        """Test that the default robust encoding handles problematic keys."""
         import warnings
 
-        # Test keys that should NOT warn (no encoding difference)
-        normal_keys = ["normal_key", "key123", "another_normal_key", "CamelCase"]
-
-        for key in normal_keys:
-            td = TensorDict({key: torch.randn(2, 3)})
-            with warnings.catch_warnings():
-                warnings.simplefilter("error")  # Convert warnings to errors
-                # Should not raise any warning/error
-                td.memmap(tmpdir / f"normal_{key}", robust_key=None)
-
-        # Test keys that SHOULD warn (encoding difference)
         problematic_keys = ["a/b/c", "key with spaces", "key:colon", "key*star"]
 
         for key in problematic_keys:
             td = TensorDict({key: torch.randn(2, 3)})
-            with pytest.warns(
-                FutureWarning,
-                match="contains characters that will be handled differently",
-            ):
-                try:
-                    td.memmap(
-                        tmpdir
-                        / f"problematic_{key.replace('/', '_').replace(' ', '_').replace(':', '_').replace('*', '_')}",
-                        robust_key=None,
-                    )
-                except RuntimeError:
-                    pass  # Expected to fail with legacy behavior for path-like keys
+            path = (
+                tmpdir
+                / f"problematic_{key.replace('/', '_').replace(' ', '_').replace(':', '_').replace('*', '_')}"
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                td.memmap(path, robust_key=None)
+                td_loaded = TensorDict.load_memmap(path, robust_key=None)
+
+            assert key in td_loaded
+            assert_allclose_td(td, td_loaded)
 
     def test_memmap_robust_key_encoding_bijective(self):
         """Test that key encoding is bijective."""

--- a/test/test_utils_key_json_split.py
+++ b/test/test_utils_key_json_split.py
@@ -5,7 +5,6 @@
 
 import importlib
 
-import pytest
 
 
 def test_utils_key_json_import_paths_are_preserved():
@@ -17,7 +16,7 @@ def test_utils_key_json_import_paths_are_preserved():
         assert getattr(utils_module, name).__module__ == "tensordict.utils"
 
 
-def test_filesystem_key_roundtrip_and_warning():
+def test_filesystem_key_roundtrip_and_default():
     utils_module = importlib.import_module("tensordict.utils")
 
     key = "a/b% c"
@@ -26,8 +25,8 @@ def test_filesystem_key_roundtrip_and_warning():
     assert encoded == "a%2Fb%25%20c"
     assert utils_module._decode_key_from_filesystem(encoded) == key
     assert utils_module._encode_key_for_filesystem(key, robust=False) == key
-    with pytest.warns(FutureWarning):
-        assert utils_module._get_robust_key_setting_with_warning(key, None) is False
+    assert utils_module._get_robust_key_setting_with_warning(key, None) is True
+    assert utils_module._get_robust_key_setting(None) is True
 
 
 def test_json_backend_roundtrip():

--- a/test/test_utils_key_json_split.py
+++ b/test/test_utils_key_json_split.py
@@ -6,7 +6,6 @@
 import importlib
 
 
-
 def test_utils_key_json_import_paths_are_preserved():
     utils_module = importlib.import_module("tensordict.utils")
     helper_module = importlib.import_module("tensordict._utils_key_json")


### PR DESCRIPTION
## Summary
- Enact the advertised robust memmap key encoding default by treating `robust_key=None` as robust behavior.
- Change public `robust_key` defaults to `True` while preserving `robust_key=False` for legacy file names.
- Remove the obsolete FutureWarning path and update tests/docs.

## Validation
- `python -m pytest test/test_utils_key_json_split.py test/test_tensordict.py::TestMemmap -q`
- `git diff --check`

## Release context
This addresses the deprecation warning audit for TensorDict 0.13.0. Other warnings found are either targeted for v0.14 or have no explicit removal target.