### PR TITLE
[Feature] Delegate UnbatchedTensor scalar conversions

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -174,6 +174,8 @@ Contract
   without modifying it.
 - **Other operations work normally**: device transfers (``to``), pointwise arithmetic (``+``, ``-``, ``*``, ``/``),
   ``clone``, gradient computation, and key-based access all behave as expected.
+- **Scalar conversions follow PyTorch**: Python conversions such as ``str()``, ``bool()``, ``int()``, ``float()``,
+  ``complex()``, and integer-index conversions delegate to the wrapped tensor.
 
 Usage
 ^^^^^
@@ -201,19 +203,26 @@ Pointwise arithmetic is applied to the underlying data:
     >>> td2.get("config").data
     tensor([2., 4., 6.])
 
+Single-element ``UnbatchedTensor`` values can be converted like regular PyTorch tensors:
+
+    >>> int(UnbatchedTensor(torch.tensor([3])))
+    3
+    >>> f"{UnbatchedTensor(torch.tensor(1.25)):.1f}"
+    '1.2'
+
 Accessing values
 ^^^^^^^^^^^^^^^^
 
-Note that for a plain TensorDict, ``get()`` returns the :class:`~tensordict.UnbatchedTensor` wrapper, while
-``__getitem__()`` (bracket syntax) returns the underlying tensor data:
+For a plain TensorDict, both ``get()`` and ``__getitem__()`` (bracket syntax) return the
+:class:`~tensordict.UnbatchedTensor` wrapper:
 
     >>> type(td.get("config"))  # UnbatchedTensor
     <class 'tensordict._unbatched.UnbatchedTensor'>
-    >>> type(td["config"])      # plain Tensor
-    <class 'torch.Tensor'>
+    >>> type(td["config"])      # UnbatchedTensor
+    <class 'tensordict._unbatched.UnbatchedTensor'>
 
-For :class:`~tensordict.tensorclass` instances, both attribute access and ``get()`` return the underlying tensor
-data (not the wrapper):
+For :class:`~tensordict.tensorclass` instances, both attribute access and ``get()`` also return the
+:class:`~tensordict.UnbatchedTensor` wrapper:
 
     >>> from tensordict import tensorclass
     >>> @tensorclass
@@ -226,9 +235,9 @@ data (not the wrapper):
     ...     batch_size=[3],
     ... )
     >>> type(tc.config)
-    <class 'torch.Tensor'>
+    <class 'tensordict._unbatched.UnbatchedTensor'>
     >>> type(tc.get("config"))
-    <class 'torch.Tensor'>
+    <class 'tensordict._unbatched.UnbatchedTensor'>
 
 Limitations
 ^^^^^^^^^^^

--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import math
 import warnings
 
 import torch
@@ -41,12 +42,66 @@ def _has_wrapper_subclass_vmap_fix():
 _HAS_WRAPPER_SUBCLASS_FIX = _has_wrapper_subclass_vmap_fix()
 
 
+class _UnbatchedTensorMixin:
+    """Shared Python protocol delegations for ``UnbatchedTensor`` variants."""
+
+    def _base_tensor(self):
+        raise NotImplementedError
+
+    def __str__(self):
+        return str(self._base_tensor())
+
+    def __format__(self, format_spec):
+        return self._base_tensor().__format__(format_spec)
+
+    def __bool__(self):
+        return bool(self._base_tensor())
+
+    def __int__(self):
+        return int(self._base_tensor())
+
+    def __float__(self):
+        return float(self._base_tensor())
+
+    def __complex__(self):
+        return complex(self._base_tensor())
+
+    def __index__(self):
+        return self._base_tensor().__index__()
+
+    def __round__(self, ndigits=None):
+        if ndigits is None:
+            return round(self._base_tensor())
+        return round(self._base_tensor(), ndigits)
+
+    def __trunc__(self):
+        return math.trunc(self._base_tensor())
+
+    def __floor__(self):
+        return math.floor(self._base_tensor())
+
+    def __ceil__(self):
+        return math.ceil(self._base_tensor())
+
+    def __array__(self, dtype=None):
+        return self._base_tensor().__array__(dtype)
+
+    def item(self):
+        return self._base_tensor().item()
+
+    def numpy(self, *, force=False):
+        return self._base_tensor().numpy(force=force)
+
+    def tolist(self):
+        return self._base_tensor().tolist()
+
+
 if _HAS_WRAPPER_SUBCLASS_FIX:
     # Fast path: _make_wrapper_subclass + __torch_dispatch__
     # Zero Dynamo overhead — no DisableTorchFunctionSubclass context manager
     # or as_subclass() calls appear in the FX graph.
 
-    class UnbatchedTensor(torch.Tensor):
+    class UnbatchedTensor(_UnbatchedTensorMixin, torch.Tensor):
         """A torch.Tensor subclass whose shape is ignored during batch operations on a TensorDict.
 
         When stored in a TensorDict, shape operations (indexing, reshape, unsqueeze,
@@ -109,6 +164,9 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
             r._data = data
             return r
 
+        def _base_tensor(self):
+            return self._data
+
         def __tensor_flatten__(self):
             return ["_data"], {}
 
@@ -146,12 +204,6 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
         def untyped_storage(self):
             return self._data.untyped_storage()
 
-        def numpy(self, *, force=False):
-            return self._data.numpy(force=force)
-
-        def tolist(self):
-            return self._data.tolist()
-
         def __repr__(self):
             return f"UnbatchedTensor({self._data!r})"
 
@@ -179,7 +231,7 @@ else:
     # Works on all PyTorch versions but emits extra FX graph nodes
     # (DisableTorchFunctionSubclass enter/exit + as_subclass) under Dynamo.
 
-    class UnbatchedTensor(torch.Tensor):  # type: ignore[no-redef]
+    class UnbatchedTensor(_UnbatchedTensorMixin, torch.Tensor):  # type: ignore[no-redef]
         """A torch.Tensor subclass whose shape is ignored during batch operations on a TensorDict.
 
         When stored in a TensorDict, shape operations (indexing, reshape, unsqueeze,
@@ -225,6 +277,10 @@ else:
             if not isinstance(data, torch.Tensor):
                 data = torch.as_tensor(data)
             return torch.Tensor._make_subclass(cls, data)
+
+        def _base_tensor(self):
+            with torch._C.DisableTorchFunctionSubclass():
+                return self.as_subclass(torch.Tensor)
 
         @classmethod
         def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import math
+import operator
 import os
 import platform
 import sys
 import warnings
 from dataclasses import dataclass
 
+import numpy as np
 import pytest
 import torch
 from packaging import version
@@ -1015,6 +1018,26 @@ class TestMetaData:
 
 
 class TestUnbatchedTensor:
+    @staticmethod
+    def _result_or_exception(fun, arg):
+        try:
+            return False, fun(arg)
+        except Exception as err:
+            return True, (type(err), str(err))
+
+    @classmethod
+    def _assert_same_conversion(cls, fun, tensor):
+        expected_is_exc, expected = cls._result_or_exception(fun, tensor)
+        actual_is_exc, actual = cls._result_or_exception(fun, UnbatchedTensor(tensor))
+
+        assert actual_is_exc is expected_is_exc
+        if expected_is_exc:
+            assert actual[0] is expected[0]
+            assert actual[1] == expected[1]
+        else:
+            assert actual == expected
+            assert not isinstance(actual, UnbatchedTensor)
+
     def test_auto_batch_size(self):
         td = TensorDict(a=UnbatchedTensor(0), b=torch.randn(2, 3)).auto_batch_size_(
             batch_dims=2
@@ -1205,6 +1228,59 @@ class TestUnbatchedTensor:
         data = torch.tensor([1, 2, 3])
         ut = UnbatchedTensor(data)
         assert ut.tolist() == [1, 2, 3]
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            torch.tensor(3),
+            torch.tensor([3]),
+            torch.tensor([[3]]),
+            torch.tensor(True),
+            torch.tensor(1.25),
+            torch.tensor(1 + 2j),
+            torch.tensor([1, 2]),
+            torch.empty(0),
+        ],
+    )
+    def test_unbatched_python_conversions_match_tensor(self, data):
+        conversion_funs = [
+            str,
+            format,
+            lambda x: format(x, ".2f"),
+            bool,
+            int,
+            float,
+            complex,
+            operator.index,
+            round,
+            lambda x: round(x, 1),
+            math.trunc,
+            math.floor,
+            math.ceil,
+            lambda x: x.item(),
+        ]
+        for fun in conversion_funs:
+            self._assert_same_conversion(fun, data)
+
+    def test_unbatched_index_protocol(self):
+        data = torch.tensor(1)
+        ut = UnbatchedTensor(data)
+        assert [10, 20, 30][ut] == [10, 20, 30][data]
+        assert hex(ut) == hex(data)
+
+    def test_unbatched_numpy_array_conversion(self):
+        data = torch.tensor([[1, 2], [3, 4]])
+        ut = UnbatchedTensor(data)
+        np.testing.assert_array_equal(np.asarray(ut), np.asarray(data))
+        np.testing.assert_array_equal(
+            np.asarray(ut, dtype=np.float64), np.asarray(data, dtype=np.float64)
+        )
+
+    def test_unbatched_string_representation(self):
+        data = torch.tensor([1.0, 2.0])
+        ut = UnbatchedTensor(data)
+        assert str(ut) == str(data)
+        assert repr(ut) == f"UnbatchedTensor({data!r})"
 
     def test_auto_batch_size_nontensor_not_excluded(self):
         td = TensorDict.from_dict(


### PR DESCRIPTION
## Summary
- Delegate Python scalar/display conversions on `UnbatchedTensor` to the wrapped tensor.
- Add coverage for string formatting, bool/int/float/complex/index conversions, math helpers, item, and NumPy array conversion.
- Document scalar conversion behavior and correct the UnbatchedTensor access examples.

## Tests
- `uv run --with pytest --with pytest-rerunfailures --with pyyaml --with pytest-instafail python -m pytest test/tensordict/test_nontensor.py::TestUnbatchedTensor -q`
- `uv run --with pytest --with pytest-rerunfailures --with pyyaml --with pytest-instafail python -m pytest test/compile/test_compile.py::TestGuardCount::test_unbatched_clone_no_recompile test/compile/test_compile.py::TestGuardCount::test_unbatched_clone_preserves_semantics -q`
- `uv run --with flake8==7.1.0 --with flake8-bugbear==22.10.27 --with flake8-comprehensions==3.10.1 --with torchfix==0.5.0 --with flake8-print==5.0.0 flake8 --config=setup.cfg tensordict/_unbatched.py test/tensordict/test_nontensor.py`
- `uv run --with black black --check tensordict/_unbatched.py test/tensordict/test_nontensor.py`
- `uv run --with pydocstyle pydocstyle tensordict/_unbatched.py`
- `python3 scripts/check_rst_titles.py docs/source/overview.rst`
