### PR TITLE
[Deprecation] Warn on to_module state replacement

### DIFF
--- a/benchmarks/nn/functional_benchmarks_test.py
+++ b/benchmarks/nn/functional_benchmarks_test.py
@@ -6,6 +6,7 @@
 
 # we use deepcopy as our implementation modifies the modules in-place
 import argparse
+import warnings
 from copy import deepcopy
 
 import pytest
@@ -240,6 +241,30 @@ def test_to_module_speed(benchmark, tdparams):
 
     def func(params=params, module=module):
         with params.to_module(module):
+            pass
+        return
+
+    benchmark(func)
+
+
+@pytest.mark.parametrize("preserve_module_state", [None, False, True])
+def test_to_module_plain_tensor_speed(benchmark, preserve_module_state):
+    module = torch.nn.Transformer()
+    params = TensorDict.from_module(module).data.detach().clone()
+    kwargs = (
+        {}
+        if preserve_module_state is None
+        else {"preserve_module_state": preserve_module_state}
+    )
+    if preserve_module_state is None:
+        warnings.filterwarnings(
+            "ignore",
+            message="TensorDict.to_module\\(\\) is replacing an existing nn.Parameter",
+            category=FutureWarning,
+        )
+
+    def func(params=params, module=module, kwargs=kwargs):
+        with params.to_module(module, **kwargs):
             pass
         return
 

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -532,6 +532,7 @@ class TensorDict(TensorDictBase):
         memo=None,
         use_state_dict: bool = False,
         non_blocking: bool = False,
+        preserve_module_state: bool | None = None,
         is_dynamo: bool | None = None,
     ):
         if is_dynamo is None:
@@ -617,9 +618,18 @@ class TensorDict(TensorDictBase):
                         key,
                         value,
                         inplace,
+                        preserve_module_state=preserve_module_state,
+                        memo=memo,
                     )
                 else:
                     if not inplace:
+                        value = _maybe_preserve_module_state(
+                            module,
+                            key,
+                            value,
+                            preserve_module_state=preserve_module_state,
+                            memo=memo,
+                        )
                         local_out = swap_tensor(module, key, value)
                     else:
                         new_val = local_out
@@ -644,6 +654,7 @@ class TensorDict(TensorDictBase):
                         memo=memo,
                         use_state_dict=use_state_dict,
                         non_blocking=non_blocking,
+                        preserve_module_state=preserve_module_state,
                         is_dynamo=is_dynamo,
                     )
 
@@ -5014,6 +5025,73 @@ class _TensorDictKeysView:
         return f"{type(self).__name__}({list(self)},\n{indent(include_nested, 4 * ' ')},\n{indent(leaves_only, 4 * ' ')})"
 
 
+_TO_MODULE_PRESERVE_MODULE_STATE_WARNING = (
+    "TensorDict.to_module() is replacing an existing nn.Parameter in the "
+    "destination module with a tensor leaf that is not an nn.Parameter. This "
+    "historical behavior can remove the key from module.state_dict(). In "
+    "tensordict v0.14, to_module() will preserve existing module parameter "
+    "and buffer registrations by default. Pass preserve_module_state=False "
+    "to keep the current replacement behavior, or preserve_module_state=True "
+    "to opt in to the v0.14 behavior now."
+)
+
+
+def _warn_to_module_preserve_module_state(memo) -> None:
+    if memo is None:
+        warn(
+            _TO_MODULE_PRESERVE_MODULE_STATE_WARNING,
+            FutureWarning,
+            stacklevel=3,
+        )
+        return
+    if memo.get("preserve_module_state_warned", False):
+        return
+    memo["preserve_module_state_warned"] = True
+    warn(
+        _TO_MODULE_PRESERVE_MODULE_STATE_WARNING,
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
+def _maybe_preserve_module_state(
+    module: torch.nn.Module,
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    preserve_module_state: bool | None,
+    memo,
+) -> torch.Tensor:
+    if preserve_module_state is False or (
+        preserve_module_state is None and isinstance(tensor, torch.nn.Parameter)
+    ):
+        return tensor
+    try:
+        param = module._parameters.get(name, NO_DEFAULT)
+    except AttributeError:
+        param = NO_DEFAULT
+    if (
+        param is not NO_DEFAULT
+        and param is not None
+        and isinstance(tensor, torch.Tensor)
+    ):
+        if preserve_module_state is None and not isinstance(tensor, torch.nn.Parameter):
+            _warn_to_module_preserve_module_state(memo)
+        elif preserve_module_state and (
+            not isinstance(tensor, torch.nn.Parameter)
+            or tensor.requires_grad != param.requires_grad
+        ):
+            return torch.nn.Parameter(tensor, requires_grad=param.requires_grad)
+    elif (
+        preserve_module_state
+        and isinstance(tensor, torch.nn.Parameter)
+        and name in getattr(module, "_buffers", {})
+    ):
+        persistent = name not in module._non_persistent_buffers_set
+        return Buffer(tensor, persistent=persistent)
+    return tensor
+
+
 def _set_tensor_dict(  # noqa: F811
     __dict__,
     _parameters,
@@ -5023,14 +5101,18 @@ def _set_tensor_dict(  # noqa: F811
     name: str,
     tensor: torch.Tensor,
     inplace: bool,
+    *,
+    preserve_module_state: bool | None,
+    memo,
 ) -> None:
     """Simplified version of torch.nn.utils._named_member_accessor."""
     was_buffer = False
-    out = _parameters.pop(name, None)  # type: ignore[assignment]
-    if out is None:
-        out = _buffers.pop(name, None)
-        was_buffer = out is not None
-    if out is None:
+    out = _parameters.pop(name, NO_DEFAULT)  # type: ignore[assignment]
+    was_parameter = out is not NO_DEFAULT
+    if out is NO_DEFAULT:
+        out = _buffers.pop(name, NO_DEFAULT)
+        was_buffer = out is not NO_DEFAULT
+    if out is NO_DEFAULT:
         # dynamo doesn't like pop...
         out = __dict__.pop(name)
     if inplace:
@@ -5039,6 +5121,26 @@ def _set_tensor_dict(  # noqa: F811
         out.data.copy_(tensor.data)
         tensor = out
         out = out_tmp
+    elif (
+        preserve_module_state is not False
+        and was_parameter
+        and out is not None
+        and isinstance(tensor, torch.Tensor)
+    ):
+        if preserve_module_state is None and not isinstance(tensor, torch.nn.Parameter):
+            _warn_to_module_preserve_module_state(memo)
+        elif preserve_module_state and (
+            not isinstance(tensor, torch.nn.Parameter)
+            or tensor.requires_grad != out.requires_grad
+        ):
+            tensor = torch.nn.Parameter(tensor, requires_grad=out.requires_grad)
+    elif (
+        preserve_module_state is True
+        and was_buffer
+        and isinstance(tensor, torch.nn.Parameter)
+    ):
+        persistent = name not in module._non_persistent_buffers_set
+        tensor = Buffer(tensor, persistent=persistent)
 
     if isinstance(tensor, torch.nn.Parameter):
         for hook in hooks:

--- a/tensordict/_tensorcollection.pyi
+++ b/tensordict/_tensorcollection.pyi
@@ -566,6 +566,7 @@ class TensorCollection:
         swap_dest: Incomplete | None = None,
         use_state_dict: bool = False,
         non_blocking: bool = False,
+        preserve_module_state: bool | None = None,
         memo: Incomplete | None = None,
     ): ...
     @property

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -3446,6 +3446,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         swap_dest=None,
         use_state_dict: bool = False,
         non_blocking: bool = False,
+        preserve_module_state: bool | None = None,
         memo=None,  # deprecated
     ):
         """Writes the content of a TensorDictBase instance onto a given nn.Module attributes, recursively.
@@ -3469,6 +3470,17 @@ class TensorDictBase(MutableMapping, TensorCollection):
             non_blocking (bool, optional): if ``True`` and this copy is between
                 different devices, the copy may occur asynchronously with respect
                 to the host.
+            preserve_module_state (bool, optional): if ``True``, existing
+                :class:`~torch.nn.Parameter` and buffer registrations are
+                preserved when writing tensor leaves to ``module``: parameters
+                remain parameters with their original ``requires_grad`` value,
+                and buffers remain registered buffers. If ``False``, tensor
+                leaves are written with the historical replacement semantics,
+                which may deregister an existing parameter when the source leaf
+                is not an :class:`~torch.nn.Parameter`. If ``None`` (the
+                v0.13 default), the historical behavior is kept but a
+                ``FutureWarning`` is emitted when a write would deregister a
+                parameter. The default will become ``True`` in v0.14.
 
         Examples:
             >>> from torch import nn
@@ -3477,7 +3489,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
             ...     num_layers=1)
             >>> params = TensorDict.from_module(module)
             >>> params.data.zero_()
-            >>> params.to_module(module)
+            >>> params.to_module(module, preserve_module_state=True)
             >>> assert (module.layers[0].linear1.weight == 0).all()
 
         Using a tensordict as a context manager can be useful to make functional calls:
@@ -3488,7 +3500,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
             ...     num_layers=1)
             >>> params = TensorDict.from_module(module)
             >>> params = params.data * 0 # Use TensorDictParams to remake these tensors regular nn.Parameter instances
-            >>> with params.to_module(module):
+            >>> with params.to_module(module, preserve_module_state=True):
             ...     # Call the module with zeroed params
             ...     y = module(*inputs)
             >>> # The module is repopulated with its original params
@@ -3512,6 +3524,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
             memo=memo,
             use_state_dict=use_state_dict,
             non_blocking=non_blocking,
+            preserve_module_state=preserve_module_state,
         )
 
     @abc.abstractmethod
@@ -3525,6 +3538,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         memo=None,
         use_state_dict: bool = False,
         non_blocking: bool = False,
+        preserve_module_state: bool | None = None,
     ):
         raise NotImplementedError
 

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -773,7 +773,7 @@ class TensorDictModuleBase(nn.Module):
             lambda x: x.detach().requires_grad_(), inplace=False
         )
 
-        with sanitized_parameters.to_module(self):
+        with sanitized_parameters.to_module(self, preserve_module_state=False):
             self._reset_parameters(self)
         return sanitized_parameters
 

--- a/tensordict/nn/ensemble.py
+++ b/tensordict/nn/ensemble.py
@@ -87,7 +87,7 @@ class EnsembleModule(TensorDictModuleBase):
         self.params_td = TensorDictParams(params_td)
 
     def _func_module_call(self, input, params):
-        with params.to_module(self.module):
+        with params.to_module(self.module, preserve_module_state=False):
             return self.module(input)
 
     def forward(self, tensordict: TensorDict) -> TensorDict:

--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -1171,6 +1171,7 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
         memo=None,
         use_state_dict: bool = False,
         non_blocking: bool = False,
+        preserve_module_state: bool | None = None,
     ): ...
 
     @_fallback

--- a/tensordict/tensorclass.pyi
+++ b/tensordict/tensorclass.pyi
@@ -594,6 +594,7 @@ class TensorClass:
         swap_dest: Incomplete | None = None,
         use_state_dict: bool = False,
         non_blocking: bool = False,
+        preserve_module_state: bool | None = None,
         memo: Incomplete | None = None,
     ) -> Self: ...
     @property

--- a/tensordict/typedtensordict.py
+++ b/tensordict/typedtensordict.py
@@ -800,11 +800,20 @@ class TypedTensorDict(TensorDictBase, metaclass=_TypedTensorDictMeta):
     # ------------------------------------------------------------------
     # _to_module
     # ------------------------------------------------------------------
-    def _to_module(self, module, *, inplace=None, return_swap=True, **kwargs):
+    def _to_module(
+        self,
+        module,
+        *,
+        inplace=None,
+        return_swap=True,
+        preserve_module_state: bool | None = None,
+        **kwargs,
+    ):
         return self._source._to_module(
             module,
             inplace=inplace,
             return_swap=return_swap,
+            preserve_module_state=preserve_module_state,
             **kwargs,
         )
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1442,7 +1442,7 @@ class TestFunctional:
         try:
 
             def call(x, td):
-                with td.to_module(module):
+                with td.to_module(module, preserve_module_state=False):
                     return module(x)
 
             call_compile = torch.compile(call, fullgraph=True, mode=mode)
@@ -1488,7 +1488,7 @@ class TestFunctional:
         td_zero.zero_()
 
         def call(x, td):
-            with td.to_module(module):
+            with td.to_module(module, preserve_module_state=False):
                 y = module(x)
             td.clear_refs_for_compile_()
             return y
@@ -1509,7 +1509,7 @@ class TestFunctional:
             assert (td_zero == 0).all()
         # torch.testing.assert_close(call_compile(x, td_zero), module(x))
 
-        td.to_module(module)
+        td.to_module(module, preserve_module_state=False)
         call_compile(x, td_zero)
         assert (call_compile(x, td_zero) == 0).all()
         assert all(
@@ -1539,7 +1539,7 @@ class TestFunctional:
         td_zero = TensorDictParams(td.data.expand(10).clone().zero_())
 
         def call(x, td):
-            with td.to_module(module):
+            with td.to_module(module, preserve_module_state=False):
                 result = module(x)
             return result
 
@@ -1673,7 +1673,7 @@ class TestExport:
                 )
 
             def batch_forward(self, params, x):
-                with params.to_module(self.arch):
+                with params.to_module(self.arch, preserve_module_state=False):
                     return self.arch(x)
                 # This could be an option but dynamo doesn't know how to trace through state_dict ops
                 # sd = self.arch.state_dict()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13,6 +13,7 @@ import pathlib
 import pickle
 import sys
 import unittest
+import warnings
 import weakref
 from collections import OrderedDict
 from collections.abc import MutableSequence
@@ -4330,6 +4331,99 @@ class TestToModule:
     def _x(self):
         return (torch.randn(2, 2, 8),)
 
+    def test_plain_tensor_to_module_warns_for_future_default(self, as_module):
+        module = nn.Linear(4, 2)
+        params = TensorDict.from_module(module, as_module=as_module).data.detach()
+
+        with pytest.warns(FutureWarning, match="preserve_module_state=True"):
+            params.to_module(module)
+
+        assert "weight" not in module.state_dict()
+        assert "bias" not in module.state_dict()
+        assert not isinstance(module.weight, nn.Parameter)
+        assert not isinstance(module.bias, nn.Parameter)
+
+    def test_plain_tensor_to_module_can_preserve_module_state(self, as_module):
+        module = nn.Linear(4, 2)
+        module.weight.requires_grad_(False)
+        params = TensorDict.from_module(module, as_module=as_module).data.detach()
+        state_dict_keys = set(module.state_dict())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            params.to_module(module, preserve_module_state=True)
+
+        assert set(module.state_dict()) == state_dict_keys
+        assert isinstance(module.weight, nn.Parameter)
+        assert isinstance(module.bias, nn.Parameter)
+        assert module.weight.requires_grad is False
+        assert module.bias.requires_grad is True
+        torch.testing.assert_close(module.weight, params["weight"])
+        torch.testing.assert_close(module.bias, params["bias"])
+
+    def test_plain_tensor_to_module_can_keep_current_behavior(self, as_module):
+        module = nn.Linear(4, 2)
+        params = TensorDict.from_module(module, as_module=as_module).data.detach()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            params.to_module(module, preserve_module_state=False)
+
+        assert "weight" not in module.state_dict()
+        assert "bias" not in module.state_dict()
+        assert not isinstance(module.weight, nn.Parameter)
+        assert not isinstance(module.bias, nn.Parameter)
+
+    def test_plain_tensor_to_module_inplace_preserves_module_state(self, as_module):
+        module = nn.Linear(4, 2)
+        params = TensorDict.from_module(module, as_module=as_module).data.detach()
+        params.zero_()
+        state_dict_keys = set(module.state_dict())
+        weight = module.weight
+        bias = module.bias
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            params.to_module(module, inplace=True)
+
+        assert set(module.state_dict()) == state_dict_keys
+        assert module.weight is weight
+        assert module.bias is bias
+        assert (module.weight == 0).all()
+        assert (module.bias == 0).all()
+
+    def test_preserve_module_state_with_custom_setattr(self, as_module):
+        class MyLinear(nn.Linear):
+            def __setattr__(self, key, value):
+                return super().__setattr__(key, value)
+
+        module = MyLinear(4, 2)
+        params = TensorDict.from_module(module, as_module=as_module).data.detach()
+        state_dict_keys = set(module.state_dict())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            params.to_module(module, preserve_module_state=True)
+
+        assert set(module.state_dict()) == state_dict_keys
+        assert isinstance(module.weight, nn.Parameter)
+        assert isinstance(module.bias, nn.Parameter)
+
+    def test_preserve_module_state_keeps_buffers(self, as_module):
+        module = nn.Module()
+        module.register_buffer("buffer", torch.ones(3))
+        params = TensorDict({"buffer": nn.Parameter(torch.zeros(3))}, [])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            params.to_module(module, preserve_module_state=True)
+
+        assert "buffer" in module.state_dict()
+        assert "buffer" in dict(module.named_buffers())
+        assert "buffer" not in dict(module.named_parameters())
+        assert not isinstance(module.buffer, nn.Parameter)
+        torch.testing.assert_close(module.buffer, torch.zeros(3))
+
     @pytest.mark.parametrize(
         "module_name,input_name",
         [["_module_shared", "_x"], ["_transformer", "_tuple_x"]],
@@ -4344,7 +4438,7 @@ class TestToModule:
             params = params.clone()
         params0 = params.clone().zero_()
         y = module(*x)
-        params0.to_module(module, inplace=inplace)
+        params0.to_module(module, inplace=inplace, preserve_module_state=False)
         y0 = module(*x)
         # check identities
         for k, p1, p2 in zip(
@@ -4356,7 +4450,7 @@ class TestToModule:
                 assert p1 is not p2, k
             else:
                 assert p1 is p2, k
-        params.to_module(module, inplace=inplace)
+        params.to_module(module, inplace=inplace, preserve_module_state=False)
         # check identities
         for p1, p2 in zip(
             TensorDict.from_module(module).values(True, True),
@@ -4383,7 +4477,7 @@ class TestToModule:
         params = TensorDict.from_module(module, as_module=as_module)
         params0 = params.clone().zero_()
         y = module(*x)
-        with params0.to_module(module, inplace=inplace):
+        with params0.to_module(module, inplace=inplace, preserve_module_state=False):
             y0 = module(*x)
             if as_module:
                 # if as_module=False, params0 is not made of parameters anymore
@@ -4416,10 +4510,10 @@ class TestToModule:
         params = TensorDict.from_module(module, as_module=as_module)
         params_meta = params.detach().to("meta")
         y = module(*x)
-        with params_meta.to_module(module):
+        with params_meta.to_module(module, preserve_module_state=False):
             module_meta = copy.deepcopy(module)
         y1 = module(*x)
-        with params.to_module(module_meta):
+        with params.to_module(module_meta, preserve_module_state=False):
             y2 = module_meta(*x)
         torch.testing.assert_close(y, y1)
         torch.testing.assert_close(y, y2)
@@ -4433,7 +4527,7 @@ class TestToModule:
         linear = MyLinear(3, 4)
         params = TensorDict.from_module(linear, as_module=as_module)
         # this will break if the parameters are not deleted before being set
-        with params.detach().to_module(linear):
+        with params.detach().to_module(linear, preserve_module_state=False):
             linear(torch.randn(3))
         assert len(list(linear.parameters())) == 2
         assert (TensorDict.from_module(linear) == params).all()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1423,7 +1423,7 @@ class TestGeneric:
         )
 
         def exec_module(params, x):
-            with params.to_module(empty_module):
+            with params.to_module(empty_module, preserve_module_state=False):
                 return empty_module(x)
 
         x = torch.zeros(3)
@@ -1471,7 +1471,7 @@ class TestGeneric:
         )
 
         def exec_module(params, x):
-            with params.to_module(empty_module):
+            with params.to_module(empty_module, preserve_module_state=False):
                 return empty_module(x)
 
         x = torch.zeros(3)
@@ -1508,7 +1508,7 @@ class TestGeneric:
         optim = torch.optim.Adam(list(params.values(True, True)))
 
         def exec_module(params, x):
-            with params.to_module(empty_module):
+            with params.to_module(empty_module, preserve_module_state=False):
                 return empty_module(x)
 
         x = torch.zeros(3, device=device)
@@ -14221,7 +14221,7 @@ class TestFCD(TestTensorDictsBase):
             td = td.expand(param_batch).clone()
             d0 = ftdim.dims(1)
             td = TensorDictParams(td)[d0]
-            td.to_module(module)
+            td.to_module(module, preserve_module_state=False)
             y = module(*make_input())
             assert y.dims == (d0,)
             assert y._tensor.shape[0] == param_batch


### PR DESCRIPTION
## Summary
- add `preserve_module_state` to `TensorDict.to_module` with the 0.13 transition behavior: warn on unsafe plain-tensor replacement by default, allow explicit legacy behavior, and opt into the 0.14 state-preserving behavior now
- preserve destination parameter/buffer registrations in the opt-in path, including parameter `requires_grad` and registered buffers
- avoid extra hot-path overhead by using a sentinel pop in the fast module-write path and short-circuiting custom setattr cases where no preservation work is needed
- make legacy functional tests pass `preserve_module_state=False` explicitly and add coverage for warnings, opt-in preservation, explicit legacy behavior, in-place syncs, custom `__setattr__`, and buffers
- extend `benchmarks/nn/functional_benchmarks_test.py` with plain-tensor `to_module` variants for default, explicit legacy, and state-preserving modes

Fixes #1719

## Tests
- `.venv/bin/python -m pytest test/test_nn.py::TestToModule -q`
- `.venv/bin/python -m pytest test/test_tensordict.py::TestGeneric::test_from_modules test/test_tensordict.py::TestGeneric::test_from_modules_expand test/test_tensordict.py::TestGeneric::test_from_modules_lazy test/test_tensordict.py::TestGeneric::test_to_module_state_dict test/test_tensordict.py::TestFCD::test_modules -q`
- `.venv/bin/python -m pytest test/test_compile.py::TestFunctional::test_functional_error test/test_compile.py::TestFunctional::test_functional test/test_compile.py::TestFunctional::test_vmap_functional test/test_compile.py::TestExport::test_export_with_td_params -q`
- `.venv/bin/python -m pytest benchmarks/nn/functional_benchmarks_test.py::test_to_module_speed benchmarks/nn/functional_benchmarks_test.py::test_to_module_plain_tensor_speed --benchmark-only --benchmark-disable-gc -q`
- `.venv/bin/pre-commit run --files tensordict/_td.py benchmarks/nn/functional_benchmarks_test.py`
- `.venv/bin/pre-commit run --files tensordict/_td.py tensordict/_tensorcollection.pyi tensordict/base.py tensordict/nn/params.py tensordict/tensorclass.pyi tensordict/typedtensordict.py test/test_compile.py test/test_nn.py test/test_tensordict.py`