### PR TITLE
[BugFix] Preserve zero-element tensors in memmap round trips

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -3156,8 +3156,29 @@ class TensorDict(TensorDictBase):
                     safe_key = legacy_key
                     memmap_file = legacy_file
 
-            if not memmap_file.exists() or dtype is None or shape is None:
+            if dtype is None or shape is None:
                 # invalid dict means
+                continue
+            shape = torch.Size(shape)
+            if not memmap_file.exists():
+                # torch.from_file does not create a backing file for a tensor
+                # with no elements. Such tensors can be reconstructed from
+                # their metadata; a missing non-empty (or nested) tensor is an
+                # incomplete entry and must not be synthesized.
+                if entry_metadata.get("is_nested", False) or shape.numel():
+                    continue
+                tensor = torch.empty(
+                    shape,
+                    device=device,
+                    dtype=_STR_DTYPE_TO_DTYPE[dtype],
+                )
+                result._set_str(
+                    key,
+                    tensor,
+                    validated=True,
+                    inplace=False,
+                    non_blocking=False,
+                )
                 continue
             try:
                 # this was absent in earlier versions of pytorch
@@ -3186,7 +3207,7 @@ class TensorDict(TensorDictBase):
                     tensor = tensor.to(device, non_blocking=True)
             else:
                 tensor = torch.zeros(
-                    torch.Size(shape),
+                    shape,
                     device=device,
                     dtype=_STR_DTYPE_TO_DTYPE[dtype],
                 )

--- a/test/tensorclass/test_tensorclass.py
+++ b/test/tensorclass/test_tensorclass.py
@@ -2664,6 +2664,26 @@ class TestTensorClass:
 
 
 class TestMemmap:
+    def test_empty_tensor_roundtrip(self, tmp_path):
+        @tensorclass
+        class MyClass:
+            vector: torch.Tensor
+            matrix: torch.Tensor
+
+        data = MyClass(
+            vector=torch.empty(0, dtype=torch.int32),
+            matrix=torch.empty(2, 0, dtype=torch.float64),
+            batch_size=[],
+        )
+        data.memmap_(tmp_path)
+
+        loaded = MyClass.load_memmap(tmp_path)
+
+        assert loaded.vector.shape == (0,)
+        assert loaded.vector.dtype is torch.int32
+        assert loaded.matrix.shape == (2, 0)
+        assert loaded.matrix.dtype is torch.float64
+
     def test_from_memmap(self, tmpdir):
         td = TensorDict(
             {

--- a/test/tensordict/test_methods.py
+++ b/test/tensordict/test_methods.py
@@ -4845,6 +4845,45 @@ class TestTensorDicts(TestTensorDictsBase):
         assert (inputs.grad == 1).all()
 
 
+class TestEmptyTensorMemmapRoundtrip:
+    @pytest.mark.parametrize("archive", [False, True])
+    def test_empty_tensor_leaves(self, tmp_path, archive):
+        td = TensorDict(
+            {
+                "empty": torch.empty(0, dtype=torch.int64),
+                "nested": {
+                    "matrix": torch.empty(0, 3, dtype=torch.float64),
+                    "robust/key": torch.empty(2, 0, dtype=torch.int16),
+                },
+            },
+            batch_size=[],
+        )
+        prefix = tmp_path / "data.tdz" if archive else tmp_path / "data"
+
+        td.memmap(prefix, robust_key=True)
+
+        assert not list(tmp_path.rglob("*.memmap"))
+        loaded = TensorDict.load_memmap(prefix, robust_key=True)
+        assert loaded["empty"].shape == (0,)
+        assert loaded["empty"].dtype is torch.int64
+        assert loaded["nested", "matrix"].shape == (0, 3)
+        assert loaded["nested", "matrix"].dtype is torch.float64
+        assert loaded["nested", "robust/key"].shape == (2, 0)
+        assert loaded["nested", "robust/key"].dtype is torch.int16
+
+    def test_missing_nonempty_leaf_is_not_reconstructed(self, tmp_path):
+        td = TensorDict(
+            {"empty": torch.empty(0), "missing": torch.ones(1)}, batch_size=[]
+        )
+        td.memmap_(tmp_path)
+        (tmp_path / "missing.memmap").unlink()
+
+        loaded = TensorDict.load_memmap(tmp_path)
+
+        assert "empty" in loaded
+        assert "missing" not in loaded
+
+
 class TestSubTensorDictMemmapRoundtrip:
     @pytest.mark.parametrize(
         "idx",


### PR DESCRIPTION
## Description

Closes #1751.

This PR reconstructs a dense zero-element tensor leaf from its memmap metadata when its backing file is absent. Reconstruction is limited to entries with complete dtype and shape metadata, a zero element count, and no nested-tensor marker.

Missing non-empty and nested-tensor payloads retain their existing behavior and are not synthesized. No placeholder files are introduced, the on-disk memmap format remains unchanged, and existing autograd behavior is unaffected.

## Motivation and Context

The root cause, minimal reproducer, affected downstream use case, and proposed fix are documented in #1751.

PhysicsNeMo currently carries a downstream workaround and associated regression coverage in [NVIDIA/physicsnemo@d1f5f9c4](https://github.com/NVIDIA/physicsnemo/commit/d1f5f9c47b1c404b1e270034a67170532d0463f9).

- [x] I have raised an issue to propose this change ([#1751](https://github.com/pytorch/tensordict/issues/1751))

## Changes

- Preserve zero-element shapes and dtypes through directory and archive memmap round trips.
- Cover nested keys, robust filesystem keys, tensorclasses, and shapes `(0,)`, `(0, 3)`, and `(2, 0)`.
- Verify that an absent non-empty payload is not mistaken for an intentional zero-element leaf.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.

## Tests

```text
197 passed, 8 skipped
```

The skipped cases are the existing `UnbatchedTensor` memmap exclusions.

```bash
python -m pytest -q \
    test/memmap/test_td_memmap_split.py \
    test/tensordict/test_misc.py::TestMemmap \
    test/tensorclass/test_tensorclass.py::TestMemmap \
    test/tensordict/test_methods.py::TestEmptyTensorMemmapRoundtrip \
    test/tensordict/test_methods.py::TestMemmapArchive \
    test/tensordict/test_methods.py::TestTensorDicts::test_memmap_like
```
