### PR TITLE
[BugFix] Preserve NonTensorStack entries in contiguous()

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -4913,6 +4913,15 @@ class NonTensorStack(LazyStackedTensorDict):
     def to_tensordict(self, *, retain_none: bool | None = None):
         return self
 
+    def contiguous(
+        self, *, canonical: bool = False, inplace: bool = False
+    ) -> NonTensorStack:
+        # A NonTensorStack is already the materialized form of stacked
+        # non-tensor data: it has no tensor leaves to make contiguous, and
+        # the parent implementation would materialize it into an empty
+        # TensorDict, silently dropping the data.
+        return self
+
     def _memmap_(
         self,
         *,

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -158,6 +158,40 @@ class TestNonTensorData:
         tdcr = pickle.loads(pickle.dumps(tdc))
         assert (tdcr == td).all()
 
+    @pytest.mark.parametrize("canonical", [False, True])
+    def test_contiguous_preserves_nontensor_stack(self, canonical):
+        # Regression test: contiguous() used to materialize NonTensorStack
+        # entries into empty TensorDicts, silently dropping the data.
+        tds = [
+            TensorDict(query=NonTensorData(f"abc{i}"), x=torch.zeros(()))
+            for i in range(3)
+        ]
+        ls = lazy_stack(tds)
+        assert isinstance(ls.get("query"), NonTensorStack)
+
+        c = ls.contiguous(canonical=canonical)
+        assert not isinstance(c, LazyStackedTensorDict)
+        query = c.get("query")
+        assert isinstance(query, NonTensorStack)
+        assert query.tolist() == ["abc0", "abc1", "abc2"]
+        # indexing round-trip
+        for i in range(3):
+            assert c[i]["query"] == f"abc{i}"
+
+        # a NonTensorStack is its own contiguous form
+        stack = NonTensorStack("a", "b")
+        assert stack.contiguous(canonical=canonical) is stack
+
+        # nested case
+        ls_nested = lazy_stack(
+            [
+                TensorDict(sub=TensorDict(q=NonTensorData(f"s{i}"), y=torch.ones(2)))
+                for i in range(2)
+            ]
+        )
+        c_nested = ls_nested.contiguous(canonical=canonical)
+        assert c_nested["sub", "q"] == ["s0", "s1"]
+
     def test_comparison(self, non_tensor_data):
         non_tensor_data = non_tensor_data.exclude(("nested", "str"))
         assert (non_tensor_data | non_tensor_data).get_non_tensor(("nested", "bool"))


### PR DESCRIPTION
## Description

`TensorDict.contiguous()` silently loses stacked `NonTensorData` entries:

```python
import torch
from tensordict import TensorDict, NonTensorData, lazy_stack

tds = [TensorDict(query=NonTensorData("abc"), x=torch.zeros(())) for _ in range(3)]
ls = lazy_stack(tds)
c = ls.contiguous()
c.get("query")  # empty TensorDict(batch_size=[3]) - the strings are gone
```

## Root cause

`NonTensorStack` subclasses `LazyStackedTensorDict` but did not override `contiguous()`. The inherited implementation materializes the stack by iterating over its tensor leaves — and a stack of `NonTensorData` has no tensor leaves, so the entry was replaced by an empty `TensorDict`, losing the data. This affects any `contiguous()` call on a container holding stacked non-tensor entries, at any nesting depth, in both the `canonical=False` and `canonical=True` paths.

## Fix

Override `contiguous()` on `NonTensorStack` to return `self`, mirroring the existing `NonTensorStack.to_tensordict()` override: the stack is already the materialized form of stacked non-tensor data, and there is nothing tensor-shaped to make contiguous. Returning `self` also preserves object identity, so `inplace=True` needs no special-casing.

## Tests

Adds `test_contiguous_preserves_nontensor_stack` to `test/tensordict/test_nontensor.py`, parametrized over `canonical`, covering:
- `lazy_stack` of `NonTensorData` -> `contiguous()` -> values preserved as `NonTensorStack` and indexing round-trips (`c[i]["query"]`)
- nested non-tensor entries
- `NonTensorStack.contiguous()` being the identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)