### PR TITLE
[Feature] Add vmap support for UnbatchedTensor

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1583,7 +1583,9 @@ class TensorDict(TensorDictBase):
 
         def _add_batch_dim_wrapper(key: str, value: Any) -> Any:
             if _is_unbatched(value):
-                return value
+                return value._with_batch_size(td.batch_size)._add_batch_dim(
+                    in_dim=in_dim, vmap_level=vmap_level
+                )
             if is_tensor_collection(value):
                 return value._add_batch_dim(in_dim=in_dim, vmap_level=vmap_level)
 
@@ -1622,7 +1624,9 @@ class TensorDict(TensorDictBase):
 
         def _process_remove(value):
             if _is_unbatched(value):
-                return value
+                return value._with_batch_size(self.batch_size)._remove_batch_dim(
+                    vmap_level=vmap_level, batch_size=batch_size, out_dim=out_dim
+                )
             if is_tensor_collection(value):
                 return value._remove_batch_dim(
                     vmap_level=vmap_level, batch_size=batch_size, out_dim=out_dim
@@ -1652,7 +1656,12 @@ class TensorDict(TensorDictBase):
 
         def _process_value(value):
             if _is_unbatched(value):
-                return value
+                return value._with_batch_size(self.batch_size)._maybe_remove_batch_dim(
+                    funcname=funcname,
+                    vmap_level=vmap_level,
+                    batch_size=batch_size,
+                    out_dim=out_dim,
+                )
             if is_tensor_collection(value):
                 return value._maybe_remove_batch_dim(
                     funcname=funcname,

--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -48,6 +48,101 @@ class _UnbatchedTensorMixin:
     def _base_tensor(self):
         raise NotImplementedError
 
+    @property
+    def batch_size(self) -> torch.Size:
+        batch_size = getattr(self, "_batch_size", None)
+        if batch_size is None:
+            return torch.Size()
+        return batch_size
+
+    @batch_size.setter
+    def batch_size(self, batch_size) -> None:
+        self._batch_size = torch.Size(batch_size)
+
+    def copy(self):
+        out = type(self)(self._base_tensor())
+        batch_size = getattr(self, "_batch_size", None)
+        if batch_size is not None:
+            out.batch_size = batch_size
+        return out
+
+    def _with_batch_size(self, batch_size):
+        out = self.copy()
+        out.batch_size = batch_size
+        return out
+
+    def _add_batch_dim(self, *, in_dim: int, vmap_level: int):
+        batch_size = list(self.batch_size)
+        if in_dim < 0 and batch_size:
+            in_dim %= len(batch_size)
+        out = self.copy()
+        out.batch_size = batch_size[:in_dim] + batch_size[in_dim + 1 :]
+        return out
+
+    def _remove_batch_dim(self, vmap_level: int, batch_size: int, out_dim: int):
+        return self._maybe_remove_batch_dim(
+            vmap_level=vmap_level, batch_size=batch_size, out_dim=out_dim
+        )
+
+    def _maybe_remove_batch_dim(
+        self,
+        funcname=None,  # noqa: ANN001
+        *,
+        vmap_level: int,
+        batch_size: int,
+        out_dim: int | None,
+    ):
+        if out_dim is None:
+            return self
+        current_batch_size = list(self.batch_size)
+        if out_dim < 0:
+            out_dim %= len(current_batch_size) + 1
+        current_batch_size.insert(out_dim, batch_size)
+        out = self.copy()
+        out.batch_size = current_batch_size
+        return out
+
+    @staticmethod
+    def _batch_size_from_args(args, kwargs=None):
+        def _find_batch_size(value):
+            if isinstance(value, _UnbatchedTensorMixin):
+                batch_size = getattr(value, "_batch_size", None)
+                if batch_size is not None:
+                    return batch_size
+            elif isinstance(value, dict):
+                for item in value.values():
+                    batch_size = _find_batch_size(item)
+                    if batch_size is not None:
+                        return batch_size
+            elif isinstance(value, (list, tuple)):
+                for item in value:
+                    batch_size = _find_batch_size(item)
+                    if batch_size is not None:
+                        return batch_size
+            return None
+
+        batch_size = _find_batch_size(args)
+        if batch_size is None and kwargs is not None:
+            batch_size = _find_batch_size(kwargs)
+        return batch_size
+
+    @classmethod
+    def _wrap_result(cls, result, batch_size):
+        def _wrap(tensor):
+            out = cls(tensor)
+            if batch_size is not None:
+                out.batch_size = batch_size
+            return out
+
+        if isinstance(result, torch.Tensor):
+            return _wrap(result)
+        if isinstance(result, (tuple, list)):
+            return type(result)(
+                _wrap(item) if isinstance(item, torch.Tensor) else item
+                for item in result
+            )
+        return result
+
     def __str__(self):
         return str(self._base_tensor())
 
@@ -136,6 +231,12 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
         UnbatchedTensor is excluded from ``auto_batch_size_()`` computation. The batch size is determined
         solely by regular tensors.
 
+        Args:
+            data (torch.Tensor or tensor-like): payload tensor.
+            batch_size (torch.Size compatible, optional): TensorDict-facing
+                batch-size metadata used by ``torch.vmap``. The payload shape is
+                left unchanged.
+
         """
 
         _pass_through = True
@@ -143,8 +244,10 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
         __torch_function__ = torch._C._disabled_torch_function_impl
 
         @staticmethod
-        def __new__(cls, data):
+        def __new__(cls, data, batch_size=None):
             if isinstance(data, cls):
+                if batch_size is not None:
+                    return data._with_batch_size(batch_size)
                 return data
             if not isinstance(data, torch.Tensor):
                 data = torch.as_tensor(data)
@@ -162,24 +265,28 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
                 **kwargs,
             )
             r._data = data
+            if batch_size is not None:
+                r.batch_size = batch_size
             return r
 
         def _base_tensor(self):
             return self._data
 
         def __tensor_flatten__(self):
-            return ["_data"], {}
+            return ["_data"], {"batch_size": getattr(self, "_batch_size", None)}
 
         @classmethod
         def __tensor_unflatten__(
             cls, inner_tensors, metadata, outer_size, outer_stride
         ):
-            return cls(inner_tensors["_data"])
+            batch_size = None if metadata is None else metadata.get("batch_size")
+            return cls(inner_tensors["_data"], batch_size=batch_size)
 
         @classmethod
         def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
             if kwargs is None:
                 kwargs = {}
+            batch_size = cls._batch_size_from_args(args, kwargs)
 
             def unwrap(x):
                 if isinstance(x, cls):
@@ -190,13 +297,7 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
 
             result = func(*unwrap(args), **unwrap(kwargs))
 
-            if isinstance(result, torch.Tensor):
-                return cls(result)
-            if isinstance(result, (tuple, list)):
-                return type(result)(
-                    cls(r) if isinstance(r, torch.Tensor) else r for r in result
-                )
-            return result
+            return cls._wrap_result(result, batch_size)
 
         def data_ptr(self):
             return self._data.data_ptr()
@@ -208,7 +309,7 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
             return f"UnbatchedTensor({self._data!r})"
 
         def __reduce_ex__(self, protocol):
-            return (UnbatchedTensor, (self._data,))
+            return (UnbatchedTensor, (self._data, self.batch_size))
 
         @classmethod
         def _stack_non_tensor(
@@ -266,17 +367,28 @@ else:
         UnbatchedTensor is excluded from ``auto_batch_size_()`` computation. The batch size is determined
         solely by regular tensors.
 
+        Args:
+            data (torch.Tensor or tensor-like): payload tensor.
+            batch_size (torch.Size compatible, optional): TensorDict-facing
+                batch-size metadata used by ``torch.vmap``. The payload shape is
+                left unchanged.
+
         """
 
         _pass_through = True
 
         @staticmethod
-        def __new__(cls, data):
+        def __new__(cls, data, batch_size=None):
             if isinstance(data, cls):
+                if batch_size is not None:
+                    return data._with_batch_size(batch_size)
                 return data
             if not isinstance(data, torch.Tensor):
                 data = torch.as_tensor(data)
-            return torch.Tensor._make_subclass(cls, data)
+            out = torch.Tensor._make_subclass(cls, data)
+            if batch_size is not None:
+                out.batch_size = batch_size
+            return out
 
         def _base_tensor(self):
             with torch._C.DisableTorchFunctionSubclass():
@@ -286,15 +398,23 @@ else:
         def __torch_function__(cls, func, types, args=(), kwargs=None):
             if kwargs is None:
                 kwargs = {}
+            batch_size = cls._batch_size_from_args(args, kwargs)
             with torch._C.DisableTorchFunctionSubclass():
                 result = func(*args, **kwargs)
                 if isinstance(result, torch.Tensor):
-                    return result.as_subclass(cls)
+                    out = result.as_subclass(cls)
+                    if batch_size is not None:
+                        out.batch_size = batch_size
+                    return out
                 if isinstance(result, (tuple, list)):
-                    return type(result)(
-                        r.as_subclass(cls) if isinstance(r, torch.Tensor) else r
-                        for r in result
-                    )
+                    result_out = []
+                    for item in result:
+                        if isinstance(item, torch.Tensor):
+                            item = item.as_subclass(cls)
+                            if batch_size is not None:
+                                item.batch_size = batch_size
+                        result_out.append(item)
+                    return type(result)(result_out)
                 return result
 
         def __repr__(self):
@@ -303,7 +423,7 @@ else:
             return f"UnbatchedTensor({tensor_repr})"
 
         def __reduce_ex__(self, protocol):
-            return (UnbatchedTensor, (self.as_subclass(torch.Tensor),))
+            return (UnbatchedTensor, (self.as_subclass(torch.Tensor), self.batch_size))
 
         @classmethod
         def _stack_non_tensor(

--- a/tensordict/nn/functional_modules.py
+++ b/tensordict/nn/functional_modules.py
@@ -16,7 +16,7 @@ from tensordict._pytree import PYTREE_REGISTERED_LAZY_TDS, PYTREE_REGISTERED_TDS
 from tensordict._td import TensorDict
 from tensordict.base import is_tensor_collection
 
-from tensordict.utils import implement_for, strtobool
+from tensordict.utils import _is_unbatched, implement_for, strtobool
 from torch import nn
 from torch.utils._pytree import SUPPORTED_NODES
 
@@ -113,7 +113,6 @@ from torch._functorch.vmap import (  # @manual=fbcode//caffe2:torch
     _broadcast_to_and_flatten,
     _get_name,
     _maybe_remove_batch_dim,
-    _validate_and_get_batch_size,
     Tensor,
     tree_flatten,
     tree_unflatten,
@@ -145,6 +144,36 @@ class _exclude_td_from_pytree:
 if not strtobool(os.getenv("PYTORCH_TENSORDICT_IMPORT_VMAP", "False")):
     # Monkey-patches
 
+    def _is_tensordict_vmap_leaf(arg: Any) -> bool:
+        return is_tensor_collection(arg) or _is_unbatched(arg)
+
+    def _vmap_dim(arg: Any) -> int:
+        if _is_unbatched(arg):
+            return len(arg.batch_size)
+        return arg.dim()
+
+    def _vmap_size(arg: Any, dim: int) -> int:
+        if _is_unbatched(arg):
+            return arg.batch_size[dim]
+        return arg.size(dim)
+
+    def _validate_tensordict_vmap_batch_size(
+        flat_in_dims: list[int | None], flat_args: list[Any]
+    ) -> int:
+        batch_sizes = [
+            _vmap_size(arg, in_dim)
+            for in_dim, arg in zip(flat_in_dims, flat_args)
+            if in_dim is not None
+        ]
+        if len(batch_sizes) == 0:
+            raise ValueError("vmap: Expected at least one Tensor to vmap over")
+        if batch_sizes and any(size != batch_sizes[0] for size in batch_sizes):
+            raise ValueError(
+                f"vmap: Expected all tensors to have the same size in the mapped "
+                f"dimension, got sizes {batch_sizes} for the mapped dimension"
+            )
+        return batch_sizes[0]
+
     def _process_batched_inputs(
         in_dims: int | tuple[int, ...], args: Any, func: Callable
     ) -> tuple[Any, ...]:
@@ -163,7 +192,7 @@ The latter is unsupported."""
 
         # we want to escape TensorDicts as they take care of adding the batch dimension
         if PYTREE_HAS_ISLEAF:
-            flat_args, args_spec = tree_flatten(args, is_leaf=is_tensor_collection)
+            flat_args, args_spec = tree_flatten(args, is_leaf=_is_tensordict_vmap_leaf)
             flat_in_dims = _broadcast_to_and_flatten(in_dims, args_spec)
             if flat_in_dims is None:
                 raise ValueError(
@@ -205,7 +234,7 @@ please use None as the respective in_dim"""
             if (
                 in_dim is not None
                 and is_tensor_collection(arg)
-                and (in_dim >= arg.dim() or in_dim < -arg.dim())
+                and (in_dim >= _vmap_dim(arg) or in_dim < -_vmap_dim(arg))
             ):
                 # TensorDict with insufficient batch dims (e.g. batch_size=[]
                 # but tensors have dims). This occurs when tree_unflatten
@@ -227,18 +256,20 @@ please use None as the respective in_dim"""
                         arg = arg.clone(False)
                         arg._change_batch_size(new_batch_size)
                         flat_args[i] = arg
-            if in_dim is not None and (in_dim < -arg.dim() or in_dim >= arg.dim()):
+            if in_dim is not None and (
+                in_dim < -_vmap_dim(arg) or in_dim >= _vmap_dim(arg)
+            ):
                 raise ValueError(
                     f"""vmap({_get_name(func)}, in_dims={in_dims}, ...)(<inputs>):
 Got in_dim={in_dim} for some input, but that input is a Tensor
-of dimensionality {arg.dim()} so expected in_dim to satisfy
--{arg.dim()} <= in_dim < {arg.dim()}."""
+of dimensionality {_vmap_dim(arg)} so expected in_dim to satisfy
+-{_vmap_dim(arg)} <= in_dim < {_vmap_dim(arg)}."""
                 )
             if in_dim is not None and in_dim < 0:
-                flat_in_dims[i] = in_dim % arg.dim()
+                flat_in_dims[i] = in_dim % _vmap_dim(arg)
 
         return (
-            _validate_and_get_batch_size(flat_in_dims, flat_args),
+            _validate_tensordict_vmap_batch_size(flat_in_dims, flat_args),
             flat_in_dims,
             flat_args,
             args_spec,
@@ -267,6 +298,10 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
                     batched_input = arg._add_batch_dim(
                         in_dim=in_dim, vmap_level=vmap_level
                     )
+                elif _is_unbatched(arg):
+                    batched_input = arg._add_batch_dim(
+                        in_dim=in_dim, vmap_level=vmap_level
+                    )
                 else:
                     batched_input = _add_batch_dim(arg, in_dim, vmap_level)
             batched_inputs.append(batched_input)
@@ -283,7 +318,7 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
     ) -> Any:
         if PYTREE_HAS_ISLEAF:
             flat_batched_outputs, output_spec = tree_flatten(
-                batched_outputs, is_leaf=is_tensor_collection
+                batched_outputs, is_leaf=_is_tensordict_vmap_leaf
             )
         else:
             with _exclude_td_from_pytree():
@@ -297,8 +332,10 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
                 f"has structure {output_spec}."
             )
 
-        if isinstance(batched_outputs, torch.Tensor) or is_tensor_collection(
-            batched_outputs
+        if (
+            isinstance(batched_outputs, torch.Tensor)
+            or is_tensor_collection(batched_outputs)
+            or _is_unbatched(batched_outputs)
         ):
             # Some weird edge case requires us to spell out the following
             # see test_out_dims_edge_case
@@ -316,7 +353,14 @@ of dimensionality {arg.dim()} so expected in_dim to satisfy
                 incompatible_error()
         flat_outputs = []
         for batched_output, out_dim in zip(flat_batched_outputs, flat_out_dims):
-            if not is_tensor_collection(batched_output):
+            if _is_unbatched(batched_output):
+                out = batched_output._maybe_remove_batch_dim(
+                    _get_name(func),
+                    vmap_level=vmap_level,
+                    batch_size=batch_size,
+                    out_dim=out_dim,
+                )
+            elif not is_tensor_collection(batched_output):
                 out = _maybe_remove_batch_dim(
                     _get_name(func), batched_output, vmap_level, batch_size, out_dim
                 )

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -1193,7 +1193,34 @@ class TestUnbatchedTensor:
         assert result.batch_size == torch.Size([4, 3])
         assert isinstance(result.get("unbatched"), UnbatchedTensor)
         assert result.get("unbatched").data_ptr() == data.data_ptr()
+        assert result.get("unbatched").batch_size == torch.Size([4, 3])
         assert result["a"].shape == (4, 3, 5)
+
+    @pytest.mark.skipif(PYTORCH_TEST_FBCODE, reason="vmap now working in fbcode")
+    def test_unbatched_vmap_return_unbatched_tensor(self):
+        from torch import vmap
+
+        data = torch.randn(7, 11)
+        td = TensorDict(
+            a=torch.randn(4, 3, 5),
+            unbatched=UnbatchedTensor(data),
+            batch_size=[4, 3],
+        )
+        result = vmap(lambda x: x["unbatched"])(td)
+        assert isinstance(result, UnbatchedTensor)
+        assert result.data_ptr() == data.data_ptr()
+        assert result.batch_size == torch.Size([4, 3])
+
+    @pytest.mark.skipif(PYTORCH_TEST_FBCODE, reason="vmap now working in fbcode")
+    def test_unbatched_vmap_direct_input(self):
+        from torch import vmap
+
+        data = torch.randn(7, 11)
+        unbatched = UnbatchedTensor(data, batch_size=[4])
+        result = vmap(lambda x: x)(unbatched)
+        assert isinstance(result, UnbatchedTensor)
+        assert result.data_ptr() == data.data_ptr()
+        assert result.batch_size == torch.Size([4])
 
     def test_unbatched_tensorclass_attr_returns_unbatched(self):
         @tensorclass


### PR DESCRIPTION
## Summary
- add TensorDict-facing batch-size metadata and vmap hooks to UnbatchedTensor
- propagate UnbatchedTensor metadata through TensorDict vmap add/remove paths
- teach the TensorDict vmap monkeypatch to treat UnbatchedTensor as a vmap leaf
- add regression tests for TensorDict-contained, returned, and direct UnbatchedTensor vmap usage

## Tests
- `uv run --with pytest python -m pytest test/tensordict/test_nontensor.py -q`
- `uv run --with pytest python -m pytest test/tensordict/test_nontensor.py::TestUnbatchedTensor test/nn/test_functorch.py test/tensorclass/test_tensorclass.py::TestVMAP test/compile/test_compile.py::test_vmap_compile test/compile/test_compile.py::TestGuardCount::test_unbatched_clone_no_recompile test/compile/test_compile.py::TestGuardCount::test_unbatched_clone_preserves_semantics -q`
- `uv run --with ruff ruff check --ignore E402 tensordict/_unbatched.py tensordict/_td.py tensordict/nn/functional_modules.py test/tensordict/test_nontensor.py`
- `git diff --check -- tensordict/_unbatched.py tensordict/_td.py tensordict/nn/functional_modules.py test/tensordict/test_nontensor.py`
