### PR TITLE
[BugFix] Preserve tensorclass identity in memmap_/load_memmap for TensorClass subclasses

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -325,7 +325,10 @@ _FALLBACK_METHOD_FROM_TD = [
     "_grad",
     "_map",
     "_maybe_remove_batch_dim",
-    "_memmap_",
+    # "_memmap_" must NOT be listed here: tensorclasses need the dedicated
+    # _memmap_ (which records the class in meta.json) rather than the
+    # TD-delegating fallback, otherwise the class identity is lost on
+    # load_memmap. See _patch_tc and the explicit assignments below.
     "_permute",
     "_remove_batch_dim",
     "_repeat",
@@ -1171,6 +1174,27 @@ def _tensorclass(cls: T, *, frozen, shadow: bool, tensor_only: bool) -> T:
             continue
         func = getattr(TensorDict, attr)
         if inspect.ismethod(func) and attr not in cls.__dict__:
+            # A genuine classmethod implementation inherited from a
+            # tensorclass base (e.g. TensorClass._load_memmap) rebinds `cls`
+            # on access and must not be shadowed by the TensorDict
+            # classmethod: shadowing _load_memmap with TensorDict._load_memmap
+            # used to break load_memmap for TensorClass subclasses (an empty
+            # instance was returned because the tensorclass directory layout
+            # was read as a plain TensorDict one). Everything else inherited
+            # from a base -- _wrap_td_method/_wrap_classmethod wrappers and
+            # methods bound to the parent class (e.g. from_list, stack on the
+            # TensorClass base) -- hardcodes the wrong class or the wrong
+            # calling convention and must be re-wrapped for cls as before.
+            inherited = next(
+                (
+                    base.__dict__[attr]
+                    for base in cls.__mro__[1:]
+                    if attr in base.__dict__
+                ),
+                None,
+            )
+            if isinstance(inherited, (classmethod, staticmethod)):
+                continue
             tdcls = func.__self__
             if issubclass(tdcls, TensorDictBase):  # detects classmethods
                 setattr(cls, attr, _wrap_classmethod(tdcls, cls, func))

--- a/test/test_tensorclass.py
+++ b/test/test_tensorclass.py
@@ -2207,6 +2207,27 @@ class TestTensorClass:
         assert isinstance(stacked_tc._tensordict.get("custom_data"), MetaData[str])
         assert stacked_tc.custom_data == "abc"
 
+    def test_td_classmethods_return_subclass(self):
+        # TensorDict classmethods exposed on TensorClass subclasses must
+        # accept the classmethod calling convention and return the subclass
+        # (they are re-wrapped per subclass; the instance-method fallbacks
+        # inherited from the TensorClass base would bind the first argument
+        # to self and crash).
+        class MC(TensorClass):
+            foo: Any
+            bar: Any
+
+        class MCChild(MC):
+            pass
+
+        out = MC.from_list([{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}])
+        assert type(out) is MC
+        assert type(MCChild.from_list([{"foo": 1, "bar": 2}])) is MCChild
+        assert type(MC.fromkeys(["foo", "bar"], 0)) is MC
+        mc = MC(foo=torch.zeros(3), bar=torch.ones(3), batch_size=[3])
+        for name in ("stack", "cat", "lazy_stack", "maybe_dense_stack"):
+            assert type(getattr(MC, name)([mc, mc])) is MC, name
+
     def test_to_lazystack(self):
         class MyTensorClass(TensorClass):
             foo: Tensor
@@ -2668,6 +2689,65 @@ class TestMemmap:
         assert isinstance(c.x, MemoryMappedTensor)
         assert isinstance(c.y.x, MemoryMappedTensor)
         assert c.z == "foo"
+
+    def test_memmap_nested_tensorclass_roundtrip(self, tmpdir):
+        # A tensorclass nested (at depth >= 2) inside a plain TensorDict must
+        # come back from a memmap_ / load_memmap roundtrip with its class
+        # identity intact -- for both the decorator and the TensorClass
+        # subclass flavors.
+        @tensorclass
+        class MyDecorated:
+            a: torch.Tensor
+            b: torch.Tensor
+
+        class MySubclassed(TensorClass["nocast"]):
+            a: torch.Tensor
+            meta: str | None = None
+
+        decorated = MyDecorated(a=torch.zeros(5), b=torch.ones(5), batch_size=[5])
+        subclassed = MySubclassed(
+            a=torch.arange(5, dtype=torch.float), meta="hello", batch_size=[5]
+        )
+        td = TensorDict(
+            {
+                "obs": {
+                    "decorated": decorated,
+                    "deep": {"subclassed": subclassed},
+                },
+                "x": torch.zeros(5),
+            },
+            batch_size=[5],
+        )
+        td.memmap_(tmpdir)
+        loaded = TensorDict.load_memmap(tmpdir)
+        assert isinstance(loaded["obs", "decorated"], MyDecorated)
+        assert isinstance(loaded["obs", "deep", "subclassed"], MySubclassed)
+        assert (loaded["obs", "decorated"].a == 0).all()
+        assert (loaded["obs", "decorated"].b == 1).all()
+        assert (
+            loaded["obs", "deep", "subclassed"].a == torch.arange(5, dtype=torch.float)
+        ).all()
+        assert loaded["obs", "deep", "subclassed"].meta == "hello"
+
+    def test_memmap_tensorclass_subclass_roundtrip(self, tmpdir):
+        # A top-level TensorClass subclass must also keep its identity, both
+        # through the generic TensorDict.load_memmap entry point and through
+        # cls.load_memmap (TensorClass subclasses used to delegate _memmap_ /
+        # _load_memmap to TensorDict, dropping the class information).
+        class MySubclassed(TensorClass["nocast"]):
+            a: torch.Tensor
+            meta: str | None = None
+
+        data = MySubclassed(a=torch.zeros(3), meta="hello", batch_size=[3])
+        data.memmap_(tmpdir)
+        loaded = TensorDict.load_memmap(tmpdir)
+        assert isinstance(loaded, MySubclassed)
+        assert (loaded.a == 0).all()
+        assert loaded.meta == "hello"
+        loaded = MySubclassed.load_memmap(tmpdir)
+        assert isinstance(loaded, MySubclassed)
+        assert (loaded.a == 0).all()
+        assert loaded.meta == "hello"
 
     def test_memmap_like(self):
         @tensorclass


### PR DESCRIPTION
## Description

A tensorclass written with the subclass syntax (`class Foo(TensorClass["nocast"])`) did not survive a `memmap_` / `load_memmap` roundtrip: it came back as a plain `TensorDict` holding the tensorclass fields, losing the class identity. This affected both top-level and nested instances. Decorator-based tensorclasses (`@tensorclass`) were unaffected at the top level, but their subclasses (`@tensorclass class Child(Parent)`) hit the same problem on load.

```python
import tempfile, torch
from tensordict import TensorDict, TensorClass

class Foo(TensorClass["nocast"]):
    a: torch.Tensor
    meta: str | None = None

foo = Foo(a=torch.zeros(5), meta="hello", batch_size=[5])
td = TensorDict({"obs": {"foo": foo}}, batch_size=[5])
with tempfile.TemporaryDirectory() as tmp:
    td.memmap_(tmp)
    back = TensorDict.load_memmap(tmp)
    print(type(back["obs", "foo"]))  # was: TensorDict -- now: Foo
```

## Root cause

Two wiring bugs in `tensordict/tensorclass.py`:

1. **Save side**: `"_memmap_"` was listed in `_FALLBACK_METHOD_FROM_TD` (added in the bulk registration of #1153). In `_patch_tc`, the fallback loop runs after the explicit `cls._memmap_ = _memmap_` assignment and overwrote it with a wrapper delegating to `self._tensordict._memmap_(...)`. The node was therefore saved as a plain TensorDict (flat fields, `_type: TensorDict`, no `_tensordict/` subdirectory), so `load_memmap` had nothing to dispatch on. The dedicated tensorclass `_memmap_`, which records the class in `meta.json`, is now preserved.

2. **Load side**: the classmethod-wrapping loop in `_tensorclass` only checked `cls.__dict__` when deciding whether a TensorDict classmethod was "missing". For `TensorClass` subclasses, the genuine `_load_memmap` classmethod is inherited from the `TensorClass` base, so the loop shadowed it with `TensorDict._load_memmap`, which silently returns an empty instance on the tensorclass directory layout. The loop now skips attributes already provided by an ancestor, unless they are `_wrap_classmethod` wrappers, which hardcode the parent class and must be re-wrapped per subclass so that e.g. `Child.from_json(...)` still returns a `Child`. (The `NonTensorData` classes had been dodging this bug only by re-assigning `_load_memmap = classmethod(_load_memmap)` in their class bodies.)

## Backward compatibility

Directories saved with the old (buggy) flat layout still load without error, degrading to a plain `TensorDict` exactly as before.

## Tests

Two tests added to `TestMemmap` in `test/test_tensorclass.py`:

- `test_memmap_nested_tensorclass_roundtrip`: both tensorclass flavors nested at depth >= 2 inside a plain TensorDict, including a non-tensor field, checking class identity and values.
- `test_memmap_tensorclass_subclass_roundtrip`: top-level `TensorClass` subclass through both `TensorDict.load_memmap` and `cls.load_memmap`.

Also verified: non-inplace `memmap()`, `memmap_(num_threads=4)`, `memmap_like()`, decorator-subclass roundtrips, and the existing suites (`test_tensorclass.py`, `test_memmap.py`, `test_td_memmap_split.py`, `test_compatibility.py`, `test_typedtensordict.py`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)