### PR TITLE
[BugFix] Skip missing TensorDictParams submodule when loading state_dict with strict=False

### DIFF
--- a/tensordict/nn/params.py
+++ b/tensordict/nn/params.py
@@ -1257,9 +1257,20 @@ class TensorDictParams(TensorDictBase, nn.Module):  # type: ignore[override,misc
             },
             [],
         ).unflatten_keys(".")
-        prefix = tuple(key for key in prefix.split(".") if key)
-        if prefix:
-            data = data.get(prefix)
+        nested_prefix = tuple(key for key in prefix.split(".") if key)
+        if nested_prefix:
+            data = data.get(nested_prefix)
+        if data is None:
+            return nn.Module._load_from_state_dict(
+                self,
+                state_dict,
+                prefix,
+                local_metadata,
+                strict,
+                missing_keys,
+                unexpected_keys,
+                error_msgs,
+            )
         self.data.load_state_dict(data)
 
     def items(

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -3266,6 +3266,28 @@ class TestTensorDictParams:
         assert any(isinstance(p, nn.Parameter) for p in params.values(True, True))
         assert weakrefs == {weakref.ref(t) for t in params.values(True, True)}
 
+    def test_load_state_dict_missing_entries(self):
+        # A checkpoint that lacks entries for the TensorDictParams prefix must
+        # not raise: loading is a no-op for the missing submodule.
+        with torch.random.fork_rng(devices=[]):
+            params = TensorDict.from_module(nn.Linear(2, 2), as_module=True)
+
+        class MyModule(nn.Module):
+            pass
+
+        module = MyModule()
+        module.params = params
+        before = params.detach().clone()
+        # state_dict that has no key under the "params" prefix
+        incompatible_keys = module.load_state_dict({}, strict=False)
+        assert set(incompatible_keys.missing_keys) == {
+            "params.bias",
+            "params.weight",
+        }
+        assert (params == before).all()
+        with pytest.raises(RuntimeError, match="Missing key"):
+            module.load_state_dict({}, strict=True)
+
     def test_inplace_ops(self):
         td = TensorDict(
             {


### PR DESCRIPTION
## Description

Loading a `state_dict` that has no entries under a `TensorDictParams` submodule
prefix crashes. In `_load_from_state_dict`, `data = data.get(prefix)` returns
`None` when the checkpoint contains nothing for that prefix, and the code then
calls `self.data.load_state_dict(None)` unconditionally, which raises. This is
the normal path for a `strict=False` load where a submodule is simply absent
from the checkpoint.

This PR guards the load so a missing submodule under `strict=False` becomes a
no-op, matching the `nn.Module` contract:

```python
if data is not None:
    self.data.load_state_dict(data)
```

## Motivation and Context

close #1472

A module holding `TensorDictParams` cannot be partially restored from a
checkpoint that omits those params, even with `strict=False`. `nn.Module`
treats missing keys as a no-op in that case, so `TensorDictParams` should too
instead of raising.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
