### PR TITLE
[BugFix] Keep recursive TensorDict metadata consistent

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -1441,6 +1441,10 @@ class LazyStackedTensorDict(TensorDictBase):
                     )
                 else:
                     raise RuntimeError
+            elif _is_unbatched(out):
+                out = out._with_batch_size(self.batch_size)
+                if self.hook_out is not None:
+                    out = self.hook_out(out)
             elif self.hook_out is not None:
                 out = self.hook_out(out)
             return out
@@ -1546,6 +1550,8 @@ class LazyStackedTensorDict(TensorDictBase):
                     return torch.nested.as_nested_tensor(items, layout=layout)
                 if as_list:
                     return items
+            if _is_unbatched(items[0]):
+                return type(items[0])._stack_non_tensor(items, dim)
             try:
                 return torch.stack(items, dim=dim, out=out)
             except RuntimeError as err:
@@ -4128,7 +4134,7 @@ class _CustomOpTensorDict(TensorDictBase):
 
     def _transform_value(self, item):
         if _is_unbatched(item):
-            return item
+            return item._with_batch_size(self.batch_size)
         return getattr(item, self.custom_op)(**self._update_custom_op_kwargs(item))
 
     def _set_str(

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -1529,10 +1529,11 @@ class TensorDict(TensorDictBase):
                 )
             else:
                 # Pass-through values (e.g., UnbatchedTensor) with shape-changing ops
-                # (indicated by batch_size being set) should be passed through unchanged.
+                # (indicated by batch_size being set) keep their payload unchanged
+                # but must expose the new TensorDict-facing batch metadata.
                 # For other ops (data ops like zero_), apply the function normally.
                 if _is_unbatched(item) and batch_size is not None:
-                    item_trsf = item
+                    item_trsf = item._with_batch_size(batch_size)
                 else:
                     _others = [
                         _other._get_str(key, default=default) for _other in others
@@ -1735,7 +1736,7 @@ class TensorDict(TensorDictBase):
         source = {}
         for key, item in self.items():
             if _is_unbatched(item):
-                source[key] = item
+                source[key] = item._with_batch_size(batch_size)
             elif isinstance(item, TensorDict):
                 # this is the simplest case, we can pre-compute the batch size easily
                 new_batch_size = batch_size + item.batch_size[batch_dims:]
@@ -1837,7 +1838,11 @@ class TensorDict(TensorDictBase):
             if _is_unbatched(val):
                 for td in tds:
                     td._set_str(
-                        key, val, validated=True, inplace=False, non_blocking=False
+                        key,
+                        val._with_batch_size(batch_size),
+                        validated=True,
+                        inplace=False,
+                        non_blocking=False,
                     )
                 return
             unbound = (
@@ -1900,6 +1905,10 @@ class TensorDict(TensorDictBase):
         splits = [
             {k: v[ss] for k, v in splits.items()} for ss in range(len(batch_sizes))
         ]
+        for split, bsz in _zip_strict(splits, batch_sizes):
+            for key, value in split.items():
+                if _is_unbatched(value):
+                    split[key] = value._with_batch_size(bsz)
         device = self.device
         is_shared = self._is_shared
         is_memmap = self._is_memmap
@@ -1943,6 +1952,10 @@ class TensorDict(TensorDictBase):
         splits = [
             {k: v[ss] for k, v in splits.items()} for ss in range(len(batch_sizes))
         ]
+        for split, bsz in _zip_strict(splits, batch_sizes):
+            for key, value in split.items():
+                if _is_unbatched(value):
+                    split[key] = value._with_batch_size(bsz)
         device = self.device
         is_shared = self._is_shared
         is_memmap = self._is_memmap
@@ -1969,16 +1982,15 @@ class TensorDict(TensorDictBase):
             mask_expand = mask_expand.squeeze(-1)
             if mndim == mask_expand.ndimension():  # no more squeeze
                 break
-        for key, value in self.items():
-            if _is_unbatched(value):
-                d[key] = value
-            else:
-                d[key] = value[mask_expand]
         dim = int(mask.sum().item())
         other_dim = self.shape[mask.ndim :]
-        return TensorDict(
-            device=self.device, source=d, batch_size=torch.Size([dim, *other_dim])
-        )
+        batch_size = torch.Size([dim, *other_dim])
+        for key, value in self.items():
+            if _is_unbatched(value):
+                d[key] = value._with_batch_size(batch_size)
+            else:
+                d[key] = value[mask_expand]
+        return TensorDict(device=self.device, source=d, batch_size=batch_size)
 
     def _view(
         self,

--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -209,7 +209,7 @@ def _gather(
 
     def _process_gather_value(value):
         if _is_unbatched(value):
-            return value
+            return value._with_batch_size(index.shape)
         return _gather_tensor(value)
 
     if out is None:
@@ -229,7 +229,13 @@ def _gather(
         )
     for key, value in input.items(is_leaf=_is_leaf_nontensor):
         if _is_unbatched(value):
-            out._set_str(key, value, validated=True, inplace=False, non_blocking=False)
+            out._set_str(
+                key,
+                value._with_batch_size(out.batch_size),
+                validated=True,
+                inplace=False,
+                non_blocking=False,
+            )
         else:
             _gather_tensor(value, out, key)
     return out
@@ -773,9 +779,11 @@ def _stack(
                     return _stack_uninit_params(values, dim)
                 if is_tensor:
                     if _is_unbatched(values[0]):
-                        return type(values[0])._stack_non_tensor(
-                            values, dim
-                        )._with_batch_size(result_batch_size)
+                        return (
+                            type(values[0])
+                            ._stack_non_tensor(values, dim)
+                            ._with_batch_size(result_batch_size)
+                        )
                     return torch.stack(values, dim)
                 with (
                     _ErrorInteceptor(

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -11311,7 +11311,16 @@ class TensorDictBase(MutableMapping, TensorCollection):
         keys = list(self.keys())
         for key in keys:
             leaf = self._get_str(key, default=None)
-            if leaf is None or _is_unbatched(leaf):
+            if leaf is None:
+                continue
+            if _is_unbatched(leaf):
+                if new_batch_size is not None and leaf.batch_size != new_batch_size:
+                    self._set_str(
+                        key,
+                        leaf._with_batch_size(new_batch_size),
+                        validated=True,
+                        inplace=False,
+                    )
                 continue
             if _is_tensor_collection(type(leaf)):
                 nested_fn(leaf)
@@ -14164,6 +14173,8 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 if _device_recorder.marked and device.type != "cuda":
                     _device_recorder.record_transfer(device)
                 value = value.to(device, non_blocking=non_blocking)
+            if value.batch_size != self.batch_size:
+                value = value._with_batch_size(self.batch_size)
             return value
         batch_size = self.batch_size
         if check_shape and _shape(value)[: self.batch_dims] != batch_size:
@@ -14226,6 +14237,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
             if _device_recorder.marked and device.type != "cuda":
                 _device_recorder.record_transfer(device)
             value = value.to(device, non_blocking=non_blocking)
+        if _is_unbatched(value):
+            if value.batch_size != self.batch_size:
+                value = value._with_batch_size(self.batch_size)
+            return value
         return value
 
     def _validate_value_devicefree(
@@ -14257,6 +14272,8 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 ) from err
             is_tc = _is_tensor_collection(cls)
         if _is_unbatched(value):
+            if value.batch_size != self.batch_size:
+                value = value._with_batch_size(self.batch_size)
             return value
 
         batch_size = self.batch_size
@@ -14312,6 +14329,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
                     f"TensorDict conversion only supports tensorclasses, tensordicts,"
                     f" numeric scalars and tensors. Got {type(value)}"
                 ) from err
+        if _is_unbatched(value):
+            if value.batch_size != self.batch_size:
+                value = value._with_batch_size(self.batch_size)
+            return value
         return value
 
     def __enter__(self):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -1271,6 +1271,431 @@ def _get_leaf_tensordict(
     return tensordict, key[0]
 
 
+class _TensorDictPropertyError(RuntimeError):
+    """Raised when recursive TensorDict metadata validation fails."""
+
+    pass
+
+
+def _check_recursive_properties(
+    tensordict: T,
+    *,
+    batch_size: bool = True,
+    shape: bool = True,
+    device: bool = True,
+    lock: bool = True,
+    names: bool = True,
+    requires_grad: bool | None = None,
+    is_shared: bool | None = None,
+    is_memmap: bool | None = None,
+    allow_none: bool = False,
+    include_non_tensor: bool = True,
+    include_unbatched: bool = True,
+    strict: bool = True,
+    raise_exception: bool = True,
+) -> bool:
+    """Recursively validates TensorDict metadata.
+
+    This private checker is intended for tests and debugging. It walks the
+    logical TensorDict tree and verifies that node metadata and leaf metadata
+    are consistent with their parent context. The function is deliberately
+    conservative: callers can disable individual checks when a test is about a
+    known special case.
+    """
+    from tensordict.base import _is_tensor_collection
+
+    if not _is_tensor_collection(type(tensordict)):
+        raise TypeError(
+            "Expected a TensorDictBase or tensorclass instance, "
+            f"got {type(tensordict)}."
+        )
+
+    _MISSING = object()
+    errors = []
+
+    def _path_str(path):
+        if not path:
+            return "<root>"
+        return repr(path)
+
+    def _type_name(obj):
+        return type(obj).__name__
+
+    def _append_key(path, key):
+        key = _unravel_key_to_tuple(key)
+        if key:
+            return path + key
+        return path + (key,)
+
+    def _add_error(path, message):
+        errors.append(f"{message} at key {_path_str(path)}.")
+
+    def _read_attr(obj, attr, path):
+        try:
+            value = getattr(obj, attr)
+        except Exception as err:
+            _add_error(
+                path,
+                f"Could not read {attr} from {_type_name(obj)}: {err}",
+            )
+            return _MISSING
+        return value
+
+    def _read_call(obj, name, path):
+        try:
+            value = getattr(obj, name)()
+        except Exception as err:
+            _add_error(
+                path,
+                f"Could not call {name} on {_type_name(obj)}: {err}",
+            )
+            return _MISSING
+        return value
+
+    def _as_size(value, path, label):
+        if value is _MISSING:
+            return _MISSING
+        if value is None and allow_none:
+            return value
+        try:
+            return torch.Size(value)
+        except Exception as err:
+            _add_error(
+                path, f"Could not convert {label}={value!r} to torch.Size: {err}"
+            )
+            return _MISSING
+
+    def _same_size(first, second):
+        return tuple(first) == tuple(second)
+
+    def _has_batch_prefix(child_size, parent_size):
+        if len(child_size) < len(parent_size):
+            return False
+        return _same_size(child_size[: len(parent_size)], parent_size)
+
+    def _check_expected_bool(value, expected, path, label):
+        if value is _MISSING:
+            return
+        if value is None and allow_none:
+            return
+        if value is None:
+            _add_error(path, f"{label} mismatch: expected {expected}, got None")
+            return
+        if bool(value) != expected:
+            _add_error(path, f"{label} mismatch: expected {expected}, got {value}")
+
+    def _leaf_is_memmap(value):
+        try:
+            from tensordict.memmap import MemoryMappedTensor
+        except ImportError:
+            return False
+        return isinstance(value, MemoryMappedTensor)
+
+    def _check_node_metadata(node, path, parent_metadata):
+        node_batch_size = _MISSING
+        node_device = _MISSING
+        node_lock = _MISSING
+        node_names = _MISSING
+
+        if batch_size or shape or names:
+            node_batch_size = _as_size(
+                _read_attr(node, "batch_size", path), path, "batch_size"
+            )
+            if (
+                batch_size
+                and node_batch_size is not _MISSING
+                and node_batch_size is not None
+            ):
+                batch_dims = _read_attr(node, "batch_dims", path)
+                if batch_dims is not _MISSING and batch_dims is not None:
+                    if batch_dims != len(node_batch_size):
+                        _add_error(
+                            path,
+                            "Batch-dims mismatch: "
+                            f"batch_dims={batch_dims}, batch_size={node_batch_size}",
+                        )
+
+        if shape:
+            node_shape = _as_size(_read_attr(node, "shape", path), path, "shape")
+            if (
+                node_shape is not _MISSING
+                and node_shape is not None
+                and node_batch_size is not _MISSING
+                and node_batch_size is not None
+                and not _same_size(node_shape, node_batch_size)
+            ):
+                _add_error(
+                    path,
+                    f"Shape mismatch: shape={node_shape}, batch_size={node_batch_size}",
+                )
+
+        if device:
+            node_device = _read_attr(node, "device", path)
+            parent_device = parent_metadata.get("device")
+            if (
+                parent_device not in (None, _MISSING)
+                and node_device not in (None, _MISSING)
+                and torch.device(node_device) != torch.device(parent_device)
+            ):
+                _add_error(
+                    path,
+                    "Device mismatch: "
+                    f"parent device={parent_device}, child device={node_device}",
+                )
+
+        if lock:
+            node_lock = _read_attr(node, "is_locked", path)
+            parent_lock = parent_metadata.get("lock")
+            if (
+                parent_lock is not _MISSING
+                and node_lock is not _MISSING
+                and parent_lock is not None
+                and node_lock is not None
+            ):
+                if bool(parent_lock) and not bool(node_lock):
+                    _add_error(
+                        path,
+                        "Lock mismatch: "
+                        f"parent is_locked={parent_lock}, child is_locked={node_lock}",
+                    )
+                elif strict and bool(node_lock) != bool(parent_lock):
+                    _add_error(
+                        path,
+                        "Lock mismatch: "
+                        f"parent is_locked={parent_lock}, child is_locked={node_lock}",
+                    )
+
+        if names:
+            node_names = _read_attr(node, "names", path)
+            if (
+                node_names is not _MISSING
+                and node_names is not None
+                and node_batch_size is not _MISSING
+                and node_batch_size is not None
+            ):
+                if len(node_names) != len(node_batch_size):
+                    _add_error(
+                        path,
+                        "Names mismatch: "
+                        f"batch_size={node_batch_size}, names={node_names}",
+                    )
+                parent_names = parent_metadata.get("names")
+                parent_batch_size = parent_metadata.get("batch_size")
+                if (
+                    parent_names not in (None, _MISSING)
+                    and parent_batch_size not in (None, _MISSING)
+                    and len(node_names) >= len(parent_names)
+                ):
+                    node_prefix = tuple(node_names[: len(parent_names)])
+                    parent_prefix = tuple(parent_names)
+                    if strict:
+                        names_match = node_prefix == parent_prefix
+                    else:
+                        names_match = all(
+                            parent_name is None or child_name == parent_name
+                            for child_name, parent_name in _zip_strict(
+                                node_prefix, parent_prefix
+                            )
+                        )
+                    if not names_match:
+                        _add_error(
+                            path,
+                            "Names mismatch: "
+                            f"parent names={parent_names}, child names={node_names}",
+                        )
+
+        if parent_metadata.get("batch_size") not in (None, _MISSING):
+            parent_batch_size = parent_metadata["batch_size"]
+            if (
+                batch_size
+                and node_batch_size is not _MISSING
+                and node_batch_size is not None
+                and not _has_batch_prefix(node_batch_size, parent_batch_size)
+            ):
+                _add_error(
+                    path,
+                    "Batch-size mismatch: "
+                    f"parent batch_size={parent_batch_size}, "
+                    f"child batch_size={node_batch_size}, "
+                    f"child type={_type_name(node)}",
+                )
+
+        if is_shared is not None:
+            _check_expected_bool(
+                _read_call(node, "is_shared", path),
+                is_shared,
+                path,
+                "is_shared",
+            )
+        if is_memmap is not None:
+            _check_expected_bool(
+                _read_call(node, "is_memmap", path),
+                is_memmap,
+                path,
+                "is_memmap",
+            )
+
+        return {
+            "batch_size": node_batch_size,
+            "device": node_device,
+            "lock": node_lock,
+            "names": node_names,
+        }
+
+    def _check_leaf_common(value, path, parent_metadata):
+        parent_device = parent_metadata.get("device")
+        if device and parent_device not in (None, _MISSING):
+            leaf_device = _read_attr(value, "device", path)
+            if leaf_device not in (None, _MISSING) and torch.device(
+                leaf_device
+            ) != torch.device(parent_device):
+                _add_error(
+                    path,
+                    "Device mismatch: "
+                    f"parent device={parent_device}, leaf device={leaf_device}",
+                )
+
+        if requires_grad is not None:
+            grad = _read_attr(value, "requires_grad", path)
+            _check_expected_bool(grad, requires_grad, path, "requires_grad")
+
+        if is_shared is not None:
+            try:
+                shared = _is_shared(value)
+            except Exception as err:
+                _add_error(
+                    path,
+                    f"Could not read is_shared from {_type_name(value)}: {err}",
+                )
+            else:
+                _check_expected_bool(shared, is_shared, path, "is_shared")
+
+        if is_memmap is not None:
+            _check_expected_bool(_leaf_is_memmap(value), is_memmap, path, "is_memmap")
+
+    def _check_regular_tensor_leaf(value, path, parent_metadata):
+        parent_batch_size = parent_metadata.get("batch_size")
+        if (batch_size or shape) and parent_batch_size not in (None, _MISSING):
+            leaf_shape = _as_size(_read_attr(value, "shape", path), path, "shape")
+            if (
+                leaf_shape is not _MISSING
+                and leaf_shape is not None
+                and not _has_batch_prefix(leaf_shape, parent_batch_size)
+            ):
+                _add_error(
+                    path,
+                    "Shape mismatch: "
+                    f"parent batch_size={parent_batch_size}, leaf shape={leaf_shape}, "
+                    f"leaf type={_type_name(value)}",
+                )
+        _check_leaf_common(value, path, parent_metadata)
+
+    def _check_unbatched_leaf(value, path, parent_metadata):
+        if not include_unbatched:
+            return
+        parent_batch_size = parent_metadata.get("batch_size")
+        leaf_batch_size = _as_size(
+            _read_attr(value, "batch_size", path), path, "batch_size"
+        )
+        if (
+            batch_size
+            and parent_batch_size not in (None, _MISSING)
+            and leaf_batch_size not in (None, _MISSING)
+            and not _same_size(leaf_batch_size, parent_batch_size)
+            and not (allow_none and len(leaf_batch_size) == 0)
+        ):
+            _add_error(
+                path,
+                "Batch-size mismatch: "
+                f"parent batch_size={parent_batch_size}, "
+                f"leaf batch_size={leaf_batch_size}, "
+                f"leaf type={_type_name(value)}",
+            )
+        _check_leaf_common(value, path, parent_metadata)
+
+    def _check_non_tensor_leaf(value, path, parent_metadata):
+        if not include_non_tensor:
+            return
+        parent_batch_size = parent_metadata.get("batch_size")
+        leaf_batch_size = _as_size(
+            _read_attr(value, "batch_size", path), path, "batch_size"
+        )
+        if (
+            batch_size
+            and parent_batch_size not in (None, _MISSING)
+            and leaf_batch_size not in (None, _MISSING)
+            and not _same_size(leaf_batch_size, parent_batch_size)
+            and not (allow_none and len(leaf_batch_size) == 0)
+        ):
+            _add_error(
+                path,
+                "Batch-size mismatch: "
+                f"parent batch_size={parent_batch_size}, "
+                f"leaf batch_size={leaf_batch_size}, "
+                f"leaf type={_type_name(value)}",
+            )
+        if shape:
+            leaf_shape = _as_size(_read_attr(value, "shape", path), path, "shape")
+            if (
+                leaf_shape not in (None, _MISSING)
+                and leaf_batch_size not in (None, _MISSING)
+                and not _same_size(leaf_shape, leaf_batch_size)
+            ):
+                _add_error(
+                    path,
+                    f"Shape mismatch: shape={leaf_shape}, batch_size={leaf_batch_size}",
+                )
+        _check_leaf_common(value, path, parent_metadata)
+
+    def _visit_leaf(value, path, parent_metadata):
+        if _is_unbatched(value):
+            _check_unbatched_leaf(value, path, parent_metadata)
+        elif is_non_tensor(value):
+            _check_non_tensor_leaf(value, path, parent_metadata)
+        elif isinstance(value, torch.Tensor):
+            _check_regular_tensor_leaf(value, path, parent_metadata)
+        elif strict:
+            _add_error(path, f"Unsupported leaf type {_type_name(value)}")
+
+    def _visit_node(node, path, parent_metadata):
+        node_metadata = _check_node_metadata(node, path, parent_metadata)
+        try:
+            items = tuple(node.items(include_nested=False))
+        except Exception as err:
+            _add_error(path, f"Could not iterate over {_type_name(node)} items: {err}")
+            return
+        for key, value in items:
+            child_path = _append_key(path, key)
+            if is_non_tensor(value):
+                _check_non_tensor_leaf(value, child_path, node_metadata)
+            elif _is_tensor_collection(type(value)):
+                _visit_node(value, child_path, node_metadata)
+            else:
+                _visit_leaf(value, child_path, node_metadata)
+
+    _visit_node(
+        tensordict,
+        (),
+        {
+            "batch_size": _MISSING,
+            "device": _MISSING,
+            "lock": _MISSING,
+            "names": _MISSING,
+        },
+    )
+    if errors:
+        if raise_exception:
+            formatted_errors = "\n".join(
+                f"{idx}. {error}" for idx, error in enumerate(errors, 1)
+            )
+            raise _TensorDictPropertyError(
+                "TensorDict recursive property check failed with "
+                f"{len(errors)} error(s):\n{formatted_errors}"
+            )
+        return False
+    return True
+
+
 def assert_close(
     actual: T,
     expected: T,

--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -7,6 +7,7 @@ import pathlib
 import shutil
 import tempfile
 import warnings
+from functools import wraps
 
 import numpy as np
 import torch
@@ -25,7 +26,7 @@ from tensordict._torch_func import _stack as stack_td
 from tensordict.base import is_tensor_collection
 from tensordict.nn.params import TensorDictParams
 from tensordict.persistent import _has_h5 as _has_h5py
-from tensordict.utils import set_lazy_legacy
+from tensordict.utils import _check_recursive_properties, set_lazy_legacy
 
 
 def prod(sequence):
@@ -441,6 +442,29 @@ class _NestedTypedTD(TypedTensorDict):
     b: torch.Tensor
     c: torch.Tensor
     my_nested_td: TensorDict
+
+
+def _wrap_checked_tensordict_factory(name):
+    factory = getattr(TestTensorDictsBase, name)
+
+    @classmethod
+    @wraps(factory.__func__)
+    def checked_factory(cls, device, _factory=factory):
+        td = _factory.__func__(cls, device)
+        _check_recursive_properties(td)
+        return td
+
+    return checked_factory
+
+
+for _td_name in dict.fromkeys(
+    td_name for td_name, _ in TestTensorDictsBase.TYPES_DEVICES
+):
+    setattr(
+        TestTensorDictsBase,
+        _td_name,
+        _wrap_checked_tensordict_factory(_td_name),
+    )
 
 
 def expand_list(list_of_tensors, *dims):

--- a/test/tensorclass/test_tensorclass.py
+++ b/test/tensorclass/test_tensorclass.py
@@ -46,6 +46,7 @@ from tensordict._lazy import _PermutedTensorDict, _ViewedTensorDict
 from tensordict._td import lazy_stack
 from tensordict.base import _GENERIC_NESTED_ERR
 from tensordict.tensorclass import from_dataclass
+from tensordict.utils import _check_recursive_properties
 
 from torch import Tensor
 
@@ -251,6 +252,37 @@ class TCStrings:
 
 
 class TestTensorClass:
+    def test_recursive_properties_common_ops(self):
+        @tensorclass
+        class MyDataNested:
+            X: torch.Tensor
+            z: str
+            y: "MyDataNested" = None
+
+        X = torch.ones(3, 4, 5)
+        z = "test_tensorclass"
+        batch_size = [3, 4]
+        data_nest = MyDataNested(X=X, z=z, batch_size=batch_size)
+        data = MyDataNested(X=X, y=data_nest, z=z, batch_size=batch_size)
+
+        def check(result):
+            _check_recursive_properties(result)
+            return result
+
+        check(data)
+        check(data._tensordict)
+        check(data.clone())
+        check(data[:2])
+        check(data.reshape(-1))
+        check(data.apply(lambda x: x))
+        check(data.unsqueeze(0))
+        check(torch.stack([data, data.clone()], 0))
+        check(LazyStackedTensorDict.lazy_stack([data, data.clone()], 0))
+
+        updated = data.clone()
+        updated.X = torch.zeros_like(updated.X)
+        check(updated)
+
     def test_get_default(self):
         @tensorclass
         class Data:

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -37,6 +37,7 @@ from tensordict.functional import pad
 from tensordict.nn import TensorDictParams
 from tensordict.tensorclass import NonTensorData, NonTensorDataBase
 from tensordict.utils import (
+    _check_recursive_properties,
     _getitem_batch_size,
     _LOCK_ERROR,
     assert_allclose_td,
@@ -156,6 +157,49 @@ def _compare_tensors_identity(td0, td1):
     TestTensorDictsBase.TYPES_DEVICES,
 )
 class TestTensorDicts(TestTensorDictsBase):
+    def test_recursive_properties_common_ops(self, td_name, device):
+        torch.manual_seed(1)
+        td = getattr(self, td_name)(device)
+
+        def check(result):
+            if isinstance(result, (tuple, list)):
+                for item in result:
+                    check(item)
+            elif isinstance(result, TensorDictBase):
+                _check_recursive_properties(result)
+            return result
+
+        check(td.clone())
+        check(td.to_tensordict(retain_none=True))
+        check(td.select(*list(td.keys()), strict=False))
+        check(td.exclude())
+        check(td.apply(lambda x: x))
+        check(td[:])
+        check(td[0])
+        check(td.reshape(-1))
+        check(torch.stack([td, td.contiguous()], 0))
+        check(torch.cat([td, td.clone()], 0))
+        check(td.unbind(0))
+        check(td.split(1, 0))
+        check(td.chunk(2, 0))
+
+        if td_name not in (
+            "sub_td",
+            "sub_td2",
+            "permute_td",
+            "unsqueezed_td",
+            "squeezed_td",
+        ):
+            check(td.unsqueeze(0))
+            check(td.permute(*range(td.batch_dims - 1, -1, -1)))
+
+        td_updated = td.clone()
+        with td_updated.unlock_():
+            td_updated.update(
+                {"recursive_check": torch.zeros(td_updated.shape, device=device)}
+            )
+        check(td_updated)
+
     @pytest.mark.skipif(PYTORCH_TEST_FBCODE, reason="vmap now working in fbcode")
     @pytest.mark.parametrize("nested", [False, True])
     def test_add_batch_dim_cache(self, td_name, device, nested):

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -170,9 +170,13 @@ class TestTensorDicts(TestTensorDictsBase):
             return result
 
         check(td.clone())
-        check(td.to_tensordict(retain_none=True))
-        check(td.select(*list(td.keys()), strict=False))
-        check(td.exclude())
+        dense_td = check(td.to_tensordict(retain_none=True))
+        if td_name == "td_h5":
+            check(dense_td.select(*list(dense_td.keys()), strict=False))
+            check(dense_td.exclude())
+        else:
+            check(td.select(*list(td.keys()), strict=False))
+            check(td.exclude())
         check(td.apply(lambda x: x))
         check(td[:])
         check(td[0])

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -171,21 +171,18 @@ class TestTensorDicts(TestTensorDictsBase):
 
         check(td.clone())
         dense_td = check(td.to_tensordict(retain_none=True))
-        if td_name == "td_h5":
-            check(dense_td.select(*list(dense_td.keys()), strict=False))
-            check(dense_td.exclude())
-        else:
-            check(td.select(*list(td.keys()), strict=False))
-            check(td.exclude())
-        check(td.apply(lambda x: x))
-        check(td[:])
-        check(td[0])
-        check(td.reshape(-1))
-        check(torch.stack([td, td.contiguous()], 0))
-        check(torch.cat([td, td.clone()], 0))
-        check(td.unbind(0))
-        check(td.split(1, 0))
-        check(td.chunk(2, 0))
+        op_td = dense_td if td_name == "td_h5" else td
+        check(op_td.select(*list(op_td.keys()), strict=False))
+        check(op_td.exclude())
+        check(op_td.apply(lambda x: x))
+        check(op_td[:])
+        check(op_td[0])
+        check(op_td.reshape(-1))
+        check(torch.stack([op_td, op_td.contiguous()], 0))
+        check(torch.cat([op_td, op_td.clone()], 0))
+        check(op_td.unbind(0))
+        check(op_td.split(1, 0))
+        check(op_td.chunk(2, 0))
 
         if td_name not in (
             "sub_td",
@@ -194,10 +191,10 @@ class TestTensorDicts(TestTensorDictsBase):
             "unsqueezed_td",
             "squeezed_td",
         ):
-            check(td.unsqueeze(0))
-            check(td.permute(*range(td.batch_dims - 1, -1, -1)))
+            check(op_td.unsqueeze(0))
+            check(op_td.permute(*range(op_td.batch_dims - 1, -1, -1)))
 
-        td_updated = td.clone()
+        td_updated = op_td.clone()
         with td_updated.unlock_():
             td_updated.update(
                 {"recursive_check": torch.zeros(td_updated.shape, device=device)}

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -1162,7 +1162,10 @@ class TestTensorDicts(TestTensorDictsBase):
             index = index[idx]
             index = index.cumsum(dim=other_dim) - 1
             td_gather = torch.gather(td, dim=dim, index=index)
-            assert td_gather.get("unbatched") is original_unbatched
+            assert (
+                td_gather.get("unbatched").data_ptr() == original_unbatched.data_ptr()
+            )
+            assert td_gather.get("unbatched").batch_size == td_gather.batch_size
             return
         index = torch.ones(td.shape, device=td.device, dtype=torch.long)
         other_dim = dim + index.ndim if dim < 0 else dim
@@ -3307,7 +3310,11 @@ class TestTensorDicts(TestTensorDictsBase):
             else:
                 tds = td.split(2, dim)
             for split_td in tds:
-                assert split_td.get("unbatched") is original_unbatched
+                assert (
+                    split_td.get("unbatched").data_ptr()
+                    == original_unbatched.data_ptr()
+                )
+                assert split_td.get("unbatched").batch_size == split_td.batch_size
             return
         t = torch.zeros(()).expand(td.shape)
         for dim in range(td.batch_dims):
@@ -3856,7 +3863,8 @@ class TestTensorDicts(TestTensorDictsBase):
         if td_name == "td_with_unbatched":
             original_unbatched = td.get("unbatched")
             tdt = td.transpose(0, 1)
-            assert tdt.get("unbatched") is original_unbatched
+            assert tdt.get("unbatched").data_ptr() == original_unbatched.data_ptr()
+            assert tdt.get("unbatched").batch_size == tdt.batch_size
             return
         tdt = td.transpose(0, 1)
         assert tdt.shape == torch.Size([td.shape[1], td.shape[0], *td.shape[2:]])
@@ -3893,7 +3901,8 @@ class TestTensorDicts(TestTensorDictsBase):
         if td_name == "td_with_unbatched":
             original_unbatched = td.get("unbatched")
             tdt = td.transpose(0, 1)
-            assert tdt.get("unbatched") is original_unbatched
+            assert tdt.get("unbatched").data_ptr() == original_unbatched.data_ptr()
+            assert tdt.get("unbatched").batch_size == tdt.batch_size
             return
         is_lazy = td_name in (
             "sub_td",
@@ -3964,7 +3973,8 @@ class TestTensorDicts(TestTensorDictsBase):
         if td_name == "td_with_unbatched":
             original_unbatched = td.get("unbatched")
             td_moved = td.movedim(0, -1)
-            assert td_moved.get("unbatched") is original_unbatched
+            assert td_moved.get("unbatched").data_ptr() == original_unbatched.data_ptr()
+            assert td_moved.get("unbatched").batch_size == td_moved.batch_size
             return
         is_lazy = td_name in (
             "sub_td",

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -29,7 +29,13 @@ from tensordict import (
     UnbatchedTensor,
 )
 from tensordict.tensorclass import MetaData, NonTensorData, NonTensorStack
-from tensordict.utils import _pass_through, is_non_tensor, LinkedList, set_list_to_stack
+from tensordict.utils import (
+    _check_recursive_properties,
+    _pass_through,
+    is_non_tensor,
+    LinkedList,
+    set_list_to_stack,
+)
 from torch import multiprocessing as mp
 
 if os.getenv("PYTORCH_TEST_FBCODE"):
@@ -1062,49 +1068,55 @@ class TestUnbatchedTensor:
             b=torch.randn(3),
             batch_size=(3,),
         )
+
+        def assert_unbatched_metadata(result):
+            assert result["a"].data_ptr() == td["a"].data_ptr()
+            assert result["a"].batch_size == result.batch_size
+            _check_recursive_properties(result)
+
         # get item
-        assert td[0]["a"] is td["a"]
-        assert td[:]["a"] is td["a"]
+        assert_unbatched_metadata(td[0])
+        assert_unbatched_metadata(td[:])
 
         unbind = td.unbind(0)[0]
-        assert unbind["a"] is td["a"]
         assert unbind.batch_size == ()
+        assert_unbatched_metadata(unbind)
 
         split = td.split(1)[0]
-        assert split["a"] is td["a"]
         assert split.batch_size == (1,)
-        assert td.split((2, 1))[0]["a"] is td["a"]
+        assert_unbatched_metadata(split)
+        assert_unbatched_metadata(td.split((2, 1))[0])
 
         reshape = td.reshape((1, 3))
-        assert reshape["a"] is td["a"]
         assert reshape.batch_size == (1, 3)
+        assert_unbatched_metadata(reshape)
         transpose = reshape.transpose(0, 1)
-        assert transpose["a"] is td["a"]
         assert transpose.batch_size == (3, 1)
+        assert_unbatched_metadata(transpose)
         permute = reshape.permute(1, 0)
-        assert permute["a"] is td["a"]
         assert permute.batch_size == (3, 1)
+        assert_unbatched_metadata(permute)
         squeeze = reshape.squeeze()
-        assert squeeze["a"] is td["a"]
         assert squeeze.batch_size == (3,)
+        assert_unbatched_metadata(squeeze)
 
         view = td.view((1, 3))
-        assert view["a"] is td["a"]
         assert view.batch_size == (1, 3)
+        assert_unbatched_metadata(view)
         unsqueeze = td.unsqueeze(0)
-        assert unsqueeze["a"] is td["a"]
         assert unsqueeze.batch_size == (1, 3)
+        assert_unbatched_metadata(unsqueeze)
         gather = td.gather(0, torch.tensor((0,)))
-        assert gather["a"] is td["a"]
         assert gather.batch_size == (1,)
+        assert_unbatched_metadata(gather)
 
         unflatten = td.unflatten(0, (1, 3))
-        assert unflatten["a"] is td["a"]
         assert unflatten.batch_size == (1, 3)
+        assert_unbatched_metadata(unflatten)
 
         flatten = unflatten.flatten(0, 1)
-        assert flatten["a"] is td["a"]
         assert flatten.batch_size == (3,)
+        assert_unbatched_metadata(flatten)
 
     def test_unbatched_torch_func(self):
         td = TensorDict(
@@ -1112,24 +1124,43 @@ class TestUnbatchedTensor:
             b=torch.randn(3),
             batch_size=(3,),
         )
-        assert torch.unbind(td, 0)[0]["a"] is td["a"]
+        unbound = torch.unbind(td, 0)[0]
+        assert unbound["a"].data_ptr() == td["a"].data_ptr()
+        assert unbound["a"].batch_size == unbound.batch_size
+        _check_recursive_properties(unbound)
         stacked = torch.stack([td, td], 0)
         assert stacked[0]["a"].data_ptr() == td["a"].data_ptr()
         assert stacked["a"].batch_size == torch.Size([2, 3])
+        _check_recursive_properties(stacked)
         catted = torch.cat([td, td], 0)
         assert catted[0]["a"].data_ptr() == td["a"].data_ptr()
         assert catted["a"].batch_size == torch.Size([6])
+        _check_recursive_properties(catted)
         assert (torch.ones_like(td)["a"] == 1).all()
-        assert torch.unsqueeze(td, 0)["a"] is td["a"]
-        assert torch.squeeze(td)["a"] is td["a"]
+        unsqueezed = torch.unsqueeze(td, 0)
+        assert unsqueezed["a"].data_ptr() == td["a"].data_ptr()
+        assert unsqueezed["a"].batch_size == unsqueezed.batch_size
+        _check_recursive_properties(unsqueezed)
+        squeezed = torch.squeeze(td)
+        assert squeezed["a"].data_ptr() == td["a"].data_ptr()
+        assert squeezed["a"].batch_size == squeezed.batch_size
+        _check_recursive_properties(squeezed)
         unflatten = torch.unflatten(td, 0, (1, 3))
-        assert unflatten["a"] is td["a"]
+        assert unflatten["a"].data_ptr() == td["a"].data_ptr()
+        assert unflatten["a"].batch_size == unflatten.batch_size
+        _check_recursive_properties(unflatten)
         flatten = torch.flatten(unflatten, 0, 1)
-        assert flatten["a"] is td["a"]
+        assert flatten["a"].data_ptr() == td["a"].data_ptr()
+        assert flatten["a"].batch_size == flatten.batch_size
+        _check_recursive_properties(flatten)
         permute = torch.permute(unflatten, (1, 0))
-        assert permute["a"] is td["a"]
+        assert permute["a"].data_ptr() == td["a"].data_ptr()
+        assert permute["a"].batch_size == permute.batch_size
+        _check_recursive_properties(permute)
         transpose = torch.transpose(unflatten, 1, 0)
-        assert transpose["a"] is td["a"]
+        assert transpose["a"].data_ptr() == td["a"].data_ptr()
+        assert transpose["a"].batch_size == transpose.batch_size
+        _check_recursive_properties(transpose)
 
     def test_unbatched_other_ops(self):
         td = TensorDict(
@@ -1172,6 +1203,7 @@ class TestUnbatchedTensor:
             warnings.simplefilter("error")
             stacked = torch.stack([td1, td2])
         assert stacked["ub"].data_ptr() == data.data_ptr()
+        _check_recursive_properties(stacked)
 
     def test_unbatched_stack_different_data_warns(self):
         td1 = TensorDict(
@@ -1209,7 +1241,8 @@ class TestUnbatchedTensor:
         assert result["ub"].batch_size == result.batch_size
         assert result["ub"].shape == torch.Size([])
         assert result["ub"].data_ptr() == data.data_ptr()
-        assert all(item["ub"].batch_size == torch.Size([]) for item in items)
+        assert all(item["ub"].batch_size == torch.Size(batch_size) for item in items)
+        _check_recursive_properties(result)
 
     def test_unbatched_stack_out_updates_batch_size_metadata(self):
         data = torch.tensor(1)
@@ -1231,6 +1264,7 @@ class TestUnbatchedTensor:
         assert result["ub"].batch_size == torch.Size([3, 2])
         assert result["ub"].shape == torch.Size([])
         assert result["ub"].data_ptr() == data.data_ptr()
+        _check_recursive_properties(result)
 
     @pytest.mark.parametrize("with_out", [False, True])
     def test_unbatched_cat_updates_batch_size_metadata(self, with_out):
@@ -1257,6 +1291,65 @@ class TestUnbatchedTensor:
         assert result["ub"].batch_size == result.batch_size
         assert result["ub"].shape == torch.Size([])
         assert result["ub"].data_ptr() == data.data_ptr()
+        _check_recursive_properties(result)
+
+    def test_lazy_stack_unbatched_updates_batch_size_metadata(self):
+        data = torch.tensor(1)
+        items = [
+            TensorDict(
+                x=torch.zeros(2),
+                ub=UnbatchedTensor(data),
+                batch_size=[2],
+            )
+            for _ in range(3)
+        ]
+        result = lazy_stack(items, 0)
+        assert result.batch_size == torch.Size([3, 2])
+        assert result["ub"].batch_size == result.batch_size
+        assert result["ub"].shape == torch.Size([])
+        assert result["ub"].data_ptr() == data.data_ptr()
+        _check_recursive_properties(result)
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            "index",
+            "slice",
+            "gather",
+            "split",
+            "chunk",
+            "masked_select",
+        ],
+    )
+    def test_unbatched_indexing_updates_batch_size_metadata(self, op):
+        data = torch.tensor(1)
+        td = TensorDict(
+            x=torch.zeros(2, 3),
+            ub=UnbatchedTensor(data),
+            batch_size=[2, 3],
+        )
+
+        if op == "index":
+            results = (td[0],)
+        elif op == "slice":
+            results = (td[:, :2],)
+        elif op == "gather":
+            results = (td.gather(0, torch.zeros(1, 3, dtype=torch.long)),)
+        elif op == "split":
+            results = td.split(1, dim=0)
+        elif op == "chunk":
+            results = td.chunk(2, dim=0)
+        elif op == "masked_select":
+            mask = torch.tensor([[True, False, True], [False, True, False]])
+            results = (td.masked_select(mask),)
+        else:
+            raise AssertionError(op)
+
+        for result in results:
+            assert result["ub"].batch_size == result.batch_size
+            assert result["ub"].shape == torch.Size([])
+            assert result["ub"].data_ptr() == data.data_ptr()
+            _check_recursive_properties(result)
 
     @pytest.mark.skipif(PYTORCH_TEST_FBCODE, reason="vmap now working in fbcode")
     def test_unbatched_vmap(self):

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -11,6 +11,7 @@ import torch
 from _utils_internal import get_available_devices
 from tensordict import (
     lazy_stack,
+    tensorclass,
     TensorDict,
     UnbatchedTensor,
     unravel_key,
@@ -141,18 +142,51 @@ def test_make_cache_key():
     )
 
 
-def test_check_recursive_properties_valid_tree():
+@tensorclass
+class _RecursivePropertiesTensorClass:
+    tensor: torch.Tensor
+    nested: TensorDict
+    metadata: str
+
+
+def _valid_nested_recursive_properties_tree():
     td = TensorDict(
         {
             "tensor": torch.zeros(3, 2),
             "nested": TensorDict({"value": torch.ones(3, 4)}, batch_size=[3]),
-            "unbatched": UnbatchedTensor(torch.ones(2), batch_size=[3]),
         },
         batch_size=[3],
     )
     td["metadata"] = "value"
+    return td
 
-    assert _check_recursive_properties(td)
+
+def _valid_lazy_recursive_properties_tree():
+    left = _valid_nested_recursive_properties_tree()
+    right = _valid_nested_recursive_properties_tree()
+    return lazy_stack([left, right], 0)
+
+
+def _valid_tensorclass_recursive_properties_tree():
+    return _RecursivePropertiesTensorClass(
+        tensor=torch.zeros(3, 2),
+        nested=TensorDict({"value": torch.ones(3, 4)}, batch_size=[3]),
+        metadata="value",
+        batch_size=[3],
+    )
+
+
+@pytest.mark.parametrize(
+    "make_tree",
+    [
+        _valid_nested_recursive_properties_tree,
+        _valid_lazy_recursive_properties_tree,
+        _valid_tensorclass_recursive_properties_tree,
+    ],
+    ids=["nested", "lazy-stack", "tensorclass"],
+)
+def test_check_recursive_properties_valid_tree(make_tree):
+    assert _check_recursive_properties(make_tree())
 
 
 def test_check_recursive_properties_stale_unbatched_metadata():

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -9,11 +9,19 @@ import numpy as np
 import pytest
 import torch
 from _utils_internal import get_available_devices
-from tensordict import TensorDict, unravel_key, unravel_key_list
+from tensordict import (
+    lazy_stack,
+    TensorDict,
+    UnbatchedTensor,
+    unravel_key,
+    unravel_key_list,
+)
 from tensordict._C import _unravel_key_to_tuple
 from tensordict.utils import (
+    _check_recursive_properties,
     _getitem_batch_size,
     _make_cache_key,
+    _TensorDictPropertyError,
     convert_ellipsis_to_idx,
     isin,
     parse_tensor_dict_string,
@@ -131,6 +139,98 @@ def test_make_cache_key():
         (1, (2, 3), id(Q)),
         (("a", id(V)), ("b", "c"), ("d", ("e", "f"))),
     )
+
+
+def test_check_recursive_properties_valid_tree():
+    td = TensorDict(
+        {
+            "tensor": torch.zeros(3, 2),
+            "nested": TensorDict({"value": torch.ones(3, 4)}, batch_size=[3]),
+            "unbatched": UnbatchedTensor(torch.ones(2), batch_size=[3]),
+        },
+        batch_size=[3],
+    )
+    td["metadata"] = "value"
+
+    assert _check_recursive_properties(td)
+
+
+def test_check_recursive_properties_stale_unbatched_metadata():
+    td = TensorDict(
+        {
+            "tensor": torch.zeros(3),
+        },
+        batch_size=[3],
+    )
+    td._set_str(
+        "unbatched",
+        UnbatchedTensor(torch.ones(())),
+        inplace=False,
+        validated=True,
+    )
+
+    assert not _check_recursive_properties(td, raise_exception=False)
+    with pytest.raises(
+        _TensorDictPropertyError,
+        match=r"Batch-size mismatch.*\('unbatched',\)",
+    ):
+        _check_recursive_properties(td)
+
+
+def test_check_recursive_properties_device_mismatch():
+    td = TensorDict({"tensor": torch.zeros(3)}, batch_size=[3])
+    td._device = torch.device("meta")
+
+    with pytest.raises(
+        _TensorDictPropertyError,
+        match="Device mismatch: parent device=meta, leaf device=cpu",
+    ):
+        _check_recursive_properties(td)
+
+
+def test_check_recursive_properties_lock_mismatch():
+    nested = TensorDict({"value": torch.ones(3)}, batch_size=[3])
+    td = TensorDict({"nested": nested}, batch_size=[3]).lock_()
+    nested._is_locked = False
+
+    with pytest.raises(
+        _TensorDictPropertyError,
+        match=r"Lock mismatch.*\('nested',\)",
+    ):
+        _check_recursive_properties(td)
+
+
+def test_check_recursive_properties_names_mismatch():
+    td = TensorDict(
+        {
+            "tensor": torch.zeros(3),
+            "nested": TensorDict({"value": torch.ones(3)}, batch_size=[3]),
+        },
+        batch_size=[3],
+        names=["batch"],
+    )
+    td["nested"].rename_("other")
+
+    with pytest.raises(
+        _TensorDictPropertyError,
+        match=r"Names mismatch.*\('nested',\)",
+    ):
+        _check_recursive_properties(td)
+
+
+def test_check_recursive_properties_lazy_stack_unbatched_metadata():
+    data = torch.ones(())
+    td = TensorDict(
+        {
+            "tensor": torch.zeros(3),
+            "unbatched": UnbatchedTensor(data, batch_size=[3]),
+        },
+        batch_size=[3],
+    )
+    result = lazy_stack([td, td], 0)
+
+    assert result["unbatched"].batch_size == result.batch_size
+    assert _check_recursive_properties(result)
 
 
 @pytest.mark.parametrize("listtype", (list, tuple))


### PR DESCRIPTION
## Description

- Add a private `_check_recursive_properties` TensorDict utility that recursively validates node and leaf metadata, with aggregated error messages and opt-outs for batch size, shape, device, lock, names, non-tensor, and unbatched checks.
- Exercise the checker in focused utility tests, high-value `UnbatchedTensor` transformation tests, all `TestTensorDictsBase` fixture factories, a broad `TestTensorDicts` common-op sweep, and a tensorclass common-op sweep.
- Keep `UnbatchedTensor` TensorDict-facing `batch_size` metadata synchronized while preserving payload storage across construction/validation, stack/cat, lazy stack, indexing, unbind/split/chunk, gather, masked select, view/reshape/unflatten, transpose/permute/movedim, and lazy custom-op views.

## Motivation and Context

TensorDict transformations can preserve an `UnbatchedTensor` payload while changing the parent TensorDict batch shape. The payload should remain shape-independent, but the wrapper metadata exposed through TensorDict should match the current parent context so downstream checks do not observe stale batch sizes.

The checker coverage added here is deliberately broader than the patched class itself: it now runs through the centralized `TestTensorDictsBase` fixture factories plus common creation/transformation/modification paths for TensorDicts and tensorclasses. Under that broader coverage, the only real implementation bugs found in this pass were `UnbatchedTensor` TensorDict-facing metadata issues; I did not find additional class-specific invariant violations in dense TensorDict, lazy stack, persistent/memmap/HDF5-backed TensorDicts, or tensorclasses.

Concrete issues patched while adding the checker:

- `UnbatchedTensor` values inserted into a TensorDict kept empty/stale metadata instead of adopting the parent batch size.
- Lazy-stack retrieval of `UnbatchedTensor` leaves returned stale metadata, especially when source leaves had empty metadata.
- Shape/index operations (`getitem`, `unbind`, `split`, `chunk`, `gather`, `masked_select`, `view`/`reshape`, `unflatten`, `transpose`/`permute`/`movedim`, and legacy lazy custom-op views) preserved payload storage but did not refresh TensorDict-facing `batch_size` metadata.

No public API is added; the checker is private for test/debug rollout.

- [ ] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes) — no issue filed for this scoped follow-up.

## Runtime impact

Local measurements on this branch:

- Representative checker benchmark over 18 transformed TensorDicts: median `6.0 us` per checker call; all representative added checker calls together: median `0.11 ms` per pass.
- `TestTensorDictsBase` fixture checks measured locally at roughly `6.7-26.5 us` per fixture construction across representative fixture types.
- Full `test/tensordict` shard before adding centralized fixture checks: `7790 passed, 898 skipped in 13.69s`.
- Full `test/tensordict` shard after adding centralized fixture checks: `7790 passed, 898 skipped in 14.35s` (`real 14.94s`).
- Full `test/tensordict` shard after the broader common-op coverage: `7809 passed, 898 skipped in 13.94s` (`real 14.47s`). This is within local run-to-run noise; expected overhead for the full shard is under about one second.
- Focused checker tests now run as `8 passed, 24030 deselected in 1.12s`; the added tensorclass common-op coverage is included in `test/tensorclass/test_tensorclass.py` (`148 passed, 1 skipped in 2.74s`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

## Tests

- `PYTHONPATH=$PWD:$PWD/test .venv/bin/python -m pytest test/tensordict -q`
- `PYTHONPATH=$PWD:$PWD/test .venv/bin/python -m pytest test/utils/test_utils.py -k 'check_recursive_properties' -q`
- `PYTHONPATH=$PWD:$PWD/test .venv/bin/python -m pytest test/tensorclass/test_tensorclass.py -q`
- `uvx pre-commit run --files test/_utils_internal.py tensordict/base.py tensordict/_td.py tensordict/_torch_func.py tensordict/_lazy.py tensordict/utils.py test/tensordict/test_nontensor.py test/tensordict/test_methods.py test/utils/test_utils.py test/tensorclass/test_tensorclass.py`
