### PR TITLE
[Feature] Support return_early in TensorDict.consolidate

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -6872,9 +6872,12 @@ class TensorDictBase(MutableMapping, TensorCollection):
             non_blocking (bool, optional): ``non_blocking`` argument passed to :meth:`~torch.Tensor.copy_`.
             inplace (bool, optional): if ``True``, the resulting tensordict is the same
                 as ``self`` with updated values. Defaults to ``False``.
-            return_early (bool, optional): if ``True`` and ``num_threads>0``,
-                the method will return a future of the tensordict. The resulting
-                tensordict can be queried using `future.result()`.
+            return_early (bool, optional): if ``True`` and ``num_threads>1``,
+                the method will return a :class:`~tensordict.utils.TensorDictFuture`
+                while the copies keep running in the background. The consolidated
+                tensordict can be queried using ``future.result()``. Incompatible
+                with ``use_buffer=True`` and ``non_blocking=True``. Defaults to
+                ``False``.
             use_buffer (bool, optional): if ``True`` and a filename is passed, an intermediate
                 local buffer will be created in shared memory, and the data will be copied at
                 the storage location as a last step. This may be faster than writing directly
@@ -6998,14 +7001,27 @@ class TensorDictBase(MutableMapping, TensorCollection):
         if num_threads is None:
             num_threads = 0
 
-        use_threads = num_threads > 1 and len(flat_dict) > 1
-        if use_threads and filename is not None:
+        if return_early and num_threads > 1:
+            if use_buffer:
+                raise NotImplementedError(
+                    "return_early=True is not supported with use_buffer=True in `consolidate`: "
+                    "the buffer must be written to the file once the copies are done."
+                )
+            if non_blocking:
+                raise NotImplementedError(
+                    "return_early=True is not supported with non_blocking=True in `consolidate`: "
+                    "the storage cannot be synchronized once the copies are done."
+                )
+        use_threads = num_threads > 1 and (return_early or len(flat_dict) > 1)
+        if use_threads and filename is not None and not return_early:
             # Concurrent writes into a freshly created memory-mapped file are
             # dominated by page-fault and writeback contention and measure
             # 2x-4x slower than a single fused copy on local filesystems.
             # Threads only pay off there when they can overlap device
-            # transfers.
+            # transfers. With return_early=True threading is about freeing the
+            # main thread rather than raw speed, so it is kept in that case.
             use_threads = any(v.device != storage.device for v in flat_dict.values())
+        consolidate_futures = None
         if use_threads:
             values = list(flat_dict.values())
 
@@ -7075,21 +7091,21 @@ class TensorDictBase(MutableMapping, TensorCollection):
                     if idx > chunk_start:
                         chunks.append((chunk_start, idx))
                     chunk_start = idx
-            if return_early:
-                # TODO: We'd need to make the result construction lazy to make this a thing
-                raise NotImplementedError(
-                    "return_early is not implemented yet for `consolidate`."
-                )
             executor = _get_shared_executor(num_threads)
-            wait(
-                [
-                    executor.submit(_copy_chunk, start_idx, stop_idx)
-                    for start_idx, stop_idx in chunks
-                ]
-            )
-            if non_blocking and (device is None or device.type != "cuda"):
-                # sync if needed
-                self._sync_all()
+            futures = [
+                executor.submit(_copy_chunk, start_idx, stop_idx)
+                for start_idx, stop_idx in chunks
+            ]
+            if return_early:
+                # the result construction below only manipulates storage
+                # views and metadata, so it can proceed while the copies are
+                # still running
+                consolidate_futures = futures
+            else:
+                wait(futures)
+                if non_blocking and (device is None or device.type != "cuda"):
+                    # sync if needed
+                    self._sync_all()
         else:
 
             def _view_and_pad(tensor):
@@ -7187,6 +7203,8 @@ class TensorDictBase(MutableMapping, TensorCollection):
             # with open(Path(filename).with_suffix(".json"), "wb") as f:
             #     metadata_dict["size"] = filesize
             #     f.write(json.dumps(metadata_dict))
+        if consolidate_futures is not None:
+            return TensorDictFuture(consolidate_futures, result)
         return result
 
     @classmethod

--- a/test/tensordict/test_generic.py
+++ b/test/tensordict/test_generic.py
@@ -49,6 +49,7 @@ from tensordict.utils import (
     is_tensorclass,
     set_lazy_legacy,
     set_list_to_stack,
+    TensorDictFuture,
 )
 from torch import nn
 from torch._subclasses import FakeTensor, FakeTensorMode
@@ -513,6 +514,35 @@ class TestGeneric:
         assert (td_ref._consolidated["storage"] == td_c._consolidated["storage"]).all()
         for key, val in td.items(True, True):
             assert td_c[key].dtype == val.dtype
+
+    @pytest.mark.parametrize("use_file", [False, True])
+    def test_consolidate_return_early(self, use_file, tmpdir):
+        td = TensorDict(
+            {
+                f"key{i}": torch.full((i % 5 + 1,), i, dtype=torch.float32)
+                for i in range(20)
+            },
+            batch_size=[],
+        )
+        td["nested"] = TensorDict({"a": torch.randn(3)}, batch_size=[])
+        td["string"] = "a string!"
+        kwargs = {"filename": Path(tmpdir) / "file.td"} if use_file else {}
+        future = td.consolidate(num_threads=4, return_early=True, **kwargs)
+        assert isinstance(future, TensorDictFuture)
+        td_c = future.result()
+        assert td_c.is_consolidated()
+        assert (td_c == td).all()
+        assert td_c["string"] == "a string!"
+
+        with pytest.raises(NotImplementedError, match="use_buffer"):
+            td.consolidate(
+                filename=Path(tmpdir) / "file2.td",
+                num_threads=4,
+                return_early=True,
+                use_buffer=True,
+            )
+        with pytest.raises(NotImplementedError, match="non_blocking"):
+            td.consolidate(num_threads=4, return_early=True, non_blocking=True)
 
     @pytest.mark.skipif(
         not torch.cuda.is_available() and not is_npu_available(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1743
* __->__ #1742
* #1741
* #1740

consolidate(num_threads>1, return_early=True) raised
NotImplementedError. Now that the threaded and sequential paths share
the storage-view rebuild step, the result can be constructed eagerly
(it only manipulates storage views and metadata) while the chunked
copies keep running in the worker threads, and a TensorDictFuture is
returned, mirroring memmap/memmap_/memmap_like.

Notes:

- With return_early=True the file-backed fused-copy fallback is
  skipped: the point of returning early is freeing the main thread,
  not raw throughput.
- return_early=True still raises for the two combinations that require
  main-thread work after the copies complete: use_buffer=True (final
  buffer-to-file write) and non_blocking=True (device sync).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>