### PR TITLE
[BugFix] Fix CI breakage from torch.squeeze and dynamo changes

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -4720,7 +4720,7 @@ class _UnsqueezedTensorDict(_CustomOpTensorDict):
         True
     """
 
-    def _legacy_squeeze(self, dim: int | None) -> Self:
+    def _legacy_squeeze(self, dim: int | None = None) -> Self:
         if dim is not None and dim < 0:
             dim = self.batch_dims + dim
         if dim == self.custom_op_kwargs.get("dim"):

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1410,8 +1410,8 @@ def _init_wrapper(
         )
         # super(type(self), self).__setattr__("_non_tensordict", {})
         # super(type(self), self).__setattr__("_is_initialized", True)
-        self.__setattr_parent__("_non_tensordict", {})
-        self.__setattr_parent__("_is_initialized", True)
+        object.__setattr__(self, "_non_tensordict", {})
+        object.__setattr__(self, "_is_initialized", True)
 
         if _has_custom_setattr:
             # The class defines a custom __setattr__ that must be
@@ -1935,7 +1935,10 @@ def _setattr(self, key: str, value: Any) -> None:  # noqa: D417
     ):
         # if we ever decide to allow anything to be written in a tc
         # or key not in self.__dataclass_fields__):
-        return self.__setattr_parent__(key, value)
+        # Call object.__setattr__ directly (not via the __setattr_parent__
+        # class attribute): dynamo re-dispatches a slot wrapper stored as a
+        # class attribute through the custom __setattr__, which recurses.
+        return object.__setattr__(self, key, value)
 
     if key not in self.__expected_keys__:
         raise AttributeError(
@@ -1965,11 +1968,11 @@ def _setattr_tensor_only(self, key: str, value: Any) -> None:  # noqa: D417
                 )
             )
         ):
-            return self.__setattr_parent__(key, value)
+            return object.__setattr__(self, key, value)
     else:
         # Pass?
         if key in SET_ATTRIBUTES:
-            return self.__setattr_parent__(key, value)
+            return object.__setattr__(self, key, value)
     if key not in self.__expected_keys__:
         raise AttributeError(
             f"Cannot set attribute {key} in {self} as this entry is not amongst the expected ones ({self.__expected_keys__})."

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -3514,7 +3514,8 @@ class TestTensorDicts(TestTensorDictsBase):
     def test_squeeze_with_none_legacy(self, td_name, device, squeeze_dim=None):
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
-        td_squeeze = torch.squeeze(td, dim=None)
+        # torch.squeeze no longer accepts dim=None; omitting dim is equivalent
+        td_squeeze = torch.squeeze(td)
         tensor = torch.ones_like(td.get("a").squeeze())
         td_squeeze.set_("a", tensor)
         assert (td_squeeze.get("a") == tensor).all()
@@ -3541,7 +3542,7 @@ class TestTensorDicts(TestTensorDictsBase):
             else contextlib.nullcontext()
         )
         with error_dec:
-            td_squeeze = torch.squeeze(td, dim=None)
+            td_squeeze = torch.squeeze(td)
         if is_lazy:
             return
         assert all(d > 1 for d in td_squeeze.batch_size), td_squeeze.batch_size


### PR DESCRIPTION
## Description

Main's CI went red on 2026-07-09 (e.g. [this run](https://github.com/pytorch/tensordict/actions/runs/29007205042)) after recent torch releases; both stable and nightly jobs fail with the same 49 tests. Two independent root causes, both fixed here:

### 1. `torch.squeeze` no longer accepts `dim=None` (40 failures)

`test_squeeze_with_none` and `test_squeeze_with_none_legacy` called `torch.squeeze(td, dim=None)`, which current torch rejects at the argument-parser level even for plain tensors. The tests now call `torch.squeeze(td)`, which has identical semantics on every torch version.

Dropping the explicit `dim=None` exposed a real library inconsistency: `_UnsqueezedTensorDict._legacy_squeeze` was missing the `dim=None` default that `TensorDictBase._legacy_squeeze` and `LazyStackedTensorDict._legacy_squeeze` already have, so `td.squeeze()` with no argument raised a `TypeError` on that class in legacy mode. Fixed by adding the default.

### 2. dynamo recursion in tensorclass `__setattr__` (9 failures)

The tensorclass machinery stores `cls.__setattr_parent__ = object.__setattr__` and calls `self.__setattr_parent__(key, value)` to perform raw attribute writes. Current dynamo re-dispatches a slot wrapper stored as a class attribute through the type's custom `__setattr__`, so `_setattr` recursed into itself infinitely under `torch.compile` (`InternalTorchDynamoError: RecursionError: maximum recursion depth exceeded`). The call sites now invoke `object.__setattr__(self, key, value)` directly, which dynamo special-cases correctly and which is equivalent in eager mode. The `__setattr_parent__` class attribute is kept for backward compatibility.

## Testing

All 49 previously failing tests pass locally on torch 2.14.0.dev20260708: the full squeeze family (95 tests), the 9 compile tests, plus full runs of `test/tensordict/test_methods.py` (6441 passed), `test/compile/test_compile.py`, `test/tensorclass`, `test/nn`, and `test/tensordict/test_generic.py`. The single remaining local `test_compile.py` failure (`TestTTDDynamoCompatibility::test_td_subclass_arithmetic_without_registration`) pre-exists on main unchanged and does not appear in the Linux CI failure set.

Generated with [Claude Code](https://claude.com/claude-code)