### PR TITLE
[BugFix] Preserve lazy cat for mixed TensorDict inputs

### DIFF
--- a/tensordict/_torch_func.py
+++ b/tensordict/_torch_func.py
@@ -433,6 +433,10 @@ def _cat(
 ) -> T:
     if not len(list_of_tensordicts):
         raise RuntimeError("list_of_tensordicts cannot be empty")
+    if any(isinstance(td, LazyStackedTensorDict) for td in list_of_tensordicts) and (
+        out is None or isinstance(out, LazyStackedTensorDict)
+    ):
+        return _lazy_cat(list_of_tensordicts, dim=dim, out=out)
 
     batch_size = list(list_of_tensordicts[0].batch_size)
     tdtype = type(list_of_tensordicts[0])
@@ -526,13 +530,33 @@ def _cat(
 
 @implements_for_lazy_td(torch.cat)
 def _lazy_cat(
-    list_of_tensordicts: Sequence[LazyStackedTensorDict],
+    list_of_tensordicts: Sequence[TensorDictBase],
     dim: int = 0,
     out: LazyStackedTensorDict | None = None,
 ) -> LazyStackedTensorDict:
     # why aren't they feeding you?
     if not len(list_of_tensordicts):
         raise RuntimeError("list_of_tensordicts cannot be empty")
+
+    if out is not None and not isinstance(out, LazyStackedTensorDict):
+        return _cat(list_of_tensordicts, dim=dim, out=out)
+
+    lazy_tds = [
+        td for td in list_of_tensordicts if isinstance(td, LazyStackedTensorDict)
+    ]
+    stack_dim = lazy_tds[0].stack_dim
+    if any((td.stack_dim != stack_dim) for td in lazy_tds):
+        raise RuntimeError("cat lazy stacked tds must have same stack dim")
+
+    if len(lazy_tds) != len(list_of_tensordicts):
+        list_of_tensordicts = [
+            (
+                td
+                if isinstance(td, LazyStackedTensorDict)
+                else _to_lazystack_for_lazy_cat(td, stack_dim)
+            )
+            for td in list_of_tensordicts
+        ]
 
     batch_size = list(list_of_tensordicts[0].batch_size)
     if dim < 0:
@@ -542,9 +566,13 @@ def _lazy_cat(
             f"dim must be in the range 0 <= dim < len(batch_size), got dim"
             f"={dim} and batch_size={batch_size}"
         )
-    stack_dim = list_of_tensordicts[0].stack_dim
-    if any((td.stack_dim != stack_dim) for td in list_of_tensordicts):
-        raise RuntimeError("cat lazy stacked tds must have same stack dim")
+    if dim != stack_dim:
+        num_stacked_tds = len(list_of_tensordicts[0].tensordicts)
+        if any(len(td.tensordicts) != num_stacked_tds for td in list_of_tensordicts):
+            raise RuntimeError(
+                "cat lazy stacked tds along a non-stack dimension requires "
+                "all inputs to have the same number of stacked tensordicts"
+            )
 
     batch_size[dim] = sum(td.batch_size[dim] for td in list_of_tensordicts)
     batch_size = torch.Size(batch_size)
@@ -568,6 +596,10 @@ def _lazy_cat(
                         new_dim,
                     )
                 )
+        if not out:
+            return _empty_lazystack_for_lazy_cat(
+                list_of_tensordicts[0], batch_size, stack_dim
+            )
         return type(list_of_tensordicts[0])(*out, stack_dim=stack_dim)
     else:
         if not isinstance(out, LazyStackedTensorDict):
@@ -595,6 +627,46 @@ def _lazy_cat(
                 )
 
         return out
+
+
+def _to_lazystack_for_lazy_cat(
+    td: TensorDictBase,
+    stack_dim: int,
+) -> LazyStackedTensorDict:
+    if stack_dim >= td.batch_dims:
+        raise RuntimeError(
+            "mixed lazy/plain cat requires non-lazy TensorDict inputs to have "
+            "the lazy stack dimension in their batch size, got "
+            f"stack_dim={stack_dim} and batch_size={td.batch_size}"
+        )
+    if td.batch_size[stack_dim] == 0:
+        return _empty_lazystack_for_lazy_cat(td, td.batch_size, stack_dim)
+    return td.to_lazystack(stack_dim)
+
+
+def _empty_lazystack_for_lazy_cat(
+    td: TensorDictBase,
+    batch_size: torch.Size,
+    stack_dim: int,
+) -> LazyStackedTensorDict:
+    batch_size = torch.Size(
+        tuple(batch_size[:stack_dim]) + tuple(batch_size[stack_dim + 1 :])
+    )
+    try:
+        names = td._maybe_names()
+    except IndexError:
+        names = None
+    if names is not None:
+        names = names[:stack_dim] + names[stack_dim + 1 :]
+        if not any(name is not None for name in names):
+            names = None
+    clz = type(td) if isinstance(td, LazyStackedTensorDict) else LazyStackedTensorDict
+    return clz._new_lazy_unsafe(
+        stack_dim=stack_dim,
+        device=td.device,
+        names=names,
+        batch_size=batch_size,
+    )
 
 
 @implements_for_td(torch.stack)
@@ -773,9 +845,11 @@ def _stack(
                     return _stack_uninit_params(values, dim)
                 if is_tensor:
                     if _is_unbatched(values[0]):
-                        return type(values[0])._stack_non_tensor(
-                            values, dim
-                        )._with_batch_size(result_batch_size)
+                        return (
+                            type(values[0])
+                            ._stack_non_tensor(values, dim)
+                            ._with_batch_size(result_batch_size)
+                        )
                     return torch.stack(values, dim)
                 with (
                     _ErrorInteceptor(

--- a/test/tensordict/test_lazy.py
+++ b/test/tensordict/test_lazy.py
@@ -389,6 +389,145 @@ class TestLazyStackedTensorDict:
             index = (slice(None),) * cat_dim + (slice(td_lazy.shape[cat_dim], None),)
             assert assert_allclose_td(res[index], td_lazy_2)
 
+    def test_cat_mixed_lazy_dense_stack_dim(self):
+        td_lazy = LazyStackedTensorDict(
+            *[
+                TensorDict({"a": torch.full((2, 3), float(i))}, [2, 3])
+                for i in range(2)
+            ],
+            stack_dim=0,
+        )
+        td_dense = TensorDict(
+            {"a": torch.arange(12, dtype=torch.float).reshape(2, 2, 3)},
+            [2, 2, 3],
+        )
+
+        res = torch.cat([td_lazy, td_dense], dim=0)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.stack_dim == 0
+        assert res.batch_size == torch.Size([4, 2, 3])
+        assert len(res.tensordicts) == 4
+        assert assert_allclose_td(res[:2], td_lazy)
+        assert assert_allclose_td(res[2:], td_dense)
+
+        res = torch.cat([td_dense, td_lazy], dim=0)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.stack_dim == 0
+        assert res.batch_size == torch.Size([4, 2, 3])
+        assert len(res.tensordicts) == 4
+        assert assert_allclose_td(res[:2], td_dense)
+        assert assert_allclose_td(res[2:], td_lazy)
+
+    @pytest.mark.parametrize("cat_dim", [1, -2])
+    def test_cat_mixed_lazy_dense_non_stack_dim(self, cat_dim):
+        td_lazy = LazyStackedTensorDict(
+            *[
+                TensorDict({"a": torch.full((2, 3), float(i))}, [2, 3])
+                for i in range(2)
+            ],
+            stack_dim=0,
+        )
+        td_dense = TensorDict(
+            {"a": torch.arange(18, dtype=torch.float).reshape(2, 3, 3)},
+            [2, 3, 3],
+        )
+
+        res = torch.cat([td_lazy, td_dense], dim=cat_dim)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.stack_dim == 0
+        assert res.batch_size == torch.Size([2, 5, 3])
+        dense_lazy = td_dense.to_lazystack(0)
+        for i, sub_td in enumerate(res.tensordicts):
+            expected = torch.cat([td_lazy.tensordicts[i], dense_lazy.tensordicts[i]], 0)
+            assert assert_allclose_td(sub_td, expected)
+
+    def test_cat_mixed_lazy_dense_preserves_non_densifiable_lazy_stack(self):
+        td_lazy = LazyStackedTensorDict(
+            TensorDict({"a": torch.ones(1), "only0": torch.zeros(1)}, []),
+            TensorDict({"a": torch.ones(2), "only1": torch.zeros(1)}, []),
+            stack_dim=0,
+        )
+        td_dense = TensorDict(
+            {
+                "a": torch.full((1, 3), 3.0),
+                "dense_only": torch.ones(1, 4),
+            },
+            [1],
+        )
+
+        res = torch.cat([td_lazy, td_dense], dim=0)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.stack_dim == 0
+        assert res.batch_size == torch.Size([3])
+        assert len(res.tensordicts) == 3
+        assert [item.shape for item in res.get("a", as_list=True)] == [
+            torch.Size([1]),
+            torch.Size([2]),
+            torch.Size([3]),
+        ]
+        assert "dense_only" in res.tensordicts[2].keys()
+
+    def test_cat_mixed_lazy_zero_length_dense_stack_dim(self):
+        td_lazy = LazyStackedTensorDict(
+            *[TensorDict({"a": torch.full((2,), float(i))}, [2]) for i in range(2)],
+            stack_dim=0,
+        )
+        td_dense_empty = TensorDict({"a": torch.empty(0, 2)}, [0, 2])
+
+        res = torch.cat([td_lazy, td_dense_empty], dim=0)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.batch_size == torch.Size([2, 2])
+        assert len(res.tensordicts) == 2
+        assert assert_allclose_td(res, td_lazy)
+
+        res = torch.cat([td_dense_empty, td_lazy], dim=0)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.batch_size == torch.Size([2, 2])
+        assert len(res.tensordicts) == 2
+        assert assert_allclose_td(res, td_lazy)
+
+        res = torch.cat([td_dense_empty, td_lazy[:0]], dim=0)
+        assert isinstance(res, LazyStackedTensorDict)
+        assert res.batch_size == torch.Size([0, 2])
+        assert len(res.tensordicts) == 0
+
+    def test_cat_mixed_lazy_dense_non_stack_dim_mismatched_slices(self):
+        td_lazy = LazyStackedTensorDict(
+            *[TensorDict({"a": torch.full((2,), float(i))}, [2]) for i in range(2)],
+            stack_dim=0,
+        )
+        td_dense = TensorDict({"a": torch.zeros(3, 2)}, [3, 2])
+
+        with pytest.raises(
+            RuntimeError,
+            match="same number of stacked tensordicts",
+        ):
+            torch.cat([td_lazy, td_dense], dim=1)
+
+    def test_cat_mixed_lazy_dense_out_dense(self):
+        td_lazy = LazyStackedTensorDict(
+            *[
+                TensorDict({"a": torch.full((2, 3), float(i))}, [2, 3])
+                for i in range(2)
+            ],
+            stack_dim=0,
+        )
+        td_dense = TensorDict(
+            {"a": torch.arange(12, dtype=torch.float).reshape(2, 2, 3)},
+            [2, 2, 3],
+        )
+        out = TensorDict({"a": torch.empty(4, 2, 3)}, [4, 2, 3])
+
+        res = torch.cat([td_lazy, td_dense], dim=0, out=out)
+        assert res is out
+        assert assert_allclose_td(
+            out,
+            TensorDict(
+                {"a": torch.cat([td_lazy.get("a"), td_dense.get("a")], 0)},
+                [4, 2, 3],
+            ),
+        )
+
     @pytest.mark.parametrize("device", [None, *get_available_devices()])
     @pytest.mark.parametrize("use_file", [False, True])
     def test_consolidate(self, device, use_file, tmpdir):


### PR DESCRIPTION
## Summary
- route mixed lazy/plain TensorDict cat through lazy cat normalization
- convert dense inputs to compatible lazy stacks instead of densifying lazy stacks
- add coverage for stack-dim, non-stack-dim, non-densifiable, zero-length, and dense out cases

## Tests
- uv run --extra tests python -m pytest test/tensordict/test_lazy.py -q