### PR TITLE
[BugFix] Preserve NonTensor entries in pad; fix NonTensorStack boolean-mask indexing

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -89,7 +89,6 @@ from tensordict.utils import (
 from torch import Tensor
 from torch.nn.utils.rnn import pad_sequence
 
-
 try:
     from functorch import dim as ftdim
 
@@ -853,10 +852,25 @@ class LazyStackedTensorDict(TensorDictBase):
             cursor_incr = 1
             # if idx is None:
             #     idx = True
+            if (
+                isinstance(idx, torch.Tensor)
+                and idx.ndim == 0
+                and idx.dtype == torch.bool
+            ):
+                # A scalar boolean behaves like a new axis (numpy semantics),
+                # not like a scalar integer index: don't let it fall through
+                # to the _is_number paths below.
+                idx = bool(idx)
             if idx is None or idx is True:
                 out.append(None)
                 num_none += cursor <= self.stack_dim
                 continue
+            if idx is False:
+                raise NotImplementedError(
+                    "Indexing a LazyStackedTensorDict with a scalar False mask "
+                    "inside a tuple index is not supported. Use a length-1 "
+                    "boolean mask on an unsqueezed tensordict instead."
+                )
             if cursor == self.stack_dim:
                 # we need to check which tds need to be indexed
                 if isinstance(idx, ftdim.Dim):
@@ -1012,6 +1026,34 @@ class LazyStackedTensorDict(TensorDictBase):
             "num_none": num_none,
             "num_squash": num_squash,
         }
+
+    def _empty_getitem_result(self, index: IndexType, stack_dim: int) -> Self:
+        """Build the zero-length lazy stack produced by an index that selects nothing.
+
+        ``_new_lazy_unsafe`` re-inserts the stack dim into the batch size it
+        is given, so it must receive the constituents' batch size (the
+        result's batch size with ``stack_dim`` removed), not the result's.
+        The result has zero constituents and therefore no key structure, but
+        it keeps the lazy-stack type so that e.g. ``torch.cat`` with sibling
+        lazy stacks still works.
+        """
+        batch_size = _getitem_batch_size(self.batch_size, index)
+        constituent_batch_size = torch.Size(
+            tuple(batch_size[:stack_dim]) + tuple(batch_size[stack_dim + 1 :])
+        )
+        names = self.names
+        if names is not None and len(names) == len(batch_size):
+            names = names[:stack_dim] + names[stack_dim + 1 :]
+            if not any(name is not None for name in names):
+                names = None
+        else:
+            names = None
+        return self._new_lazy_unsafe(
+            stack_dim=stack_dim,
+            device=self.device,
+            names=names,
+            batch_size=constituent_batch_size,
+        )
 
     def _set_at_str(self, key, value, index, *, validated, non_blocking: bool):
         if not validated:
@@ -2442,9 +2484,10 @@ class LazyStackedTensorDict(TensorDictBase):
             isinstance(index, torch.Tensor)
             and index.shape == ()
             and index.dtype == torch.bool
-            and index.all()
         ):
-            self.unsqueeze(0).update(value)
+            if index is None or bool(index):
+                self.unsqueeze(0).update(value)
+            # a scalar False mask selects nothing: no-op
             return self
 
         if is_tensor_collection(value) or isinstance(value, dict):
@@ -2553,9 +2596,12 @@ class LazyStackedTensorDict(TensorDictBase):
             isinstance(index, torch.Tensor)
             and index.shape == ()
             and index.dtype == torch.bool
-            and index.all()
         ):
-            return self.unsqueeze(0)
+            result = self.unsqueeze(0)
+            if index is None or bool(index):
+                return result
+            # x[False] (or a scalar False mask) adds a zero-sized leading dim
+            return result[0:0]
         split_index = self._split_index(index)
         converted_idx = split_index["index_dict"]
         isinteger = split_index["isinteger"]
@@ -2578,15 +2624,12 @@ class LazyStackedTensorDict(TensorDictBase):
                             result.append(self.tensordicts[i][_idx])
                             result[-1] = result[-1].squeeze(cat_dim)
                 if not result:
-                    batch_size = _getitem_batch_size(self.batch_size, index)
-                else:
-                    batch_size = None
+                    return self._empty_getitem_result(index, cat_dim)
                 return self._new_lazy_unsafe(
                     *result,
                     stack_dim=cat_dim,
                     device=self.device,
                     names=self.names,
-                    batch_size=batch_size,
                 )
             else:
                 for i, _idx in converted_idx.items():
@@ -2637,6 +2680,9 @@ class LazyStackedTensorDict(TensorDictBase):
                         result.append(self.tensordicts[i])
                     else:
                         result.append(self.tensordicts[i][_idx])
+                if not result:
+                    # e.g. an empty slice along the stack dim
+                    return self._empty_getitem_result(index, new_stack_dim)
                 result = LazyStackedTensorDict.lazy_stack(
                     result, new_stack_dim, stack_dim_name=self._td_dim_name
                 )

--- a/tensordict/functional.py
+++ b/tensordict/functional.py
@@ -12,12 +12,14 @@ import torch
 from tensordict._lazy import LazyStackedTensorDict
 from tensordict._td import TensorDict
 from tensordict.base import (
+    _is_leaf_nontensor,
     _is_tensor_collection,
     CompatibleType,
     NestedKey,
     T,
     TensorDictBase,
 )
+from tensordict.tensorclass import NonTensorData, NonTensorStack
 from tensordict.utils import (
     _check_keys,
     _is_unbatched,
@@ -47,7 +49,11 @@ def pad(
             (padding_left, padding_right). To pad two dimensions,
             (padding_left, padding_right, padding_top, padding_bottom) and so on.
             pad_size must be even and less than or equal to twice the number of batch dimensions.
-         value (float, optional): The fill value to pad by, default 0.0
+         value (float, optional): The fill value to pad by, default 0.0.
+            Non-tensor entries (:class:`~tensordict.NonTensorData` /
+            :class:`~tensordict.NonTensorStack`) keep their values at the
+            valid positions and hold ``None`` in the pad slots instead of
+            ``value``.
          inplace (bool, optional): If ``True``, the input tensordict's identity
             and key set are preserved, and each leaf's storage is replaced by
             its padded counterpart one at a time. This keeps peak memory close
@@ -112,6 +118,11 @@ def pad(
     if safe:
         _pad_preflight(tensordict, pad_size)
 
+    if is_non_tensor(tensordict):
+        # NonTensorStack is a LazyStackedTensorDict subclass: dispatch before
+        # the lazy-stack branch so non-tensor values are preserved.
+        return _pad_non_tensor(tensordict, pad_size, inplace=inplace)
+
     if inplace and isinstance(tensordict, LazyStackedTensorDict):
         return _pad_lazy_stack_inplace(tensordict, pad_size, value)
 
@@ -143,6 +154,21 @@ def pad(
         if _is_unbatched(tensor):
             if not inplace:
                 out._set_str(key, tensor, validated=True, inplace=False)
+            continue
+
+        if is_non_tensor(tensor):
+            if not tensor.batch_size:
+                # Unbatched non-tensor metadata: not indexed along the batch
+                # dims, so padding leaves it untouched.
+                if not inplace:
+                    out._set_str(key, tensor, validated=True, inplace=False)
+                continue
+            if inplace and isinstance(tensor, NonTensorStack):
+                _pad_non_tensor(tensor, pad_size, inplace=True)
+                continue
+            padded = _pad_non_tensor(tensor, pad_size, inplace=False)
+            del tensor
+            out._set_str(key, padded, validated=True, inplace=False)
             continue
 
         if _is_tensor_collection(type(tensor)):
@@ -182,6 +208,24 @@ def _pad_preflight(tensordict: TensorDictBase, pad_size: Sequence[int]) -> None:
     non-negative. Catches the realistic user-error class of failures before
     ``inplace=True`` has rebound any leaf.
     """
+    if is_non_tensor(tensordict):
+        shape = tensordict.batch_size
+        if not shape:
+            return
+        if len(pad_size) > 2 * len(shape):
+            raise RuntimeError(
+                f"pad_size of length {len(pad_size)} is too long for non-tensor "
+                f"value with batch size {tuple(shape)}."
+            )
+        for i in range(len(pad_size) // 2):
+            left, right = pad_size[2 * i], pad_size[2 * i + 1]
+            if shape[i] + left + right < 0:
+                raise RuntimeError(
+                    f"Pad ({left}, {right}) on dim {i} of non-tensor value "
+                    f"(size {shape[i]}) would produce a negative output size."
+                )
+        return
+
     if isinstance(tensordict, LazyStackedTensorDict):
         stack_dim = tensordict.stack_dim
         pairs = [
@@ -227,6 +271,100 @@ def _pad_preflight(tensordict: TensorDictBase, pad_size: Sequence[int]) -> None:
                 )
 
 
+def _pad_non_tensor(
+    tensordict: TensorDictBase,
+    pad_size: Sequence[int],
+    *,
+    inplace: bool = False,
+) -> TensorDictBase:
+    """Pad a ``NonTensorData`` / ``NonTensorStack`` along its leading batch dims.
+
+    Non-tensor values cannot be filled with a numeric constant: the valid
+    positions keep their original values and every pad slot holds a
+    ``NonTensorData`` whose data is ``None``. Negative pad sizes crop, like
+    :func:`torch.nn.functional.pad`.
+    """
+    pairs = [(pad_size[2 * i], pad_size[2 * i + 1]) for i in range(len(pad_size) // 2)]
+    if all(left == 0 and right == 0 for left, right in pairs):
+        return tensordict
+    result = _pad_non_tensor_rec(tensordict, pairs)
+    if not inplace:
+        return result
+    if not isinstance(tensordict, NonTensorStack):
+        raise RuntimeError(
+            "pad(..., inplace=True) cannot preserve the identity of a "
+            "NonTensorData input since the padded result is a NonTensorStack. "
+            "Use inplace=False instead."
+        )
+    if tensordict.stack_dim == 0:
+        new_tensordicts = result.tensordicts
+    else:
+        new_tensordicts = result.unbind(tensordict.stack_dim)
+    tensordict.tensordicts[:] = new_tensordicts
+    tensordict._change_batch_size(result.batch_size)
+    return tensordict
+
+
+def _pad_non_tensor_rec(
+    tensordict: TensorDictBase, pairs: list[tuple[int, int]]
+) -> NonTensorStack:
+    left, right = pairs[0]
+    rest = pairs[1:]
+    elements = list(tensordict.unbind(0))
+    if rest and any(p != 0 for pair in rest for p in pair):
+        elements = [_pad_non_tensor_rec(element, rest) for element in elements]
+    if left < 0:
+        elements = elements[-left:]
+        left = 0
+    if right < 0:
+        elements = elements[: len(elements) + right]
+        right = 0
+    inner_shape = list(tensordict.batch_size[1:])
+    for dim, (inner_left, inner_right) in enumerate(rest):
+        inner_shape[dim] += inner_left + inner_right
+    device = tensordict.device
+    items = (
+        [
+            NonTensorData(data=None, batch_size=inner_shape, device=device)
+            for _ in range(left)
+        ]
+        + elements
+        + [
+            NonTensorData(data=None, batch_size=inner_shape, device=device)
+            for _ in range(right)
+        ]
+    )
+    if not items:
+        raise RuntimeError(
+            "Padding a non-tensor value to a zero-sized batch dimension is not "
+            "supported: a NonTensorStack cannot be empty."
+        )
+    return NonTensorStack(*items, stack_dim=0)
+
+
+def _pad_filler_like(template: TensorDictBase, value: float) -> TensorDictBase:
+    """Build a pad-slot constituent shaped like ``template``.
+
+    Tensor leaves are filled with ``value``; non-tensor leaves hold ``None``
+    (a non-tensor value cannot be filled with a numeric constant).
+    """
+    if is_non_tensor(template):
+        return NonTensorData(
+            data=None, batch_size=template.batch_size, device=template.device
+        )
+    filler = template.apply(lambda t: torch.full_like(t, value))
+    for key in template.keys(True, True, is_leaf=_is_leaf_nontensor):
+        leaf = template.get(key)
+        if is_non_tensor(leaf):
+            filler.set(
+                key,
+                NonTensorData(
+                    data=None, batch_size=leaf.batch_size, device=leaf.device
+                ),
+            )
+    return filler
+
+
 def _pad_lazy_stack_inplace(
     tensordict: LazyStackedTensorDict,
     pad_size: Sequence[int],
@@ -262,15 +400,11 @@ def _pad_lazy_stack_inplace(
 
     if right > 0:
         template = tensordict.tensordicts[-1]
-        new_pads = [
-            template.apply(lambda t: torch.full_like(t, value)) for _ in range(right)
-        ]
+        new_pads = [_pad_filler_like(template, value) for _ in range(right)]
         tensordict.tensordicts.extend(new_pads)
     if left > 0:
         template = tensordict.tensordicts[0]
-        new_pads = [
-            template.apply(lambda t: torch.full_like(t, value)) for _ in range(left)
-        ]
+        new_pads = [_pad_filler_like(template, value) for _ in range(left)]
         tensordict.tensordicts[:0] = new_pads
 
     new_batch_size = list(tensordict.batch_size)

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -2940,8 +2940,9 @@ class LinkedList(list):
     def __repr__(self) -> str:
         return f"LinkedList({super().__repr__()})"
 
-    def __str__(self) -> str:
-        return f"LinkedList({super().__str__()})"
+    # No __str__ override: list has no __str__ of its own, so a
+    # super().__str__() call would dispatch back to this class's __repr__
+    # and print a doubly-wrapped "LinkedList(LinkedList([...]))".
 
     def __eq__(self, other: Any) -> bool:
         return list(self) == other

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -98,7 +98,7 @@ class TestFSDP:
         try:
             mp.set_start_method("spawn")
         except Exception:
-            tdlogger.info("start method already set to", mp.get_start_method())
+            tdlogger.info("start method already set to %s", mp.get_start_method())
         proc0 = mp.Process(target=self.worker, args=(0, tmpdir))
         proc1 = mp.Process(target=self.worker, args=(1, tmpdir))
         proc0.start()
@@ -162,7 +162,7 @@ class TestNPUFSDP:
         try:
             mp.set_start_method("spawn")
         except Exception:
-            tdlogger.info("start method already set to", mp.get_start_method())
+            tdlogger.info("start method already set to %s", mp.get_start_method())
         proc0 = mp.Process(target=self.worker, args=(0, tmpdir))
         proc1 = mp.Process(target=self.worker, args=(1, tmpdir))
         proc0.start()
@@ -238,7 +238,7 @@ class TestDTensor:
         try:
             mp.set_start_method("spawn")
         except Exception:
-            tdlogger.info("start method already set to", mp.get_start_method())
+            tdlogger.info("start method already set to %s", mp.get_start_method())
         server_queue = mp.Queue(1)
         client_queue = mp.Queue(1)
         server_worker = mp.Process(

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -2469,6 +2469,110 @@ class TestGeneric:
         assert td["b"] is old_b
         assert td.batch_size == torch.Size([3, 4])
 
+    def test_pad_nontensor(self):
+        td = TensorDict(
+            {
+                "x": torch.arange(3).unsqueeze(-1),
+                "instr": NonTensorStack("a", "b", "c"),
+            },
+            batch_size=[3],
+        )
+        padded = pad(td, [0, 2])
+        assert isinstance(padded.get("instr"), NonTensorStack)
+        assert padded.get("instr").batch_size == torch.Size([5])
+        assert padded.get("instr").tolist() == ["a", "b", "c", None, None]
+        assert padded["x"].squeeze(-1).tolist() == [0, 1, 2, 0, 0]
+        # left + right pad
+        assert pad(td, [1, 1]).get("instr").tolist() == [None, "a", "b", "c", None]
+        # negative pad crops
+        assert pad(td, [-1, 1]).get("instr").tolist() == ["b", "c", None]
+
+    def test_pad_nontensor_2dim(self):
+        instr = torch.stack(
+            [NonTensorStack(*[f"{i}{j}" for j in range(2)]) for i in range(3)]
+        )
+        td = TensorDict({"instr": instr, "x": torch.ones(3, 2)}, batch_size=[3, 2])
+        padded = pad(td, [0, 1, 1, 0])
+        assert padded.batch_size == torch.Size([4, 3])
+        assert padded.get("instr").tolist() == [
+            [None, "00", "01"],
+            [None, "10", "11"],
+            [None, "20", "21"],
+            [None, None, None],
+        ]
+
+    def test_pad_nontensor_broadcast_data(self):
+        td = TensorDict(
+            {"meta": NonTensorData("m", batch_size=[3]), "x": torch.ones(3)},
+            batch_size=[3],
+        )
+        padded = pad(td, [0, 2])
+        assert padded.get("meta").tolist() == ["m", "m", "m", None, None]
+
+    def test_pad_nontensor_inplace(self):
+        td = TensorDict(
+            {
+                "x": torch.arange(3).float(),
+                "instr": NonTensorStack("a", "b", "c"),
+            },
+            batch_size=[3],
+        )
+        instr = td.get("instr")
+        out = pad(td, [0, 2], inplace=True)
+        assert out is td
+        # NonTensorStack entries are padded in place: identity preserved.
+        assert out.get("instr") is instr
+        assert out.get("instr").tolist() == ["a", "b", "c", None, None]
+        assert out["x"].tolist() == [0.0, 1.0, 2.0, 0.0, 0.0]
+
+    def test_pad_nontensor_top_level(self):
+        stack = NonTensorStack("a", "b")
+        padded = pad(stack, [1, 1])
+        assert isinstance(padded, NonTensorStack)
+        assert padded.tolist() == [None, "a", "b", None]
+        # inplace preserves the stack's identity
+        out = pad(stack, [0, 1], inplace=True)
+        assert out is stack
+        assert stack.tolist() == ["a", "b", None]
+        # NonTensorData cannot be padded in place (it must become a stack)
+        with pytest.raises(RuntimeError, match="cannot preserve the identity"):
+            pad(NonTensorData("a", batch_size=[2]), [0, 1], inplace=True)
+
+    def test_pad_nontensor_safe(self):
+        td = TensorDict({"instr": NonTensorStack("a", "b", "c")}, batch_size=[3])
+        with pytest.raises(RuntimeError, match="negative output size"):
+            pad(td, [-4, 0])
+
+    def test_pad_nontensor_lazy_stack(self):
+        def _make():
+            return lazy_stack(
+                [
+                    TensorDict(
+                        {
+                            "x": torch.ones(4) * i,
+                            "instr": NonTensorStack(*[f"{i}{j}" for j in range(4)]),
+                        },
+                        batch_size=[4],
+                    )
+                    for i in range(2)
+                ],
+                dim=0,
+            )
+
+        expected = [
+            ["00", "01", "02", "03", None, None],
+            ["10", "11", "12", "13", None, None],
+            [None] * 6,
+        ]
+        # Padding along both the stack dim and the constituent dim keeps
+        # non-tensor values for the valid positions; new slots hold None.
+        padded = pad(_make(), [0, 1, 0, 2], value=9.0)
+        assert padded.get("instr").tolist() == expected
+        lst = _make()
+        out = pad(lst, [0, 1, 0, 2], value=9.0, inplace=True)
+        assert out is lst
+        assert out.get("instr").tolist() == expected
+
     def test_pad_safe_default_is_true(self):
         td = TensorDict({"a": torch.ones(3, 4)}, batch_size=[3, 4])
         old_a = td["a"]
@@ -12012,6 +12116,70 @@ class TestLazyStackedTensorDict:
         split1b = td[:, mask1a], td[:, mask1b], td[:, mask1c]
         assert (torch.cat(split1b, dim=1) == td).all()
 
+    def test_lazy_mask_nested_stack(self):
+        # Boolean-masking a lazy stack whose constituents are themselves lazy
+        # stacks: the per-constituent scalar masks must behave like new-axis
+        # indices, not integer indices.
+        outer = LazyStackedTensorDict(
+            *[
+                LazyStackedTensorDict(
+                    *[
+                        TensorDict({"a": torch.full((), float(i * 10 + j))}, [])
+                        for j in range(2)
+                    ],
+                    stack_dim=0,
+                )
+                for i in range(3)
+            ],
+            stack_dim=0,
+        )
+        mask = torch.tensor([True, False, True])
+        masked = outer[mask]
+        assert masked.batch_size == torch.Size([2, 2])
+        assert masked["a"].tolist() == [[0.0, 1.0], [20.0, 21.0]]
+
+    def test_lazy_scalar_bool_index(self):
+        lst = LazyStackedTensorDict(
+            *[TensorDict({"a": torch.full((), float(i))}, []) for i in range(2)],
+            stack_dim=0,
+        )
+        # bare scalar masks: True adds a size-1 leading dim, False a size-0 one
+        assert lst[torch.tensor(True)].batch_size == torch.Size([1, 2])
+        assert lst[torch.tensor(False)].batch_size == torch.Size([0, 2])
+        assert lst[True].batch_size == torch.Size([1, 2])
+        assert lst[False].batch_size == torch.Size([0, 2])
+        # scalar True inside a tuple index (matches dense semantics)
+        indexed = lst[(torch.tensor(True),)]
+        assert indexed.batch_size == torch.Size([1, 2])
+        assert indexed["a"].tolist() == [[0.0, 1.0]]
+        with pytest.raises(NotImplementedError, match="scalar False"):
+            lst[(torch.tensor(False),)]
+        # scalar False assignment is a no-op
+        before = lst["a"].tolist()
+        lst[torch.tensor(False)] = TensorDict({"a": torch.full((1, 2), 5.0)}, [1, 2])
+        assert lst["a"].tolist() == before
+
+    def test_lazy_empty_selection_batch_size(self):
+        lst = LazyStackedTensorDict(
+            *[TensorDict({"a": torch.ones(2)}, [2]) for _ in range(3)],
+            stack_dim=0,
+        )
+        # empty slice along the stack dim used to raise "items cannot be empty"
+        assert lst[0:0].batch_size == torch.Size([0, 2])
+        # all-False mask used to return batch_size [0, 0, 2]
+        assert lst[torch.zeros(3, dtype=torch.bool)].batch_size == torch.Size([0, 2])
+        # the empty result keeps the lazy type so cat with siblings still works
+        recat = torch.cat([lst[0:1], lst[0:0], lst[1:]], 0)
+        assert recat.batch_size == torch.Size([3, 2])
+        assert (recat == lst).all()
+        # zero-size in a non-leading position
+        lst_sd1 = LazyStackedTensorDict(
+            *[TensorDict({"a": torch.ones(3)}, [3]) for _ in range(2)],
+            stack_dim=1,
+        )
+        empty = lst_sd1[:, torch.zeros(2, dtype=torch.bool)]
+        assert empty.batch_size == torch.Size([3, 0])
+
     @pytest.mark.parametrize("stack_dim", [0, 1, 2])
     @pytest.mark.parametrize("mask_dim", [0, 1, 2])
     @pytest.mark.parametrize("single_mask_dim", [True, False])
@@ -14644,6 +14812,75 @@ class TestNonTensorData:
         assert result._td() is td.get("a")
         result.extend(["baz", "qux"])
         assert result._td() is None
+
+    def test_linked_list_str(self):
+        td = TensorDict(a=NonTensorStack("foo", "bar"), batch_size=(2,))
+        # str must not double-wrap: list has no __str__ of its own, so a
+        # naive super().__str__() would bounce back to LinkedList.__repr__.
+        assert str(td["a"]) == "LinkedList(['foo', 'bar'])"
+        assert repr(td["a"]) == "LinkedList(['foo', 'bar'])"
+
+    def test_nontensorstack_boolean_mask(self):
+        td = TensorDict(
+            {
+                "x": torch.arange(3),
+                "instr": NonTensorStack("a", "b", "c"),
+            },
+            batch_size=[3],
+        )
+        mask = torch.tensor([True, False, True])
+        masked = td[mask]
+        assert isinstance(masked.get("instr"), NonTensorStack)
+        assert masked.get("instr").batch_size == torch.Size([2])
+        assert masked.get("instr").tolist() == ["a", "c"]
+        assert masked["instr"] == ["a", "c"]
+        # all-False mask
+        empty = td[torch.zeros(3, dtype=torch.bool)]
+        assert empty.batch_size == torch.Size([0])
+        assert empty.get("instr").batch_size == torch.Size([0])
+        assert empty.get("instr").tolist() == []
+
+    def test_nontensorstack_boolean_mask_2d(self):
+        instr = torch.stack(
+            [NonTensorStack(*[f"{i}{j}" for j in range(2)]) for i in range(3)]
+        )
+        td = TensorDict(
+            {"instr": instr, "x": torch.arange(6).view(3, 2)}, batch_size=[3, 2]
+        )
+        # mask along dim 0 of a 2D NonTensorStack used to raise an IndexError
+        mask = torch.tensor([True, False, True])
+        masked = td[mask]
+        assert masked.get("instr").tolist() == [["00", "01"], ["20", "21"]]
+        assert masked["x"].tolist() == [[0, 1], [4, 5]]
+        # full-shape mask flattens
+        full_mask = torch.tensor([[True, False], [False, True], [True, True]])
+        assert td[full_mask].get("instr").tolist() == ["00", "11", "20", "21"]
+        # boolean setitem with nested stacks
+        value = TensorDict(
+            {
+                "instr": torch.stack(
+                    [NonTensorStack("p", "q"), NonTensorStack("r", "s")]
+                ),
+                "x": torch.zeros(2, 2, dtype=torch.long),
+            },
+            batch_size=[2, 2],
+        )
+        td[mask] = value
+        assert td.get("instr").tolist() == [["p", "q"], ["10", "11"], ["r", "s"]]
+
+    def test_nontensorstack_scalar_bool_index(self):
+        stack = NonTensorStack("a", "b")
+        assert stack[torch.tensor(True)].tolist() == [["a", "b"]]
+        assert stack[torch.tensor(False)].batch_size == torch.Size([0, 2])
+        indexed = stack[(torch.tensor(True),)]
+        assert isinstance(indexed, NonTensorStack)
+        assert indexed.batch_size == torch.Size([1, 2])
+        assert indexed.tolist() == [["a", "b"]]
+        # masking to empty keeps the NonTensorStack type
+        empty = stack[torch.zeros(2, dtype=torch.bool)]
+        assert isinstance(empty, NonTensorStack)
+        assert empty.batch_size == torch.Size([0])
+        assert empty.tolist() == []
 
     def test_new_empty_nontensorstack(self):
         td = TensorDict(a=NonTensorStack("a", "b").unsqueeze(-1), batch_size=(2,))


### PR DESCRIPTION
## Summary

`tensordict.pad` silently destroyed NonTensor entries: padding a TensorDict containing a `NonTensorStack` returned the entry as a stack of **empty** TensorDicts for *all* positions, valid ones included. Repro:

```python
import torch
from tensordict import NonTensorStack, TensorDict, pad
td = TensorDict({"x": torch.arange(3).unsqueeze(-1), "instr": NonTensorStack("a", "b", "c")}, batch_size=[3])
p = pad(td, [0, 2])
p["instr"]  # before: stack of empty TensorDicts — 'a','b','c' gone;  after: ['a','b','c',None,None]
p["x"]      # correctly zero-padded
```

Root cause: `NonTensorStack` is a `LazyStackedTensorDict` subclass, so it fell into the generic lazy-stack branch and had its leaves filled with the numeric `value`.

## What changed

**`pad` (functional.py)** now routes non-tensor entries to a dedicated path. Valid positions keep their original values; each pad slot holds a `NonTensorData` with `data=None` (a non-tensor value can't be filled with a numeric constant). Covered cases:

- top-level `NonTensorData` / `NonTensorStack` inputs and nested entries
- multi-dimensional padding and negative (cropping) pads
- broadcast `NonTensorData` (single value over a batch dim)
- unbatched (`batch_size=[]`) non-tensor metadata is carried through untouched
- `inplace=True`: `NonTensorStack` identity is preserved; the lazy-stack stack-dim grow path fills new slots with `None` for non-tensor leaves
- `safe=True` pre-flight validates non-tensor pad sizes too

**Boolean-mask indexing (`_lazy.py`)** — two related sharp edges surfaced by the same downstream code:

- Masking dim 0 of a 2-D `NonTensorStack` raised `IndexError` because a scalar bool inside a tuple index was treated like a scalar integer. Scalar bools now follow numpy new-axis semantics (`True` -> size-1 dim, `False` -> size-0 dim) in both `__getitem__` and `__setitem__`.
- Indices selecting nothing (empty slice along the stack dim, all-False mask) raised `"items cannot be empty"` or produced a wrong batch size (`[0, 0, ...]`); they now return a correctly-shaped zero-length lazy stack that still interops with `torch.cat`.

**`LinkedList` (utils.py)** printed doubly-wrapped (`LinkedList(LinkedList([...]))`) because `__str__` called `super().__str__()`, which dispatched back to `__repr__`. Dropped the redundant `__str__`.

## Tests

Added to `test/test_tensordict.py` (extends existing pad / lazy-stack / non-tensor coverage):

- `test_pad_nontensor`, `_2dim`, `_broadcast_data`, `_inplace`, `_top_level`, `_safe`, `_lazy_stack`
- `test_lazy_mask_nested_stack`, `test_lazy_scalar_bool_index`, `test_lazy_empty_selection_batch_size`
- `test_nontensorstack_boolean_mask`, `_2d`, `_scalar_bool_index`, `test_linked_list_str`

Full `test/test_tensordict.py` (7716 passed), pad/index/mask subsets, `test_compile.py` subset, and `test_tensorclass.py` non-tensor/stack subset all pass.

## Downstream

torchrl's collector `trajs_per_batch` path (`torchrl/collectors/utils.py::_traj_emit`) carries a workaround that pads non-tensor keys separately; once this lands that workaround can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)