### PR TITLE
[BugFix] Fix UnbatchedTensor stack metadata

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2902,6 +2902,12 @@ class TensorDict(TensorDictBase):
                 continue
             dest = self._get_str(key, NO_DEFAULT)
             if _is_unbatched(dest):
+                self._set_str(
+                    key,
+                    dest._with_batch_size(self.batch_size),
+                    inplace=False,
+                    validated=True,
+                )
                 continue
             new_dest = torch.stack(
                 vals,

--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -453,7 +453,7 @@ def _cat(
         for key in keys:
             items = [td._get_str(key, NO_DEFAULT) for td in list_of_tensordicts]
             if _is_unbatched(items[0]):
-                out[key] = items[0]
+                out[key] = items[0]._with_batch_size(batch_size)
             elif not is_compiling():
                 with _ErrorInteceptor(
                     key, "Attempted to concatenate tensors on different devices at key"
@@ -495,7 +495,11 @@ def _cat(
             first_item = list_of_tensordicts[0]._get_str(key, NO_DEFAULT)
             if _is_unbatched(first_item):
                 out._set_str(
-                    key, first_item, validated=True, inplace=False, non_blocking=False
+                    key,
+                    first_item._with_batch_size(batch_size),
+                    validated=True,
+                    inplace=False,
+                    non_blocking=False,
                 )
             else:
                 with (
@@ -760,12 +764,18 @@ def _stack(
                     out[key].append(tensor)
                 out[key] = (out[key], is_not_init, is_tensor)
 
+            result_batch_size = LazyStackedTensorDict._compute_batch_size(
+                batch_size, dim, len(list_of_tensordicts)
+            )
+
             def stack_fn(key, values, is_not_init, is_tensor):
                 if is_not_init:
                     return _stack_uninit_params(values, dim)
                 if is_tensor:
                     if _is_unbatched(values[0]):
-                        return type(values[0])._stack_non_tensor(values, dim)
+                        return type(values[0])._stack_non_tensor(
+                            values, dim
+                        )._with_batch_size(result_batch_size)
                     return torch.stack(values, dim)
                 with (
                     _ErrorInteceptor(
@@ -790,9 +800,7 @@ def _stack(
 
             result = clz._new_unsafe(
                 out,
-                batch_size=LazyStackedTensorDict._compute_batch_size(
-                    batch_size, dim, len(list_of_tensordicts)
-                ),
+                batch_size=result_batch_size,
                 device=device,
                 names=names,
             )

--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -325,7 +325,11 @@ if _HAS_WRAPPER_SUBCLASS_FIX:
                     "per batch element, consider using a regular tensor.",
                     stacklevel=2,
                 )
-            return first
+            batch_size = list(first.batch_size)
+            if dim < 0:
+                dim += len(batch_size) + 1
+            batch_size.insert(dim, len(list_of_non_tensor))
+            return first._with_batch_size(batch_size)
 
 else:
     # Safe fallback: _make_subclass + __torch_function__
@@ -439,4 +443,8 @@ else:
                     "per batch element, consider using a regular tensor.",
                     stacklevel=2,
                 )
-            return first
+            batch_size = list(first.batch_size)
+            if dim < 0:
+                dim += len(batch_size) + 1
+            batch_size.insert(dim, len(list_of_non_tensor))
+            return first._with_batch_size(batch_size)

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -1113,8 +1113,12 @@ class TestUnbatchedTensor:
             batch_size=(3,),
         )
         assert torch.unbind(td, 0)[0]["a"] is td["a"]
-        assert torch.stack([td, td], 0)[0]["a"] is td["a"]
-        assert torch.cat([td, td], 0)[0]["a"] is td["a"]
+        stacked = torch.stack([td, td], 0)
+        assert stacked[0]["a"].data_ptr() == td["a"].data_ptr()
+        assert stacked["a"].batch_size == torch.Size([2, 3])
+        catted = torch.cat([td, td], 0)
+        assert catted[0]["a"].data_ptr() == td["a"].data_ptr()
+        assert catted["a"].batch_size == torch.Size([6])
         assert (torch.ones_like(td)["a"] == 1).all()
         assert torch.unsqueeze(td, 0)["a"] is td["a"]
         assert torch.squeeze(td)["a"] is td["a"]
@@ -1178,6 +1182,81 @@ class TestUnbatchedTensor:
         )
         with pytest.warns(UserWarning, match="different data storage"):
             torch.stack([td1, td2])
+
+    @pytest.mark.parametrize(
+        "batch_size, dim, expected_batch_size",
+        [
+            ([], 0, [3]),
+            ([2], 0, [3, 2]),
+            ([2], 1, [2, 3]),
+            ([2, 1], -1, [2, 1, 3]),
+        ],
+    )
+    def test_unbatched_stack_updates_batch_size_metadata(
+        self, batch_size, dim, expected_batch_size
+    ):
+        data = torch.tensor(1)
+        items = [
+            TensorDict(
+                x=torch.zeros(batch_size),
+                ub=UnbatchedTensor(data),
+                batch_size=batch_size,
+            )
+            for _ in range(3)
+        ]
+        result = torch.stack(items, dim)
+        assert result.batch_size == torch.Size(expected_batch_size)
+        assert result["ub"].batch_size == result.batch_size
+        assert result["ub"].shape == torch.Size([])
+        assert result["ub"].data_ptr() == data.data_ptr()
+        assert all(item["ub"].batch_size == torch.Size([]) for item in items)
+
+    def test_unbatched_stack_out_updates_batch_size_metadata(self):
+        data = torch.tensor(1)
+        items = [
+            TensorDict(
+                x=torch.zeros(2),
+                ub=UnbatchedTensor(data),
+                batch_size=[2],
+            )
+            for _ in range(3)
+        ]
+        out = TensorDict(
+            x=torch.empty(3, 2),
+            ub=UnbatchedTensor(data),
+            batch_size=[3, 2],
+        )
+        result = torch.stack(items, 0, out=out)
+        assert result is out
+        assert result["ub"].batch_size == torch.Size([3, 2])
+        assert result["ub"].shape == torch.Size([])
+        assert result["ub"].data_ptr() == data.data_ptr()
+
+    @pytest.mark.parametrize("with_out", [False, True])
+    def test_unbatched_cat_updates_batch_size_metadata(self, with_out):
+        data = torch.tensor(1)
+        items = [
+            TensorDict(
+                x=torch.zeros(2),
+                ub=UnbatchedTensor(data),
+                batch_size=[2],
+            )
+            for _ in range(3)
+        ]
+        out = None
+        if with_out:
+            out = TensorDict(
+                x=torch.empty(6),
+                ub=UnbatchedTensor(data),
+                batch_size=[6],
+            )
+        result = torch.cat(items, 0, out=out)
+        if with_out:
+            assert result is out
+        assert result.batch_size == torch.Size([6])
+        assert result["ub"].batch_size == result.batch_size
+        assert result["ub"].shape == torch.Size([])
+        assert result["ub"].data_ptr() == data.data_ptr()
 
     @pytest.mark.skipif(PYTORCH_TEST_FBCODE, reason="vmap now working in fbcode")
     def test_unbatched_vmap(self):


### PR DESCRIPTION
## Summary
- update `UnbatchedTensor` stack handling to carry TensorDict-facing batch-size metadata
- set `UnbatchedTensor.batch_size` in TensorDict `stack`/`cat` paths, including `out=`
- add regression tests for stack/cat metadata while preserving payload storage sharing

## Tests
- `uv run --with pytest python -m pytest test/tensordict/test_nontensor.py::TestUnbatchedTensor -q`
- `uv run --with pytest python -m pytest test/tensordict/test_nontensor.py -q`
- `uv run --with pytest python -m pytest test/compile/test_compile.py::test_vmap_compile test/compile/test_compile.py::TestGuardCount::test_unbatched_clone_no_recompile test/compile/test_compile.py::TestGuardCount::test_unbatched_clone_preserves_semantics -q`
- `uv run --with ruff ruff check --ignore E402 tensordict/_unbatched.py tensordict/_torch_func.py tensordict/_td.py test/tensordict/test_nontensor.py`
- `git diff --check -- tensordict/_unbatched.py tensordict/_torch_func.py tensordict/_td.py test/tensordict/test_nontensor.py`
