### PR TITLE
[CI] Add TensorDict PR label prefixes

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -8,6 +8,7 @@
 #   - Matching is case-insensitive
 #
 # Supported prefixes -> label:
+#   [BE]                                -> BE
 #   [BugFix], [Fix]                     -> bug
 #   [Feature]                           -> Feature
 #   [Doc], [Docs], [Documentation]      -> documentation
@@ -18,12 +19,14 @@
 #   [Performance], [Perf]              -> Performance
 #   [Deprecation], [Deprecated]         -> Deprecation
 #   [Setup]                             -> setup
-#   [Distributed], [Dist]              -> Distributed
+#   [Distributed], [Dist], [DTensor]    -> Distributed
 #   [Benchmark], [Benchmarks], [Bench]  -> Benchmarks
 #   [Typing], [Type]                    -> Typing
 #   [BC-breaking], [BC]                 -> BC-breaking
 #   [Formatting], [Format]             -> Formatting
 #   [Quality]                           -> Quality
+#   [Release]                           -> release
+#   [Versioning]                        -> versioning
 #------------------------------------------------------------
 
 name: PR Label
@@ -65,6 +68,7 @@ jobs:
 
           | Prefix | Label Applied | Example |
           |--------|---------------|---------|
+          | `[BE]` | BE | `[BE] Improve internal plumbing` |
           | `[BugFix]` or `[Fix]` | bug | `[BugFix] Fix memory leak in TensorDict` |
           | `[Feature]` | Feature | `[Feature] Add new storage backend` |
           | `[Doc]` or `[Docs]` | documentation | `[Doc] Update installation guide` |
@@ -75,12 +79,14 @@ jobs:
           | `[Performance]` or `[Perf]` | Performance | `[Perf] Optimize tensor operations` |
           | `[Deprecation]` | Deprecation | `[Deprecation] Mark old function` |
           | `[Setup]` | setup | `[Setup] Update build configuration` |
-          | `[Distributed]` or `[Dist]` | Distributed | `[Distributed] Add scatter collective` |
+          | `[Distributed]`, `[Dist]`, or `[DTensor]` | Distributed | `[DTensor] Add cross-mesh transfer` |
           | `[Benchmark]` or `[Bench]` | Benchmarks | `[Benchmark] Add compile benchmark` |
           | `[Typing]` or `[Type]` | Typing | `[Typing] Add type stubs` |
           | `[BC-breaking]` or `[BC]` | BC-breaking | `[BC-breaking] Remove deprecated API` |
           | `[Formatting]` or `[Format]` | Formatting | `[Format] Fix code style` |
           | `[Quality]` | Quality | `[Quality] Improve error messages` |
+          | `[Release]` | release | `[Release] Publish release artifacts` |
+          | `[Versioning]` | versioning | `[Versioning] Bump release version` |
 
           **Note:** Matching is case-insensitive. Common variations (singular/plural) are supported.
           COMMENT_EOF
@@ -109,6 +115,7 @@ jobs:
 
           # Map prefixes to GitHub label names
           case "$PREFIX_LOWER" in
+            be)                        LABEL="BE" ;;
             bugfix|fix|bug)            LABEL="bug" ;;
             feature|features)          LABEL="Feature" ;;
             doc|docs|documentation)    LABEL="documentation" ;;
@@ -119,12 +126,14 @@ jobs:
             performance|perf)          LABEL="Performance" ;;
             deprecation|deprecated)    LABEL="Deprecation" ;;
             setup)                     LABEL="setup" ;;
-            distributed|dist)          LABEL="Distributed" ;;
+            distributed|dist|dtensor)  LABEL="Distributed" ;;
             benchmark|benchmarks|bench) LABEL="Benchmarks" ;;
             typing|type)               LABEL="Typing" ;;
             bc-breaking|bc)            LABEL="BC-breaking" ;;
             formatting|format)         LABEL="Formatting" ;;
             quality)                   LABEL="Quality" ;;
+            release)                   LABEL="release" ;;
+            versioning)                LABEL="versioning" ;;
             *)
               echo "::error::Unknown or invalid prefix '[$PREFIX]'."
               post_help_comment "Unknown or invalid prefix \`[$PREFIX]\`." "$PR_TITLE"


### PR DESCRIPTION
## Summary
- Add missing title-prefix mappings for regular TensorDict labels: `[BE]`, `[Versioning]`, and `[Release]`.
- Treat `[DTensor]` as a distributed-work alias and map it to the existing `Distributed` label.
- Update the help-comment prefix table to match the mappings.

## Diagnosis
- Checked 265 failing `PR Label` workflow runs.
- The high-volume missing prefix was `[DTensor]` (99 failing runs), which should map to the existing `Distributed` label.
- `[Versioning]` failed on the 0.13.0 version bump and is listed in the repo's canonical PR tags, so it now maps to `versioning`.
- `[Release]` failed on a release/version-bump PR and maps to the existing `release` label.
- Existing supported prefixes such as `[BugFix]`, `[Distributed]`, `[Benchmark]`, `[Performance]`, `[Compile]`, `[Fix]`, and `[Perf]` were already covered; recent failures there were either transient GitHub errors or titles that did not start with a prefix at run time.
- I did not add `[Linter]` or no-prefix titles; those should use an existing canonical prefix such as `[CI]` / `[Quality]` or add a prefix.
- I also did not map `[Minor]` because this repo currently has no `small change` label; mapping it to `suitable for minor` would conflate two different meanings.

## Validation
- `bash -n /tmp/td-pr-label-step.sh`
- Stubbed `gh` and checked mappings for `[BE]`, `[DTensor]`, `[Distributed]`, `[Release]`, `[Versioning]`, `[BugFix]`, `[Fix]`, and `[Perf]`
- `git diff --check -- .github/workflows/pr-label.yml`
