### PR TITLE
[Test] Fix CUDA failures in non-contiguous consolidate tests

### DIFF
--- a/test/tensordict/test_generic.py
+++ b/test/tensordict/test_generic.py
@@ -502,7 +502,11 @@ class TestGeneric:
             transposed.view(-1)
         assert strided.stride(-1) == 2
 
-        td = TensorDict({"transposed": transposed, "strided": strided}, batch_size=[])
+        td = TensorDict(
+            {"transposed": transposed, "strided": strided},
+            batch_size=[],
+            device=device,
+        )
         td_c = td.consolidate(num_threads=num_threads)
 
         for key, expected in td.items():
@@ -516,7 +520,8 @@ class TestGeneric:
         base = torch.arange(24, dtype=torch.float32, device=device, requires_grad=True)
         transposed = base.reshape(2, 3, 4).transpose(0, 1)
 
-        actual = TensorDict({"value": transposed}, batch_size=[]).consolidate()["value"]
+        td = TensorDict({"value": transposed}, batch_size=[], device=device)
+        actual = td.consolidate()["value"]
 
         assert torch.equal(actual, transposed)
         assert not actual.requires_grad


### PR DESCRIPTION
## Description

The nightly GPU jobs (both stable torch 2.13 and nightly torch) have been red since 2026-07-18 with 3 failures:

```
test/tensordict/test_generic.py::TestGeneric::test_consolidate_non_contiguous[0-device1]
test/tensordict/test_generic.py::TestGeneric::test_consolidate_non_contiguous[2-device1]
test/tensordict/test_generic.py::TestGeneric::test_consolidate_non_contiguous_requires_grad[device1]
RuntimeError: Expected all tensors to be on the same device, but got other is on cuda:0,
different from other tensors on cpu (when checking argument in method wrapper_CUDA__equal)
```

Root cause: the tests added in #1747 build device-less `TensorDict`s holding CUDA leaves. `consolidate()` allocates its single backing storage on `td.device` — cpu when the tensordict has no device — and moves every leaf into that storage, so on CUDA runners the consolidated values come back on cpu and `torch.equal(actual, expected)` raises the device-mismatch error. The library change in #1747 itself is fine; CPU jobs pass 30k+ tests.

Fix: pass `device=device` to the constructors, matching the convention of `test_consolidate`. This also makes the tests exercise the on-device consolidation path with non-contiguous inputs, which is the coverage #1747 intended.

## Testing

- Reproduced the exact CI failure locally on torch 2.13.0 using MPS in place of CUDA (same single-storage device semantics): device-less construction fails with the same error for `num_threads=0` and `2`; on-device construction passes all three scenarios including the `requires_grad` variant.
- `pytest test/tensordict/test_generic.py` on torch 2.13.0 (cpu): 337 passed, 8 skipped.
- `black==24.4.2` clean.

Not addressed here: `test/tensordict/test_mp.py::TestMap::test_map_seed_single` timed out once on stable-cpu (3.10) on 2026-07-20 but passed on the 18th/19th — flaky, unrelated. The `test-rl-gpu` failures are torchrl-side test-environment issues (missing `hoptorch`, a sota-implementations import-path bug), not tensordict regressions.

Generated with [Claude Code](https://claude.com/claude-code)