### PR TITLE
[Performance] Reuse a shared thread pool across serialization calls

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -73,6 +73,7 @@ from tensordict.utils import (
     _convert_list_to_stack,
     _DTYPE_TO_STR_DTYPE,
     _GENERIC_NESTED_ERR,
+    _get_shared_executor,
     _is_dataclass as is_dataclass,
     _is_list_tensor_compatible,
     _is_non_tensor,
@@ -7079,13 +7080,13 @@ class TensorDictBase(MutableMapping, TensorCollection):
                 raise NotImplementedError(
                     "return_early is not implemented yet for `consolidate`."
                 )
-            with ThreadPoolExecutor(num_threads) as executor:
-                wait(
-                    [
-                        executor.submit(_copy_chunk, start_idx, stop_idx)
-                        for start_idx, stop_idx in chunks
-                    ]
-                )
+            executor = _get_shared_executor(num_threads)
+            wait(
+                [
+                    executor.submit(_copy_chunk, start_idx, stop_idx)
+                    for start_idx, stop_idx in chunks
+                ]
+            )
             if non_blocking and (device is None or device.type != "cuda"):
                 # sync if needed
                 self._sync_all()
@@ -7271,30 +7272,23 @@ class TensorDictBase(MutableMapping, TensorCollection):
         """
         prefix = Path(prefix) if prefix is not None else self._memmap_prefix
         if num_threads > 1:
-            with (
-                ThreadPoolExecutor(max_workers=num_threads)
-                if not return_early
-                else contextlib.nullcontext()
-            ) as executor:
-                if return_early:
-                    executor = ThreadPoolExecutor(max_workers=num_threads)
-                futures = []
-                result = self._memmap_(
-                    prefix=prefix,
-                    copy_existing=copy_existing,
-                    executor=executor,
-                    futures=futures,
-                    inplace=True,
-                    like=False,
-                    share_non_tensor=share_non_tensor,
-                    existsok=existsok,
-                    robust_key=robust_key,
-                )
-                if not return_early:
-                    concurrent.futures.wait(futures)
-                    return result
-                else:
-                    return TensorDictFuture(futures, result)
+            executor = _get_shared_executor(num_threads)
+            futures = []
+            result = self._memmap_(
+                prefix=prefix,
+                copy_existing=copy_existing,
+                executor=executor,
+                futures=futures,
+                inplace=True,
+                like=False,
+                share_non_tensor=share_non_tensor,
+                existsok=existsok,
+                robust_key=robust_key,
+            )
+            if not return_early:
+                concurrent.futures.wait(futures)
+                return result
+            return TensorDictFuture(futures, result)
         return self._memmap_(
             prefix=prefix,
             copy_existing=copy_existing,
@@ -7501,30 +7495,23 @@ class TensorDictBase(MutableMapping, TensorCollection):
         prefix = Path(prefix) if prefix is not None else self._memmap_prefix
 
         if num_threads > 1:
-            with (
-                ThreadPoolExecutor(max_workers=num_threads)
-                if not return_early
-                else contextlib.nullcontext()
-            ) as executor:
-                if return_early:
-                    executor = ThreadPoolExecutor(max_workers=num_threads)
-                futures = []
-                result = self._memmap_(
-                    prefix=prefix,
-                    copy_existing=copy_existing,
-                    executor=executor,
-                    futures=futures,
-                    inplace=False,
-                    like=False,
-                    share_non_tensor=share_non_tensor,
-                    existsok=existsok,
-                    robust_key=robust_key,
-                )
-                if not return_early:
-                    concurrent.futures.wait(futures)
-                    return result
-                else:
-                    return TensorDictFuture(futures, result)
+            executor = _get_shared_executor(num_threads)
+            futures = []
+            result = self._memmap_(
+                prefix=prefix,
+                copy_existing=copy_existing,
+                executor=executor,
+                futures=futures,
+                inplace=False,
+                like=False,
+                share_non_tensor=share_non_tensor,
+                existsok=existsok,
+                robust_key=robust_key,
+            )
+            if not return_early:
+                concurrent.futures.wait(futures)
+                return result
+            return TensorDictFuture(futures, result)
 
         return self._memmap_(
             prefix=prefix,
@@ -7603,40 +7590,31 @@ class TensorDictBase(MutableMapping, TensorCollection):
         """
         prefix = Path(prefix) if prefix is not None else self._memmap_prefix
         if num_threads > 1:
-            with (
-                ThreadPoolExecutor(max_workers=num_threads)
-                if not return_early
-                else contextlib.nullcontext()
-            ) as executor:
-                if return_early:
-                    executor = ThreadPoolExecutor(max_workers=num_threads)
-                futures = []
+            executor = _get_shared_executor(num_threads)
+            futures = []
 
-                # we create an empty copy of self
-                # This is because calling MMapTensor.from_tensor(mmap_tensor) does nothing
-                # if both are in filesystem
-                def empty(x):
-                    return torch.empty((), device=x.device, dtype=x.dtype).expand(
-                        x.shape
-                    )
+            # we create an empty copy of self
+            # This is because calling MMapTensor.from_tensor(mmap_tensor) does nothing
+            # if both are in filesystem
+            def empty(x):
+                return torch.empty((), device=x.device, dtype=x.dtype).expand(x.shape)
 
-                input = self.apply(empty)
-                result = input._memmap_(
-                    prefix=prefix,
-                    copy_existing=copy_existing,
-                    executor=executor,
-                    futures=futures,
-                    inplace=False,
-                    like=True,
-                    share_non_tensor=share_non_tensor,
-                    existsok=existsok,
-                    robust_key=robust_key,
-                )
-                if not return_early:
-                    concurrent.futures.wait(futures)
-                    return result
-                else:
-                    return TensorDictFuture(futures, result)
+            input = self.apply(empty)
+            result = input._memmap_(
+                prefix=prefix,
+                copy_existing=copy_existing,
+                executor=executor,
+                futures=futures,
+                inplace=False,
+                like=True,
+                share_non_tensor=share_non_tensor,
+                existsok=existsok,
+                robust_key=robust_key,
+            )
+            if not return_early:
+                concurrent.futures.wait(futures)
+                return result
+            return TensorDictFuture(futures, result)
 
         def empty_expand(x):
             return torch.empty((), device=x.device, dtype=x.dtype).expand(x.shape)

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -2421,7 +2421,8 @@ def _get_shared_executor(num_threads: int) -> concurrent.futures.ThreadPoolExecu
 
 # the workers don't survive a fork: drop the executors in the child so that
 # they are recreated on first use
-os.register_at_fork(after_in_child=_SHARED_EXECUTORS.clear)
+if hasattr(os, "register_at_fork"):  # not available on Windows, which cannot fork
+    os.register_at_fork(after_in_child=_SHARED_EXECUTORS.clear)
 
 
 def _is_json_serializable(item):

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -2398,6 +2398,32 @@ class TensorDictFuture:
         return self.resulting_td
 
 
+_SHARED_EXECUTORS: dict[int, concurrent.futures.ThreadPoolExecutor] = {}
+_SHARED_EXECUTORS_LOCK = threading.Lock()
+
+
+def _get_shared_executor(num_threads: int) -> concurrent.futures.ThreadPoolExecutor:
+    """Returns a process-wide executor with ``num_threads`` workers.
+
+    Repeated serialization calls (e.g. checkpoint loops) reuse the pool
+    instead of spawning and tearing down threads on every call. The tasks
+    submitted to it must not themselves submit to (and wait on) the shared
+    pool, or they may deadlock.
+    """
+    with _SHARED_EXECUTORS_LOCK:
+        executor = _SHARED_EXECUTORS.get(num_threads)
+        if executor is None:
+            executor = _SHARED_EXECUTORS[num_threads] = (
+                concurrent.futures.ThreadPoolExecutor(max_workers=num_threads)
+            )
+        return executor
+
+
+# the workers don't survive a fork: drop the executors in the child so that
+# they are recreated on first use
+os.register_at_fork(after_in_child=_SHARED_EXECUTORS.clear)
+
+
 def _is_json_serializable(item):
     if isinstance(item, dict):
         for key, val in item.items():

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -20,6 +20,7 @@ from tensordict import (
 from tensordict._C import _unravel_key_to_tuple
 from tensordict.utils import (
     _check_recursive_properties,
+    _get_shared_executor,
     _getitem_batch_size,
     _make_cache_key,
     _TensorDictPropertyError,
@@ -487,6 +488,19 @@ def test_parse_tensor_dict_string():
         batch_size=[1],
     )
     assert str(td) == str(parse_tensor_dict_string(str(td)))
+
+
+def test_get_shared_executor():
+    executor = _get_shared_executor(2)
+    # repeated calls with the same thread count reuse the pool
+    assert _get_shared_executor(2) is executor
+    # distinct thread counts get distinct pools
+    assert _get_shared_executor(3) is not executor
+    assert executor.submit(lambda: 1).result() == 1
+    # the pool survives (i.e. is not shut down by) a threaded save
+    td = TensorDict({"a": torch.zeros(2), "b": torch.ones(3)})
+    td.consolidate(num_threads=2)
+    assert executor.submit(lambda: 2).result() == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1743
* #1742
* __->__ #1741
* #1740

memmap_/memmap/memmap_like and consolidate spun up (and tore down) a
fresh ThreadPoolExecutor on every call, which costs ~0.3ms per call in
thread spawn/teardown - noticeable in checkpoint loops that save small
tensordicts at every iteration. Calls with return_early=True never shut
their executor down at all, abandoning a full thread pool to the GC on
every call.

Add tensordict.utils._get_shared_executor(num_threads): a process-wide,
lazily-created pool per thread count, reused across calls. Executors do
not survive a fork, so the cache is cleared in the child via
os.register_at_fork.

The serialization tasks submitted to the pool are leaf functions that
never submit to (and wait on) the pool themselves, so sharing it cannot
deadlock.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>