### PR TITLE
[CI] Pin MACOSX_DEPLOYMENT_TARGET for nightly macOS wheels

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -60,6 +60,12 @@ jobs:
           python3 -c """import sys;print(sys.version)"""
           python3 -mpip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/${{ matrix.cuda_support[1] }}
       - name: Build tensordict Nightly
+        env:
+          # Tag macOS wheels for macOS >= 11 instead of the runner's OS
+          # version: macos-latest runners produce macosx_15_0 wheels that
+          # cannot be installed on older machines, and no sdist is published
+          # as fallback.
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
         run: |
           rm -r dist || true
           export PATH="/opt/python/${{ matrix.python_version[1] }}/bin:$PATH"


### PR DESCRIPTION
## Description

The nightly macOS wheels are built on `macos-latest` runners without `MACOSX_DEPLOYMENT_TARGET`, so the wheel tag inherits the runner's OS version: tensordict-nightly 2026.6.11 ships only `macosx_15_0_universal2` wheels, and no sdist is published as a fallback. The result is that nightlies cannot be installed on macOS 14 or older (torchrl-nightly, by contrast, tags `macosx_10_13_universal2`).

This pins `MACOSX_DEPLOYMENT_TARGET=11.0` (the arm64 floor, matching the universal2 tag) on the nightly build step so wheels install on any Apple-silicon-capable macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)