### PR TITLE
[BugFix] Fix _SubTensorDict memmap round trip

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -4655,13 +4655,27 @@ class _SubTensorDict(TensorDictBase):
         device: torch.device | None = None,
         *,
         robust_key,
+        out=None,
     ):
-        index = metadata["index"]
+        index = _str_to_index(metadata["index"])
+        if out is not None:
+            if not isinstance(out, _SubTensorDict):
+                raise TypeError(
+                    f"Loading a _SubTensorDict into a {type(out).__name__} output is not supported. "
+                    "Provide a _SubTensorDict as `out` or None."
+                )
+            TensorDict.load_memmap(
+                prefix / "_source",
+                device=device,
+                out=out._source,
+                robust_key=robust_key,
+            )
+            return out
         return _SubTensorDict(
             TensorDict.load_memmap(
                 prefix / "_source", device=device, robust_key=robust_key
             ),
-            _str_to_index(index),
+            index,
         )
 
     def make_memmap(
@@ -5189,31 +5203,46 @@ def _set_tensor_dict(  # noqa: F811
 
 
 def _index_to_str(index: IndexType) -> Any:
+    # Tag containers explicitly: JSON round-trips tuples as lists, so an
+    # untagged encoding cannot distinguish a tuple of indices from an
+    # advanced (list) index when loading back.
     if isinstance(index, tuple):
-        return tuple(_index_to_str(elt) for elt in index)
+        return ("tuple", [_index_to_str(elt) for elt in index])
+    if isinstance(index, list):
+        return ("list", [_index_to_str(elt) for elt in index])
     if isinstance(index, slice):
         return ("slice", {"start": index.start, "stop": index.stop, "step": index.step})
     if isinstance(index, range):
         return ("range", {"start": index.start, "stop": index.stop, "step": index.step})
     if isinstance(index, Tensor):
         return ("tensor", index.tolist(), str(index.device))
+    if index is Ellipsis:
+        return ("ellipsis",)
     return index
 
 
 def _str_to_index(index: Any) -> IndexType:
-    if isinstance(index, tuple):
+    if isinstance(index, (tuple, list)):
         if not len(index):
-            return index
-        if index[0] == "slice":
-            index = index[1]
-            return slice(index["start"], index["stop"], index["step"])
-        if index[0] == "range":
-            index = index[1]
-            return range(index["start"], index["stop"], index["step"])
-        if index[0] == "tensor":
-            index, device = index[1:]
-            return torch.tensor(index, device=device)
-        return tuple(_index_to_str(elt) for elt in index)
+            return ()
+        tag = index[0]
+        if tag == "tuple":
+            return tuple(_str_to_index(elt) for elt in index[1])
+        if tag == "list":
+            return [_str_to_index(elt) for elt in index[1]]
+        if tag == "slice":
+            content = index[1]
+            return slice(content["start"], content["stop"], content["step"])
+        if tag == "range":
+            content = index[1]
+            return range(content["start"], content["stop"], content["step"])
+        if tag == "tensor":
+            content, device = index[1:]
+            return torch.tensor(content, device=device)
+        if tag == "ellipsis":
+            return Ellipsis
+        # Legacy (untagged) metadata: a sequence of indices saved as a tuple.
+        return tuple(_str_to_index(elt) for elt in index)
     return index
 
 

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -7743,22 +7743,22 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
         metadata = _load_metadata(prefix)
         type_name = metadata["_type"]
+        if device is not None:
+            device = torch.device(device)
         if type_name != str(cls):
             import tensordict
 
             for other_cls in tensordict.base._ACCEPTED_CLASSES:
                 if str(other_cls) == type_name:
-                    return other_cls._load_memmap(
-                        prefix, metadata, robust_key=robust_key
-                    )
+                    break
             else:
                 raise RuntimeError(
                     f"Could not find name {type_name} in {tensordict.base._ACCEPTED_CLASSES}. "
                     f"Did you call _register_tensor_class(cls) on {type_name}?"
                 )
-        if device is not None:
-            device = torch.device(device)
-        out = cls._load_memmap(
+        else:
+            other_cls = cls
+        out = other_cls._load_memmap(
             prefix, metadata, device=device, out=out, robust_key=robust_key
         )
         if (

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -30,7 +30,7 @@ from tensordict import (
     TensorDict,
 )
 from tensordict._lazy import _CustomOpTensorDict
-from tensordict._td import _SubTensorDict, is_tensor_collection
+from tensordict._td import _str_to_index, _SubTensorDict, is_tensor_collection
 from tensordict._torch_func import _stack as stack_td
 from tensordict.base import _is_leaf_nontensor, TensorDictBase
 from tensordict.functional import pad
@@ -4816,6 +4816,58 @@ class TestTensorDicts(TestTensorDictsBase):
         outputs = inputs + 1
         outputs.backward(torch.ones_like(outputs))
         assert (inputs.grad == 1).all()
+
+
+class TestSubTensorDictMemmapRoundtrip:
+    @pytest.mark.parametrize(
+        "idx",
+        [
+            (slice(None), slice(0, 2)),
+            (slice(None), slice(0, 2, None)),
+            (torch.tensor([0, 2]),),
+            ([0, 2],),
+            1,
+        ],
+    )
+    def test_sub_td_memmap_roundtrip(self, idx, tmp_path):
+        td = TensorDict(
+            {"a": torch.randn(4, 3, 2, 1, 5), "b": {"c": torch.randn(4, 3, 2, 1)}},
+            batch_size=[4, 3, 2, 1],
+        )
+        sub = td._get_sub_tensordict(idx)
+        sub.memmap(tmp_path / "sub", copy_existing=True)
+        loaded = TensorDict.load_memmap(tmp_path / "sub")
+        assert isinstance(loaded, _SubTensorDict)
+        assert loaded.batch_size == sub.batch_size
+        assert (loaded["a"] == sub["a"]).all()
+        assert (loaded["b", "c"] == sub["b", "c"]).all()
+
+    def test_sub_td_memmap_device_dispatch(self, tmp_path):
+        # device must be forwarded when load_memmap dispatches to another class
+        td = TensorDict({"a": torch.randn(4, 3)}, batch_size=[4, 3])
+        sub = td._get_sub_tensordict((slice(0, 2),))
+        sub.memmap(tmp_path / "sub", copy_existing=True)
+        loaded = TensorDict.load_memmap(tmp_path / "sub", device="meta")
+        assert loaded.device == torch.device("meta")
+        assert loaded["a"].device == torch.device("meta")
+
+    def test_sub_td_load_memmap_(self, tmp_path):
+        td = TensorDict({"a": torch.randn(4, 3)}, batch_size=[4, 3])
+        sub = td._get_sub_tensordict((slice(None), slice(0, 2)))
+        sub.memmap(tmp_path / "sub", copy_existing=True)
+        td_dest = TensorDict({"a": torch.zeros(4, 3)}, batch_size=[4, 3])
+        sub_dest = td_dest._get_sub_tensordict((slice(None), slice(0, 2)))
+        sub_dest.load_memmap_(tmp_path / "sub")
+        assert (td_dest["a"] == td["a"]).all()
+
+    def test_str_to_index_legacy_format(self):
+        # metadata saved before the tagged index encoding: tuples arrive as
+        # untagged JSON lists
+        legacy = [
+            ["slice", {"start": None, "stop": None, "step": None}],
+            ["slice", {"start": 0, "stop": 2, "step": None}],
+        ]
+        assert _str_to_index(legacy) == (slice(None), slice(0, 2))
 
 
 class TestBackward:


### PR DESCRIPTION
## Description

Saving a `_SubTensorDict` via `memmap` and loading it back was broken:

```python
td = TensorDict({"a": torch.randn(4, 3, 2, 1, 5)}, batch_size=[4, 3, 2, 1])
sub = td._get_sub_tensordict((slice(None), slice(0, 2)))  # batch [4, 2, 2, 1]
sub.memmap(path, copy_existing=True)
loaded = TensorDict.load_memmap(path)
loaded.batch_size  # [2, 2, 1] -- wrong
loaded["a"]        # TypeError: new(): invalid data type 'str'
```

Root cause: the index metadata did not survive the JSON round trip. `_index_to_str` encoded tuples as tuples, but JSON serializes tuples as arrays, so `_str_to_index` received plain lists on load and returned them untouched — the `("slice", {...})` markers were never decoded. Indexing with the literal string `"slice"` raised the `TypeError`, and the malformed list-of-lists index (interpreted as advanced indexing) produced the wrong `batch_size`. In addition, the tuple branch of `_str_to_index` recursed into `_index_to_str` (the encoder) instead of itself.

## Changes

- `_index_to_str` now tags containers explicitly (`("tuple", [...])`, `("list", [...])`, `("ellipsis",)`) so tuple indices and advanced list indices remain distinguishable after JSON. `_str_to_index` decodes all tags, accepts lists as well as tuples, and keeps a legacy fallback that decodes old untagged metadata as a tuple of indices.
- `_SubTensorDict._load_memmap` accepts `out`: a `_SubTensorDict` output loads into `out._source`, which makes `load_memmap_` work on sub-tensordicts; any other output type raises a `TypeError`.
- `TensorDictBase.load_memmap` forwards `device` and `out` when dispatching to a different class (they were silently dropped), and the post-load `_sync_all()` now applies on the dispatched path too.

## Tests

New `TestSubTensorDictMemmapRoundtrip` in `test/tensordict/test_methods.py`: round trip over slice/tensor/list/int indices (checking type, batch size, and values including nested keys), device pass-through on the dispatched path (`device="meta"`), `load_memmap_` into an existing sub-tensordict, and decoding of legacy untagged index metadata.

Generated with [Claude Code](https://claude.com/claude-code)
