### PR TITLE
[Doc] Refresh TensorDict README for 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,161 +14,213 @@
 
 # TensorDict
 
-TensorDict is a dictionary-like class that inherits properties from tensors,
-such as indexing, shape operations, casting to device or storage and many more.
-The code-base consists of two main components: [`TensorDict`](https://docs.pytorch.org/tensordict/stable/reference/generated/tensordict.TensorDict.html),
-a specialized dictionary for PyTorch tensors, and [`tensorclass`](https://docs.pytorch.org/tensordict/stable/reference/generated/tensordict.tensorclass.html),
-a dataclass for tensors.
+**TensorDict is a batched, nested `dict[str, Tensor]` that behaves like a tensor.**
 
-```python
-from tensordict import TensorDict
+Move it, slice it, reshape it, stack it, save it, compile it, or do arithmetic on
+it: every tensor leaf follows the same operation, and one shared `batch_size`
+keeps the structure honest.
 
-data = TensorDict(
-    obs=torch.randn(128, 84),
-    action=torch.randn(128, 4),
-    reward=torch.randn(128, 1),
-    batch_size=[128],
-)
-
-data_gpu = data.to("cuda")      # all tensors move together
-sub = data_gpu[:64]              # all tensors are sliced
-stacked = torch.stack([data, data])  # works like a tensor
+```text
+TensorDict(batch_size=[32])
+|-- obs:      Tensor[32, 128]
+|-- action:   Tensor[32]
+|-- reward:   Tensor[32]
+`-- next:
+    `-- obs:  Tensor[32, 128]
 ```
 
-[**Key Features**](#key-features) |
-[**Examples**](#examples) |
+[**30-second demo**](#30-second-demo) |
+[**Why TensorDict**](#why-tensordict) |
+[**What is new in 0.13**](#what-is-new-in-013) |
+[**Patterns**](#patterns) |
 [**Installation**](#installation) |
 [**Ecosystem**](#ecosystem) |
-[**Citation**](#citation) |
-[**License**](#license)
+[**Citation**](#citation)
 
-## Key Features
-
-TensorDict makes your code-bases more _readable_, _compact_, _modular_ and _fast_.
-It abstracts away tailored operations, dispatching them on the leaves for you.
-
-- **Composability**: `TensorDict` generalizes `torch.Tensor` operations to collections of tensors.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_shapes.html)
-- **Speed**: asynchronous transfer to device, fast node-to-node communication through `consolidate`, compatible with `torch.compile`.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_memory.html)
-- **Shape operations**: indexing, slicing, concatenation, reshaping -- everything you can do with a tensor.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_slicing.html)
-- **Distributed / multiprocessed**: distribute TensorDict instances across workers, devices and machines.
-  [[doc]](https://docs.pytorch.org/tensordict/stable/distributed.html)
-- **Serialization** and memory-mapping for efficient checkpointing.
-  [[doc]](https://docs.pytorch.org/tensordict/stable/saving.html)
-- **Functional programming** and compatibility with `torch.vmap`.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/functional.html)
-- **Nesting**: nest TensorDict instances to create hierarchical structures.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_keys.html)
-- **Lazy preallocation**: preallocate memory without initializing tensors.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_preallocation.html)
-- **`@tensorclass`**: a specialized dataclass for `torch.Tensor`.
-  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensorclass_fashion.html)
-
-## Examples
-
-Check our [**Getting Started**](GETTING_STARTED.md) guide for a full overview of TensorDict's features.
-
-### Before / after
-
-Working with groups of tensors is common in ML. Without a shared structure,
-every operation must be repeated for each tensor:
+## 30-second demo
 
 ```python
-# Without TensorDict
-obs = obs.to("cuda")
-action = action.to("cuda")
-reward = reward.to("cuda")
-next_obs = next_obs.to("cuda")
+import torch
+from tensordict import TensorDict
 
-obs_batch = obs[:32]
-action_batch = action[:32]
-reward_batch = reward[:32]
-next_obs_batch = next_obs[:32]
+batch = TensorDict(
+    {
+        "obs": torch.randn(32, 128),
+        "action": torch.randint(0, 4, (32,)),
+        "reward": torch.randn(32),
+        "next": {"obs": torch.randn(32, 128)},
+    },
+    batch_size=[32],
+)
+
+mini = batch[:8]                 # slices every leaf
+device = "cuda" if torch.cuda.is_available() else "cpu"
+on_device = batch.to(device)       # moves every leaf; non-blocking internally
+scaled = batch * 0.5             # arithmetic on the whole structure
+merged = batch + batch           # leaf-wise TensorDict arithmetic
+stacked = torch.stack([batch, batch], 0)
+
+print(mini.shape)                # torch.Size([8])
+print(stacked.shape)             # torch.Size([2, 32])
 ```
 
-With TensorDict, all of that collapses to:
+The object remains a mapping, but the batch acts like a tensor. That is the
+point: write the operation once, apply it to every tensor that belongs to the
+same example, rollout, batch, parameter set, or dataset shard.
+
+## Why TensorDict
+
+Plain dictionaries are flexible. TensorDict keeps that flexibility and adds the
+parts tensor programs need once the code gets serious.
+
+| With a plain `dict` | With `TensorDict` |
+|---------------------|-------------------|
+| Manually keep leading dimensions aligned | One `batch_size` validates the structure |
+| Repeat `.to(device)` for every tensor | `td.to(device)` moves the full batch |
+| Hand-roll slicing, stacking, reshaping | `td[:32]`, `torch.stack`, `td.reshape` |
+| Manually recurse through nested state | Nested keys are first-class |
+| Duplicate arithmetic over leaves | `td + td`, `td * scalar`, `td.abs()` |
+| Invent checkpoint formats | `td.save`, `td.memmap`, `load_memmap` |
+| Hope generic code keeps working | PyTorch-native APIs, `torch.compile` coverage |
+
+Use TensorDict when the unit of data is not one tensor anymore, but it should
+still move through your program like one tensor.
+
+## Performance is part of the API
+
+TensorDict is not just syntax for recursive Python loops. Core paths are built
+for high-throughput PyTorch workloads:
+
+- **Arithmetic dispatch**: operations such as `td + td`, `td * 0.5`, `td.abs()`
+  and in-place variants apply directly to leaves and use PyTorch foreach kernels
+  where available.
+- **Device and host transfers**: D2H and H2D copies are dispatched across the
+  full structure. TensorDict uses non-blocking leaf transfers internally when
+  possible, so the common path is just `td.to(device)`; pass
+  `non_blocking=False` only when you need an explicitly synchronous transfer.
+- **Shape operations without boilerplate**: indexing, `view`, `reshape`,
+  `permute`, `unsqueeze`, `squeeze`, `flatten`, `unflatten`, `stack` and `cat`
+  operate on the batch structure rather than on hand-maintained lists of leaves.
+- **Low-allocation workflows**: lazy stacks, preallocation, memory mapping and
+  `inplace=True` shape-changing operations help reduce peak memory in data-heavy
+  pipelines.
+- **Compile-aware internals**: TensorDict is used in compiled training and RL
+  loops, and the codebase carries dedicated `torch.compile` coverage for hot
+  paths.
+
+For deeper numbers, see the [benchmark notes][#docs-package-benchmark].
+
+## What is new in 0.13
+
+TensorDict 0.13 focuses on making structured tensor programs more practical in
+large training systems:
+
+- **Tabular import/export** for pandas, CSV, Parquet and JSON workflows.
+- **More `inplace=True` shape operations**, including `gather`, `repeat`,
+  `repeat_interleave`, `roll`, `reshape`, `flatten`, `unflatten` and
+  `contiguous`.
+- **Improved `torch.compile` behavior** for TensorClass initialization,
+  dynamic-shape export, locking paths and shallow clones.
+- **Safer memmap filenames by default** through robust key encoding.
+- **A migration path for module state preservation** with
+  `to_module(..., preserve_module_state=...)`.
+- **CPU-only release wheels** for TensorDict, avoiding duplicate GPU wheel
+  artifacts for a package whose compiled extension is device-independent.
+
+## Patterns
+
+### One batch through the whole training step
+
+TensorDict lets datasets, models and losses agree on one container instead of a
+long argument list.
 
 ```python
-# With TensorDict
-data = data.to("cuda")
-data_batch = data[:32]
-```
+for batch in dataloader:
+    batch = batch.to(device)
+    batch = model(batch)
+    loss = loss_module(batch)
 
-This holds for any operation: `reshape`, `unsqueeze`, `permute`, `to`, indexing,
-`torch.stack`, `torch.cat`, and many more.
-
-### Generic training loops
-
-Using TensorDict primitives, most supervised training loops can be rewritten
-in a generic way:
-
-```python
-for i, data in enumerate(dataset):
-    data = model(data)
-    loss = loss_module(data)
     loss.backward()
     optimizer.step()
     optimizer.zero_grad()
 ```
 
-Each step of the training loop -- data loading, model prediction, loss
-computation -- can be swapped independently without touching the rest.
-The same loop works across classification, segmentation, RL, and more.
+That loop can stay stable while the schema changes from classification to
+segmentation, RL rollouts, model-based prediction or LLM post-training batches.
 
-### Fast copy on device
-
-By default, device transfers are asynchronous and synchronized only when needed:
+### Nested data without custom plumbing
 
 ```python
-td_cuda = TensorDict(**dict_of_tensors, device="cuda")
-td_cpu = td_cuda.to("cpu")
-td_cpu = td_cuda.to("cpu", non_blocking=False)  # force synchronous
+td = TensorDict(
+    {
+        "agents": {
+            "policy": torch.randn(64, 8),
+            "value": torch.randn(64, 1),
+        },
+        "env": {
+            "reward": torch.randn(64),
+            "done": torch.zeros(64, dtype=torch.bool),
+        },
+    },
+    batch_size=[64],
+)
+
+policy = td["agents", "policy"]
+td["env", "reward"] = td["env", "reward"].clip(-1, 1)
 ```
 
-### Coding an optimizer
+Nested keys are part of the API, not an afterthought.
 
-Using TensorDict you can code the Adam optimizer as you would for a single
-tensor and apply it to a collection of parameters. On CUDA, these operations
-use fused kernels:
+### Functional modules and parameter sets
+
+TensorDict can hold module parameters, swap them into modules, vectorize over
+ensembles and make model state explicit.
 
 ```python
-class Adam:
-    def __init__(self, weights: TensorDict, alpha: float=1e-3,
-                 beta1: float=0.9, beta2: float=0.999,
-                 eps: float = 1e-6):
-        weights = weights.lock_()
-        self.weights = weights
-        self.t = 0
+from tensordict import TensorDict
 
-        self._mu = weights.data.clone()
-        self._sigma = weights.data.mul(0.0)
-        self.beta1 = beta1
-        self.beta2 = beta2
-        self.alpha = alpha
-        self.eps = eps
+params = TensorDict.from_module(module)
 
-    def step(self):
-        self._mu.mul_(self.beta1).add_(self.weights.grad, 1 - self.beta1)
-        self._sigma.mul_(self.beta2).add_(self.weights.grad.pow(2), 1 - self.beta2)
-        self.t += 1
-        mu = self._mu.div_(1-self.beta1**self.t)
-        sigma = self._sigma.div_(1 - self.beta2 ** self.t)
-        self.weights.data.add_(mu.div_(sigma.sqrt_().add_(self.eps)).mul_(-self.alpha))
+with params.to_module(module, preserve_module_state=True):
+    out = module(inputs)
 ```
 
-## Ecosystem
+This is the same foundation used by TorchRL modules and functional training
+utilities.
 
-TensorDict is used across a range of domains:
+### Checkpoint and share large tensor batches
 
-| Domain | Projects |
-|--------|----------|
-| **Reinforcement Learning** | [TorchRL](https://github.com/pytorch/rl) (PyTorch), [DreamerV3-torch](https://github.com/NM512/dreamerv3-torch), [Dreamer4](https://github.com/nicklashansen/dreamer4), [SkyRL](https://github.com/NovaSky-AI/SkyRL) |
-| **LLM Post-Training** | [verl](https://github.com/verl-project/verl), [ROLL](https://github.com/alibaba/ROLL) (Alibaba), [LMFlow](https://github.com/OptimalScale/LMFlow), [LoongFlow](https://github.com/baidu-baige/LoongFlow) (Baidu) |
-| **Robotics & Simulation** | [MuJoCo Playground](https://github.com/google-deepmind/mujoco_playground) (Google DeepMind), [ProtoMotions](https://github.com/NVlabs/ProtoMotions) (NVIDIA), [holosoma](https://github.com/amazon-far/holosoma) (Amazon) |
-| **Physics & Scientific ML** | [PhysicsNeMo](https://github.com/NVIDIA/physicsnemo) (NVIDIA) |
-| **Genomics** | [Medaka](https://github.com/nanoporetech/medaka) (Oxford Nanopore) |
+```python
+td = TensorDict({"tokens": tokens, "scores": scores}, batch_size=[n])
+td.memmap("/tmp/batch")          # memory-map every leaf
+reloaded = TensorDict.load_memmap("/tmp/batch")
+```
+
+Memory-mapped TensorDicts are useful for large offline datasets, replay buffers,
+inter-process handoff and checkpointed intermediate state.
+
+## Key features
+
+- **Tensor-like collection ops**: indexing, slicing, device casting, dtype
+  casting, reshaping, stacking and concatenation.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_shapes.html)
+- **Nested structures** with tuple keys and predictable batch semantics.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_keys.html)
+- **Fast memory workflows**: asynchronous transfers, memmap, consolidated
+  tensors, lazy stacks and preallocation.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensordict_memory.html)
+- **Functional programming** with parameter TensorDicts, `to_module` and
+  compatibility with `torch.vmap`.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/functional.html)
+- **`@tensorclass`**: a tensor-aware dataclass for structured tensor objects.
+  [[tutorial]](https://docs.pytorch.org/tensordict/stable/tutorials/tensorclass_fashion.html)
+- **Distributed and multiprocessed pipelines** across workers, devices and
+  machines. [[doc]](https://docs.pytorch.org/tensordict/stable/distributed.html)
+- **Serialization and memory mapping** for efficient checkpointing and dataset
+  storage. [[doc]](https://docs.pytorch.org/tensordict/stable/saving.html)
+
+For a longer tour, start with [GETTING_STARTED.md](GETTING_STARTED.md) or the
+[online documentation][#docs-package].
 
 ## Installation
 
@@ -178,37 +230,53 @@ TensorDict is used across a range of domains:
 pip install tensordict
 ```
 
-For the latest features:
-
-```bash
-pip install tensordict-nightly
-```
-
 **With conda**:
 
 ```bash
 conda install -c conda-forge tensordict
 ```
 
-**With uv + PyTorch nightlies**:
+**Nightly builds**:
 
-If you're using a PyTorch nightly, install tensordict with `--no-deps` to prevent
-uv from re-resolving `torch` from PyPI:
+```bash
+pip install tensordict-nightly
+```
+
+**From source with an existing PyTorch install**:
+
+```bash
+pip install -e . --no-deps
+```
+
+If you use `uv` with PyTorch nightlies, keep `torch` pinned to the PyTorch wheel
+index or install TensorDict with `--no-deps` so the resolver does not replace
+your existing PyTorch build:
 
 ```bash
 uv pip install -e . --no-deps
-```
-
-Or explicitly point uv at the PyTorch nightly wheel index:
-
-```bash
 uv pip install -e . --prerelease=allow -f "https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html"
 ```
 
+## Ecosystem
+
+TensorDict started in reinforcement learning, where batches quickly become
+nested trajectories. It is now used anywhere tensor batches are structured data:
+RL rollouts, LLM post-training samples, robotics trajectories, simulation state,
+model parameters, checkpointed datasets and scientific pipelines.
+
+| Domain | Projects |
+|--------|----------|
+| **Reinforcement Learning** | [TorchRL](https://github.com/pytorch/rl) (PyTorch), [DreamerV3-torch](https://github.com/NM512/dreamerv3-torch), [Dreamer4](https://github.com/nicklashansen/dreamer4), [SkyRL](https://github.com/NovaSky-AI/SkyRL) |
+| **LLM Post-Training** | [verl](https://github.com/verl-project/verl), [ROLL](https://github.com/alibaba/ROLL) (Alibaba), [LMFlow](https://github.com/OptimalScale/LMFlow), [LoongFlow](https://github.com/baidu-baige/LoongFlow) (Baidu) |
+| **Robotics and Simulation** | [MuJoCo Playground](https://github.com/google-deepmind/mujoco_playground) (Google DeepMind), [ProtoMotions](https://github.com/NVlabs/ProtoMotions) (NVIDIA), [holosoma](https://github.com/amazon-far/holosoma) (Amazon) |
+| **Physics and Scientific ML** | [PhysicsNeMo](https://github.com/NVIDIA/physicsnemo) (NVIDIA) |
+| **Genomics** | [Medaka](https://github.com/nanoporetech/medaka) (Oxford Nanopore) |
+
 ## Citation
 
-If you're using TensorDict, please refer to this BibTeX entry to cite this work:
-```
+If you use TensorDict, please cite the TorchRL paper:
+
+```bibtex
 @misc{bou2023torchrl,
       title={TorchRL: A data-driven decision-making library for PyTorch},
       author={Albert Bou and Matteo Bettini and Sebastian Dittert and Vikash Kumar and Shagun Sodhani and Xiaomeng Yang and Gianni De Fabritiis and Vincent Moens},


### PR DESCRIPTION
## Description

Refreshes the README ahead of the 0.13 release with a more direct pitch and a faster path to understanding what TensorDict does.

Highlights:
- lead with TensorDict as a batched, nested `dict[str, Tensor]` that behaves like a tensor;
- add a short copy-pastable demo covering slicing, device transfer, arithmetic, and stacking;
- explain why TensorDict is preferable to a plain dict for structured tensor batches;
- call out performance-sensitive paths such as TensorDict arithmetic, D2H/H2D transfer, foreach-backed operations, low-allocation workflows, and compile-aware internals;
- add a concise 0.13 teaser covering tabular import/export, broader `inplace=True` shape ops, compile fixes, robust memmap keys, and `to_module(..., preserve_module_state=...)`.

## Checks

- `git diff --check`
- README internal/ref link sanity script
- README code fence balance script
- Demo execution skipped locally because `torch` is not installed in the active Python environment