### PR TITLE
[CI] Fix M1 wheel builds broken by py3.14 runner base conda

### DIFF
--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -59,3 +59,9 @@ jobs:
       env-var-script: .github/scripts/version_script.sh
       build-command: pip wheel . && mkdir -p dist && mv tensordict*.whl ./dist
       build-platform: python-build-package
+      # Workaround for the M1 runners' Homebrew miniconda base env moving to
+      # py3.14, where test-infra's `conda install -y conda=25.3.0` no longer
+      # solves. Provisioning a fresh miniconda gives an active py3.10 env where
+      # the pin still solves. Drop once pytorch/test-infra bumps its conda pin
+      # (https://github.com/pytorch/test-infra/pull/7951).
+      setup-miniconda: true


### PR DESCRIPTION
## Problem

**Build M1 Wheels** runs started failing around 2026-07-08 20:00 UTC, on every branch and every matrix python version (the py3.10 job fails just like the others). Example: https://github.com/pytorch/tensordict/actions/runs/29003865594

Root cause: the M1 runners' preinstalled Homebrew miniconda **base** environment was updated to Python 3.14. test-infra's `setup-binary-builds` action runs `conda install -y conda=25.3.0` in the active (base) env, which now fails with:

```
LibMambaUnsatisfiableError: Encountered problems while solving:
└─ pin on python =3.14 * is not installable because it requires
   └─ python =3.14 *, which conflicts with any installable versions previously reported.
```

`conda=25.3.0` has no Python 3.14 build — the defaults channel only ships py3.14 conda builds from **26.1.0** onward. The failure is unrelated to the build matrix (the `python=3.14` pin is the runner base env's own python), so excluding 3.14 from the matrix would not help. Occasional green runs just mean the job landed on a runner whose base env hasn't been updated yet. pytorch/rl and pytorch/vision's M1 wheel builds broke the same way at the same time.

## Fix

Pass `setup-miniconda: true` to the reusable `build_wheels_macos.yml` workflow, same as https://github.com/pytorch/rl/pull/3960. The job then provisions a fresh miniconda via `conda-incubator/setup-miniconda` with an active py3.10 env, where the `conda=25.3.0` pin still solves. pytorch/executorch already uses this configuration and its macOS wheel builds stayed green after the runner update.

This is a workaround until pytorch/test-infra bumps its conda pin to a py3.14-compatible version (>=26.1); https://github.com/pytorch/test-infra/pull/7951 tracks bumping that pin.

The Build M1 Wheels run on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
