### PR TITLE
[Feature] Support group_dst/group_src in TensorDict p2p methods

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2863,23 +2863,31 @@ class LazyStackedTensorDict(TensorDictBase):
 
     def _send(
         self,
-        dst: int,
+        dst: int | None,
         _tag: int = -1,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_dst: int | None = None,
     ) -> int:
         for td in self.tensordicts:
-            _tag = td._send(dst, _tag=_tag, pseudo_rand=pseudo_rand, group=group)
+            _tag = td._send(
+                dst,
+                _tag=_tag,
+                pseudo_rand=pseudo_rand,
+                group=group,
+                group_dst=group_dst,
+            )
         return _tag
 
     def _isend(
         self,
-        dst: int,
+        dst: int | None,
         _tag: int = -1,
         _futures: list[torch.Future] | None = None,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
         return_early: bool = False,
+        group_dst: int | None = None,
     ) -> int | list[torch.Future]:
         if _futures is None:
             is_root = True
@@ -2888,7 +2896,12 @@ class LazyStackedTensorDict(TensorDictBase):
             is_root = False
         for td in self.tensordicts:
             _tag = td._isend(
-                dst, _tag=_tag, pseudo_rand=pseudo_rand, _futures=_futures, group=group
+                dst,
+                _tag=_tag,
+                pseudo_rand=pseudo_rand,
+                _futures=_futures,
+                group=group,
+                group_dst=group_dst,
             )
         if is_root and not return_early:
             for _future in _futures:
@@ -2899,23 +2912,33 @@ class LazyStackedTensorDict(TensorDictBase):
 
     def _recv(
         self,
-        src: int,
+        src: int | None,
         _tag: int = -1,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
+        non_blocking: bool = False,
+        group_src: int | None = None,
     ) -> int:
         for td in self.tensordicts:
-            _tag = td._recv(src, _tag=_tag, pseudo_rand=pseudo_rand, group=group)
+            _tag = td._recv(
+                src,
+                _tag=_tag,
+                pseudo_rand=pseudo_rand,
+                group=group,
+                non_blocking=non_blocking,
+                group_src=group_src,
+            )
         return _tag
 
     def _irecv(
         self,
-        src: int,
+        src: int | None,
         return_premature: bool = False,
         _tag: int = -1,
         _future_list: list[torch.Future] | None = None,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_src: int | None = None,
     ) -> tuple[int, list[torch.Future]] | list[torch.Future] | None:
         root = False
         if _future_list is None:
@@ -2929,6 +2952,7 @@ class LazyStackedTensorDict(TensorDictBase):
                 _future_list=_future_list,
                 pseudo_rand=pseudo_rand,
                 group=group,
+                group_src=group_src,
             )
 
         if not root:

--- a/tensordict/_tensorcollection.pyi
+++ b/tensordict/_tensorcollection.pyi
@@ -1039,18 +1039,20 @@ class TensorCollection:
     ) -> Self | None: ...
     def send(
         self,
-        dst: int,
+        dst: int | None = None,
         *,
         group: dist.ProcessGroup | None = None,
+        group_dst: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         consolidated: bool = False,
     ) -> None: ...
     def recv(
         self,
-        src: int,
+        src: int | None = None,
         *,
         group: dist.ProcessGroup | None = None,
+        group_src: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         consolidated: bool = False,
@@ -1072,17 +1074,20 @@ class TensorCollection:
     ): ...
     def isend(
         self,
-        dst: int,
+        dst: int | None = None,
         *,
         group: "dist.ProcessGroup" | None = None,  # noqa: F821
+        group_dst: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
+        return_early: bool = False,
     ) -> int: ...
     def irecv(
         self,
-        src: int,
+        src: int | None = None,
         *,
         group: dist.ProcessGroup | None = None,
+        group_src: int | None = None,
         return_premature: bool = False,
         init_tag: int = 0,
         pseudo_rand: bool = False,

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -9756,9 +9756,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
     def send(
         self,
-        dst: int | "TensorDictPipe",  # noqa: F821
+        dst: int | "TensorDictPipe" | None = None,  # noqa: F821
         *,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_dst: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         consolidated: bool = False,
@@ -9766,15 +9767,25 @@ class TensorDictBase(MutableMapping, TensorCollection):
         """Sends the content of a tensordict to a distant worker.
 
         Args:
-            dst (int or TensorDictPipe): the rank of the destination worker
-                where the content should be sent, or a
+            dst (int or TensorDictPipe, optional): the global rank of the
+                destination worker where the content should be sent, or a
                 :class:`~tensordict._ucxx.TensorDictPipe` for UCXX-based
-                transport.
+                transport. Mutually exclusive with ``group_dst``; exactly one
+                of the two must be provided.
 
         Keyword Args:
             group (torch.distributed.ProcessGroup, optional): if set, the specified process group
                 will be used for communication. Otherwise, the default process group
                 will be used.
+                Defaults to ``None``.
+            group_dst (int, optional): the rank of the destination worker
+                *relative to* ``group``. Requires ``group`` to be passed and is
+                mutually exclusive with ``dst``. When set, the p2p calls are
+                issued directly on the group's backend, so ``group`` may be a
+                standalone :class:`~torch.distributed.ProcessGroup` built
+                against a store (never registered through
+                :func:`~torch.distributed.init_process_group` or
+                :func:`~torch.distributed.new_group`).
                 Defaults to ``None``.
             init_tag (int): the initial tag to be used to mark the tensors.
                 Note that this will be incremented by as much as the number of
@@ -9852,22 +9863,38 @@ class TensorDictBase(MutableMapping, TensorCollection):
         from tensordict._ucxx import TensorDictPipe
 
         if isinstance(dst, TensorDictPipe):
+            if group_dst is not None:
+                raise ValueError(
+                    "`group_dst` cannot be used when `dst` is a TensorDictPipe."
+                )
             dst.send(self)
             return
+        _check_p2p_peer(dst, group_dst, group, "dst", "group_dst")
         if consolidated:
             from torch import distributed as dist
 
             td_c = self if self.is_consolidated() else self.consolidate(metadata=True)
-            dist.send(td_c._consolidated["storage"], dst=dst, group=group)
+            storage = td_c._consolidated["storage"]
+            if group_dst is not None:
+                group.send([storage], group_dst, 0).wait()
+            else:
+                dist.send(storage, dst=dst, group=group)
             return
-        self._send(dst, _tag=init_tag - 1, pseudo_rand=pseudo_rand, group=group)
+        self._send(
+            dst,
+            _tag=init_tag - 1,
+            pseudo_rand=pseudo_rand,
+            group=group,
+            group_dst=group_dst,
+        )
 
     def _send(
         self,
-        dst: int,
+        dst: int | None,
         _tag: int = -1,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_dst: int | None = None,
     ) -> int:
         from torch import distributed as dist
 
@@ -9876,7 +9903,13 @@ class TensorDictBase(MutableMapping, TensorCollection):
             if isinstance(value, Tensor):
                 pass
             elif _is_tensor_collection(type(value)):
-                _tag = value._send(dst, _tag=_tag, pseudo_rand=pseudo_rand, group=group)
+                _tag = value._send(
+                    dst,
+                    _tag=_tag,
+                    pseudo_rand=pseudo_rand,
+                    group=group,
+                    group_dst=group_dst,
+                )
                 continue
             else:
                 raise NotImplementedError(f"Type {type(value)} is not supported.")
@@ -9884,15 +9917,21 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 _tag += 1
             else:
                 _tag = int_generator(_tag + 1)
-            dist.send(value, dst=dst, tag=_tag, group=group)
+            if group_dst is not None:
+                # Direct backend call: works for raw (unregistered) groups,
+                # which the functional API rejects.
+                group.send([value], group_dst, _tag).wait()
+            else:
+                dist.send(value, dst=dst, tag=_tag, group=group)
 
         return _tag
 
     def recv(
         self,
-        src: int | "TensorDictPipe",  # noqa: F821
+        src: int | "TensorDictPipe" | None = None,  # noqa: F821
         *,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_src: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         consolidated: bool = False,
@@ -9902,16 +9941,27 @@ class TensorDictBase(MutableMapping, TensorCollection):
         Check the example in the `send` method for context.
 
         Args:
-            src (int or TensorDictPipe): the rank of the source worker, or a
+            src (int or TensorDictPipe, optional): the global rank of the
+                source worker, or a
                 :class:`~tensordict._ucxx.TensorDictPipe` for UCXX-based
                 transport.  When a pipe is passed, the data is received
                 in-place into this tensordict's consolidated storage (if
-                available).
+                available). Mutually exclusive with ``group_src``; exactly one
+                of the two must be provided.
 
         Keyword Args:
             group (torch.distributed.ProcessGroup, optional): if set, the specified process group
                 will be used for communication. Otherwise, the default process group
                 will be used.
+                Defaults to ``None``.
+            group_src (int, optional): the rank of the source worker *relative
+                to* ``group``. Requires ``group`` to be passed and is mutually
+                exclusive with ``src``. When set, the p2p calls are issued
+                directly on the group's backend, so ``group`` may be a
+                standalone :class:`~torch.distributed.ProcessGroup` built
+                against a store (never registered through
+                :func:`~torch.distributed.init_process_group` or
+                :func:`~torch.distributed.new_group`).
                 Defaults to ``None``.
             init_tag (int): the ``init_tag`` used by the source worker.
             pseudo_rand (bool): if True, the sequence of tags will be pseudo-
@@ -9931,14 +9981,28 @@ class TensorDictBase(MutableMapping, TensorCollection):
         from tensordict._ucxx import TensorDictPipe
 
         if isinstance(src, TensorDictPipe):
+            if group_src is not None:
+                raise ValueError(
+                    "`group_src` cannot be used when `src` is a TensorDictPipe."
+                )
             return src.recv(self)
+        _check_p2p_peer(src, group_src, group, "src", "group_src")
         if consolidated:
             from torch import distributed as dist
 
             storage = self._consolidated["storage"]
-            dist.recv(storage, src=src, group=group)
+            if group_src is not None:
+                group.recv([storage], group_src, 0).wait()
+            else:
+                dist.recv(storage, src=src, group=group)
             return
-        return self._recv(src, _tag=init_tag - 1, pseudo_rand=pseudo_rand, group=group)
+        return self._recv(
+            src,
+            _tag=init_tag - 1,
+            pseudo_rand=pseudo_rand,
+            group=group,
+            group_src=group_src,
+        )
 
     async def asend(self, dst: "TensorDictPipe") -> None:  # noqa: F821
         """Sends the content of a tensordict through a UCXX pipe (async).
@@ -9975,11 +10039,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
     def _recv(
         self,
-        src: int,
+        src: int | None,
         _tag: int = -1,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
         non_blocking: bool = False,
+        group_src: int | None = None,
     ) -> int:
         from torch import distributed as dist
 
@@ -9988,7 +10053,13 @@ class TensorDictBase(MutableMapping, TensorCollection):
             if isinstance(value, Tensor):
                 pass
             elif _is_tensor_collection(type(value)):
-                _tag = value._recv(src, _tag=_tag, pseudo_rand=pseudo_rand, group=group)
+                _tag = value._recv(
+                    src,
+                    _tag=_tag,
+                    pseudo_rand=pseudo_rand,
+                    group=group,
+                    group_src=group_src,
+                )
                 continue
             else:
                 raise NotImplementedError(f"Type {type(value)} is not supported.")
@@ -9996,7 +10067,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 _tag += 1
             else:
                 _tag = int_generator(_tag + 1)
-            dist.recv(value, src=src, tag=_tag, group=group)
+            if group_src is not None:
+                # Direct backend call: works for raw (unregistered) groups,
+                # which the functional API rejects.
+                group.recv([value], group_src, _tag).wait()
+            else:
+                dist.recv(value, src=src, tag=_tag, group=group)
             self._set_str(
                 key, value, inplace=True, validated=True, non_blocking=non_blocking
             )
@@ -10188,9 +10264,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
     def isend(
         self,
-        dst: int,
+        dst: int | None = None,
         *,
         group: "torch.distributed.ProcessGroup" | None = None,  # noqa: F821
+        group_dst: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         return_early: bool = False,
@@ -10198,13 +10275,23 @@ class TensorDictBase(MutableMapping, TensorCollection):
         """Sends the content of the tensordict asynchronously.
 
         Args:
-            dst (int): the rank of the destination worker where the content
-                should be sent.
+            dst (int, optional): the global rank of the destination worker
+                where the content should be sent. Mutually exclusive with
+                ``group_dst``; exactly one of the two must be provided.
 
         Keyword Args:
             group (torch.distributed.ProcessGroup, optional): if set, the specified process group
                 will be used for communication. Otherwise, the default process group
                 will be used.
+                Defaults to ``None``.
+            group_dst (int, optional): the rank of the destination worker
+                *relative to* ``group``. Requires ``group`` to be passed and is
+                mutually exclusive with ``dst``. When set, the p2p calls are
+                issued directly on the group's backend, so ``group`` may be a
+                standalone :class:`~torch.distributed.ProcessGroup` built
+                against a store (never registered through
+                :func:`~torch.distributed.init_process_group` or
+                :func:`~torch.distributed.new_group`).
                 Defaults to ``None``.
             init_tag (int): the initial tag to be used to mark the tensors.
                 Note that this will be incremented by as much as the number of
@@ -10281,22 +10368,25 @@ class TensorDictBase(MutableMapping, TensorCollection):
             ...     secondary_worker.join()
 
         """
+        _check_p2p_peer(dst, group_dst, group, "dst", "group_dst")
         return self._isend(
             dst,
             _tag=init_tag - 1,
             pseudo_rand=pseudo_rand,
             group=group,
+            group_dst=group_dst,
             return_early=return_early,
         )
 
     def _isend(
         self,
-        dst: int,
+        dst: int | None,
         _tag: int = -1,
         _futures: list[torch.Future] | None = None,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
         return_early: bool = False,
+        group_dst: int | None = None,
     ) -> int:
         from torch import distributed as dist
 
@@ -10314,6 +10404,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
                     _futures=_futures,
                     group=group,
                     return_early=return_early,
+                    group_dst=group_dst,
                 )
                 continue
             elif isinstance(value, Tensor):
@@ -10324,7 +10415,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 _tag += 1
             else:
                 _tag = int_generator(_tag + 1)
-            _future = dist.isend(value, dst=dst, tag=_tag, group=group)
+            if group_dst is not None:
+                # Direct backend call: works for raw (unregistered) groups,
+                # which the functional API rejects.
+                _future = group.send([value], group_dst, _tag)
+            else:
+                _future = dist.isend(value, dst=dst, tag=_tag, group=group)
             _futures.append(_future)
         if root and not return_early:
             for _future in _futures:
@@ -10335,9 +10431,10 @@ class TensorDictBase(MutableMapping, TensorCollection):
 
     def irecv(
         self,
-        src: int,
+        src: int | None = None,
         *,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_src: int | None = None,
         return_premature: bool = False,
         init_tag: int = 0,
         pseudo_rand: bool = False,
@@ -10347,12 +10444,23 @@ class TensorDictBase(MutableMapping, TensorCollection):
         Check the example in the :meth:`~.isend` method for context.
 
         Args:
-            src (int): the rank of the source worker.
+            src (int, optional): the global rank of the source worker. Mutually
+                exclusive with ``group_src``; exactly one of the two must be
+                provided.
 
         Keyword Args:
             group (torch.distributed.ProcessGroup, optional): if set, the specified process group
                 will be used for communication. Otherwise, the default process group
                 will be used.
+                Defaults to ``None``.
+            group_src (int, optional): the rank of the source worker *relative
+                to* ``group``. Requires ``group`` to be passed and is mutually
+                exclusive with ``src``. When set, the p2p calls are issued
+                directly on the group's backend, so ``group`` may be a
+                standalone :class:`~torch.distributed.ProcessGroup` built
+                against a store (never registered through
+                :func:`~torch.distributed.init_process_group` or
+                :func:`~torch.distributed.new_group`).
                 Defaults to ``None``.
             return_premature (bool): if ``True``, returns a list of futures to wait
                 upon until the tensordict is updated. Defaults to ``False``,
@@ -10370,22 +10478,25 @@ class TensorDictBase(MutableMapping, TensorCollection):
             if ``return_premature=True``, a list of futures to wait
                 upon until the tensordict is updated.
         """
+        _check_p2p_peer(src, group_src, group, "src", "group_src")
         return self._irecv(
             src,
             return_premature=return_premature,
             _tag=init_tag - 1,
             pseudo_rand=pseudo_rand,
             group=group,
+            group_src=group_src,
         )
 
     def _irecv(
         self,
-        src: int,
+        src: int | None,
         return_premature: bool = False,
         _tag: int = -1,
         _future_list: list[torch.Future] = None,
         pseudo_rand: bool = False,
         group: "torch.distributed.ProcessGroup" | None = None,
+        group_src: int | None = None,
     ) -> tuple[int, list[torch.Future]] | list[torch.Future] | None:
         from torch import distributed as dist
 
@@ -10403,6 +10514,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
                     _future_list=_future_list,
                     pseudo_rand=pseudo_rand,
                     group=group,
+                    group_src=group_src,
                 )
                 continue
             elif isinstance(value, Tensor):
@@ -10413,7 +10525,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 _tag += 1
             else:
                 _tag = int_generator(_tag + 1)
-            _future_list.append(dist.irecv(value, src=src, tag=_tag, group=group))
+            if group_src is not None:
+                # Direct backend call: works for raw (unregistered) groups,
+                # which the functional API rejects.
+                _future_list.append(group.recv([value], group_src, _tag))
+            else:
+                _future_list.append(dist.irecv(value, src=src, tag=_tag, group=group))
         if not root:
             return _tag, _future_list
         elif return_premature:
@@ -17668,6 +17785,32 @@ _ACCEPTED_CLASSES = (
     Tensor,
     TensorDictBase,
 )
+
+
+def _check_p2p_peer(
+    peer: int | None,
+    group_peer: int | None,
+    group: "torch.distributed.ProcessGroup" | None,
+    peer_name: str,
+    group_peer_name: str,
+) -> None:
+    """Validates the global-rank / group-rank peer arguments of the p2p methods.
+
+    Mirrors the torch functional API contract: the peer is specified either
+    globally (``dst``/``src``) or relative to ``group``
+    (``group_dst``/``group_src``), never both.
+    """
+    if group_peer is not None:
+        if group is None:
+            raise ValueError(f"`{group_peer_name}` requires `group` to be passed.")
+        if peer is not None:
+            raise ValueError(
+                f"`{peer_name}` and `{group_peer_name}` are mutually exclusive."
+            )
+    elif peer is None:
+        raise ValueError(
+            f"Exactly one of `{peer_name}` and `{group_peer_name}` must be provided."
+        )
 
 
 def _resolve_tensorclass_type(type_str: str):

--- a/tensordict/tensorclass.pyi
+++ b/tensordict/tensorclass.pyi
@@ -1116,18 +1116,20 @@ class TensorClass:
     ) -> Self | None: ...
     def send(
         self,
-        dst: int,
+        dst: int | None = None,
         *,
         group: dist.ProcessGroup | None = None,
+        group_dst: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         consolidated: bool = False,
     ) -> None: ...
     def recv(
         self,
-        src: int,
+        src: int | None = None,
         *,
         group: dist.ProcessGroup | None = None,
+        group_src: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
         consolidated: bool = False,
@@ -1149,17 +1151,20 @@ class TensorClass:
     ) -> Self: ...
     def isend(
         self,
-        dst: int,
+        dst: int | None = None,
         *,
         group: "dist.ProcessGroup" | None = None,  # noqa: F821
+        group_dst: int | None = None,
         init_tag: int = 0,
         pseudo_rand: bool = False,
+        return_early: bool = False,
     ) -> int: ...
     def irecv(
         self,
-        src: int,
+        src: int | None = None,
         *,
         group: dist.ProcessGroup | None = None,
+        group_src: int | None = None,
         return_premature: bool = False,
         init_tag: int = 0,
         pseudo_rand: bool = False,

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -7,6 +7,7 @@ import abc
 import argparse
 import os
 import sys
+from datetime import timedelta
 
 import pytest
 import torch
@@ -1249,6 +1250,251 @@ class TestSendConsolidated:
             main_worker.join(timeout=TIMEOUT)
             secondary_worker.join(timeout=TIMEOUT)
             assert out == "yuppie"
+
+
+# ========================================================================
+# Test group_dst / group_src over raw (unregistered) process groups
+# ------------------------------------------------------------------------
+
+
+def _make_raw_pair_group(rank, port, backend="gloo"):
+    """Builds a standalone pair process group over a TCPStore.
+
+    No ``init_process_group`` / ``new_group`` anywhere: the group never goes
+    through the c10d registry, so global-rank lookups would fail on it.
+    """
+    store = dist.TCPStore("localhost", port, 2, rank == 0)
+    prefix_store = dist.PrefixStore("raw_pair", store)
+    if backend == "gloo":
+        return dist.ProcessGroupGloo(prefix_store, rank, 2, timedelta(seconds=TIMEOUT))
+    if backend == "nccl":
+        return dist.ProcessGroupNCCL(prefix_store, rank, 2)
+    raise ValueError(f"Unknown backend {backend}")
+
+
+class TestRawGroupSendRecv:
+    """p2p transfer over standalone (unregistered) groups via group_dst/group_src."""
+
+    port = 29520
+
+    @staticmethod
+    def make_td(ones):
+        fun = torch.ones if ones else torch.zeros
+        return TensorDict(
+            {
+                ("a", "b"): fun(2),
+                "c": fun(2, 3),
+                "_": fun(2, 1, 5),
+            },
+            [2],
+        )
+
+    @classmethod
+    def client(cls, mode, pseudo_rand):
+        pg = _make_raw_pair_group(1, cls.port)
+        td = cls.make_td(ones=True)
+        if mode == "isend":
+            td.isend(group=pg, group_dst=0, pseudo_rand=pseudo_rand)
+        elif mode == "consolidated":
+            td.send(group=pg, group_dst=0, consolidated=True)
+        else:
+            td.send(group=pg, group_dst=0, pseudo_rand=pseudo_rand)
+
+    @classmethod
+    def server(cls, queue, mode, pseudo_rand, return_premature):
+        pg = _make_raw_pair_group(0, cls.port)
+        td = cls.make_td(ones=False)
+        if mode == "consolidated":
+            td = td.consolidate(metadata=True)
+            td.recv(group=pg, group_src=1, consolidated=True)
+        elif mode == "irecv":
+            out = td.irecv(
+                group=pg,
+                group_src=1,
+                pseudo_rand=pseudo_rand,
+                return_premature=return_premature,
+            )
+            if return_premature:
+                for fut in out:
+                    fut.wait()
+        else:
+            td.recv(group=pg, group_src=1, pseudo_rand=pseudo_rand)
+        assert (td == 1).all()
+        queue.put("yuppie")
+
+    def _run(self, client_mode, server_mode, pseudo_rand=False, return_premature=False):
+        queue = mp.Queue(1)
+        main_worker = mp.Process(
+            target=type(self).server,
+            args=(queue, server_mode, pseudo_rand, return_premature),
+        )
+        secondary_worker = mp.Process(
+            target=type(self).client, args=(client_mode, pseudo_rand)
+        )
+
+        main_worker.start()
+        secondary_worker.start()
+        try:
+            out = queue.get(timeout=TIMEOUT)
+            assert out == "yuppie"
+        finally:
+            main_worker.join(timeout=TIMEOUT)
+            secondary_worker.join(timeout=TIMEOUT)
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    @pytest.mark.parametrize("pseudo_rand", [True, False])
+    def test_send_recv_raw(self, pseudo_rand, set_context):
+        self._run("send", "recv", pseudo_rand=pseudo_rand)
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    @pytest.mark.parametrize("pseudo_rand", [True, False])
+    def test_isend_recv_raw(self, pseudo_rand, set_context):
+        self._run("isend", "recv", pseudo_rand=pseudo_rand)
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    @pytest.mark.parametrize("return_premature", [True, False])
+    def test_irecv_raw(self, return_premature, set_context):
+        self._run("isend", "irecv", return_premature=return_premature)
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    def test_consolidated_raw(self, set_context):
+        self._run("consolidated", "consolidated")
+
+
+class TestRegisteredGroupSendRecv:
+    """group_dst/group_src also work with groups registered via new_group."""
+
+    @classmethod
+    def client(cls):
+        dist.init_process_group(
+            "gloo",
+            rank=1,
+            world_size=2,
+            init_method="tcp://localhost:29522",
+        )
+        group = dist.new_group([0, 1])
+        td = TensorDict({("a", "b"): torch.ones(2), "c": torch.ones(2, 3)}, [2])
+        td.send(group=group, group_dst=0)
+
+    @classmethod
+    def server(cls, queue):
+        dist.init_process_group(
+            "gloo",
+            rank=0,
+            world_size=2,
+            init_method="tcp://localhost:29522",
+        )
+        group = dist.new_group([0, 1])
+        td = TensorDict({("a", "b"): torch.zeros(2), "c": torch.zeros(2, 3)}, [2])
+        td.recv(group=group, group_src=1)
+        assert (td == 1).all()
+        queue.put("yuppie")
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    def test_registered_group(self, set_context):
+        queue = mp.Queue(1)
+        main_worker = mp.Process(target=type(self).server, args=(queue,))
+        secondary_worker = mp.Process(target=type(self).client)
+
+        main_worker.start()
+        secondary_worker.start()
+        try:
+            out = queue.get(timeout=TIMEOUT)
+            assert out == "yuppie"
+        finally:
+            main_worker.join(timeout=TIMEOUT)
+            secondary_worker.join(timeout=TIMEOUT)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.device_count() >= 2, reason="not enough cuda devices"
+)
+class TestRawGroupSendRecvNCCL:
+    port = 29523
+
+    @classmethod
+    def client(cls):
+        torch.cuda.set_device(1)
+        pg = _make_raw_pair_group(1, cls.port, backend="nccl")
+        td = TensorDict(
+            {("a", "b"): torch.ones(2), "c": torch.ones(2, 3)},
+            [2],
+            device="cuda:1",
+        )
+        td.send(group=pg, group_dst=0)
+
+    @classmethod
+    def server(cls, queue):
+        torch.cuda.set_device(0)
+        pg = _make_raw_pair_group(0, cls.port, backend="nccl")
+        td = TensorDict(
+            {("a", "b"): torch.zeros(2), "c": torch.zeros(2, 3)},
+            [2],
+            device="cuda:0",
+        )
+        td.recv(group=pg, group_src=1)
+        assert (td == 1).all()
+        queue.put("yuppie")
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    def test_send_recv_raw_nccl(self, set_context):
+        queue = mp.Queue(1)
+        main_worker = mp.Process(target=type(self).server, args=(queue,))
+        secondary_worker = mp.Process(target=type(self).client)
+
+        main_worker.start()
+        secondary_worker.start()
+        try:
+            out = queue.get(timeout=TIMEOUT)
+            assert out == "yuppie"
+        finally:
+            main_worker.join(timeout=TIMEOUT)
+            secondary_worker.join(timeout=TIMEOUT)
+
+
+class TestGroupPeerValidation:
+    """Argument validation for group_dst/group_src (single process, no comms)."""
+
+    @staticmethod
+    def make_td():
+        return TensorDict({"a": torch.zeros(1)}, [])
+
+    def test_group_peer_requires_group(self):
+        td = self.make_td()
+        with pytest.raises(ValueError, match="requires `group`"):
+            td.send(group_dst=0)
+        with pytest.raises(ValueError, match="requires `group`"):
+            td.isend(group_dst=0)
+        with pytest.raises(ValueError, match="requires `group`"):
+            td.recv(group_src=0)
+        with pytest.raises(ValueError, match="requires `group`"):
+            td.irecv(group_src=0)
+
+    def test_peer_and_group_peer_mutually_exclusive(self):
+        store = dist.TCPStore("localhost", 29524, 1, True)
+        pg = dist.ProcessGroupGloo(
+            dist.PrefixStore("solo", store), 0, 1, timedelta(seconds=10)
+        )
+        td = self.make_td()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            td.send(0, group=pg, group_dst=0)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            td.isend(0, group=pg, group_dst=0)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            td.recv(0, group=pg, group_src=0)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            td.irecv(0, group=pg, group_src=0)
+
+    def test_missing_peer(self):
+        td = self.make_td()
+        with pytest.raises(ValueError, match="Exactly one"):
+            td.send()
+        with pytest.raises(ValueError, match="Exactly one"):
+            td.isend()
+        with pytest.raises(ValueError, match="Exactly one"):
+            td.recv()
+        with pytest.raises(ValueError, match="Exactly one"):
+            td.irecv()
 
 
 # ========================================================================


### PR DESCRIPTION
## Description

Adds `group_dst` (for `send`/`isend`) and `group_src` (for `recv`/`irecv`) keyword arguments to the TensorDict p2p methods, mirroring the torch functional API. The peer is specified either globally (`dst`/`src`) or relative to `group` (`group_dst`/`group_src`), never both.

When the group-relative spelling is used, the p2p calls are issued directly on the group's backend (`pg.send([tensor], group_dst, tag)` / `pg.recv([tensor], group_src, tag)`) instead of going through the functional API. This makes the methods work with *standalone* `ProcessGroup` objects constructed directly against a store (e.g. `dist.ProcessGroupGloo(PrefixStore(...), rank, world_size, timeout)`) that were never registered through `init_process_group`/`new_group` — the functional API rejects those because it resolves ranks through the c10d registry (and `dist.recv(..., group_src=...)` still hits the registry on current torch, so it cannot be built on directly).

## Motivation

Elastic topologies (dynamic worker fleets, per-client server/client pair groups) deliberately avoid a fixed global world: no all-participants startup barrier, workers can join and leave, and the default process group stays free for training collectives. Today such code has to hand-roll a per-leaf `pg.send`/`pg.recv` loop that reimplements `TensorDictBase._send`. With this change it can delegate to `td.isend`/`td.irecv` and gets the `consolidated=True` single-buffer path (one p2p op per message instead of one per leaf) for free. Unblocks a follow-up on pytorch/rl#3958.

## Changes

- `send`/`isend`: new keyword-only `group_dst`; `recv`/`irecv`: new keyword-only `group_src`; `dst`/`src` become optional.
- Validation (shared `_check_p2p_peer` helper): `group_dst`/`group_src` require `group`, are mutually exclusive with `dst`/`src`, and exactly one peer spelling must be provided.
- The `consolidated=True` send/recv path forwards the new arguments.
- `LazyStackedTensorDict` overrides forward the new parameters (`_recv` now also forwards `non_blocking`, which was previously dropped).
- Stubs (`_tensorcollection.pyi`, `tensorclass.pyi`) updated; tensorclasses get the feature through the wrapped methods.
- No behavior change for existing callers: the global-rank path, the tag protocol (incrementing tags, `pseudo_rand`), and wire compatibility are untouched.

## Tests

Extends `test/distributed/test_distributed.py`:

- Raw gloo pair group over `TCPStore`/`PrefixStore` with no `init_process_group` anywhere: `send`/`recv`, `isend`/`recv`, `irecv` (with and without `return_premature`), and a `consolidated=True` round trip, all including a nested key.
- Registered-group regression: `group_dst`/`group_src` with a `new_group` subgroup.
- Error cases: `group_dst` without `group`, `dst` and `group_dst` together, and neither provided.
- NCCL raw-pair variant, skipped unless 2+ CUDA devices are available.

Existing send/recv suites (58 tests) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)