### PR TITLE
[BugFix] Support non-contiguous TensorDict consolidation

### DIFF
--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -7045,7 +7045,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
                     stride = v.stride()
                     if (stride and stride[-1] != 1) or v.storage_offset():
                         v = v.clone(memory_format=torch.contiguous_format)
-                    flat_view = v.view(-1).view(torch.uint8)
+                    flat_view = v.reshape(-1).view(torch.uint8)
                     pad = offsets[idx + 1] - offsets[idx] - flat_view.numel()
                     if pad:
                         flat_view = torch.cat([flat_view, flat_view.new_zeros(pad)])
@@ -7116,7 +7116,7 @@ class TensorDictBase(MutableMapping, TensorCollection):
         else:
 
             def _view_and_pad(tensor):
-                result = tensor.view(-1).view(torch.uint8)
+                result = tensor.reshape(-1).view(torch.uint8)
                 # result must always have a multiple of 8 elements
                 pad = 0
                 if need_padding:

--- a/test/tensordict/test_generic.py
+++ b/test/tensordict/test_generic.py
@@ -487,6 +487,42 @@ class TestGeneric:
                 )
             ), td_c.to_dict()
 
+    @pytest.mark.parametrize("device", get_available_devices())
+    @pytest.mark.parametrize("num_threads", [0, 2])
+    def test_consolidate_non_contiguous(self, device, num_threads):
+        transposed = (
+            torch.arange(24, dtype=torch.float32, device=device)
+            .reshape(2, 3, 4)
+            .transpose(0, 1)
+        )
+        strided = torch.arange(48, dtype=torch.int64, device=device).reshape(3, 4, 4)[
+            ..., ::2
+        ]
+        with pytest.raises(RuntimeError):
+            transposed.view(-1)
+        assert strided.stride(-1) == 2
+
+        td = TensorDict({"transposed": transposed, "strided": strided}, batch_size=[])
+        td_c = td.consolidate(num_threads=num_threads)
+
+        for key, expected in td.items():
+            actual = td_c[key]
+            assert torch.equal(actual, expected)
+            assert actual.shape == expected.shape
+            assert actual.dtype == expected.dtype
+
+    @pytest.mark.parametrize("device", get_available_devices())
+    def test_consolidate_non_contiguous_requires_grad(self, device):
+        base = torch.arange(24, dtype=torch.float32, device=device, requires_grad=True)
+        transposed = base.reshape(2, 3, 4).transpose(0, 1)
+
+        actual = TensorDict({"value": transposed}, batch_size=[]).consolidate()["value"]
+
+        assert torch.equal(actual, transposed)
+        assert not actual.requires_grad
+        transposed.sum().backward()
+        assert torch.equal(base.grad, torch.ones_like(base))
+
     @pytest.mark.parametrize("use_file", [False, True])
     def test_consolidate_many_leaves_num_threads(self, use_file, tmpdir):
         # Exercises the chunked multithreaded copy path with enough leaves


### PR DESCRIPTION
## Summary

- flatten tensor leaves with `reshape` before reinterpreting them as bytes
- support non-contiguous transposed leaves in both threaded and non-threaded consolidation paths
- add regression coverage for transposed and final-dimension-strided leaves, value/shape/dtype preservation, available CPU/CUDA devices, and existing autograd detachment behavior

## Root cause

The consolidation copy paths flattened leaves with `view(-1)`, which rejects valid non-contiguous layouts when their strides cannot represent a flattened view.

## Validation

- `python -m pytest test/tensordict/test_generic.py test/tensordict/test_lazy.py test/tensorclass/test_tensorclass.py -k consolidate -q` (86 passed, 3 skipped)
- `pre-commit run --files tensordict/base.py test/tensordict/test_generic.py`
