### PR TITLE
[CI] Fix Linux aarch64 nightly wheel builds

### DIFF
--- a/.github/scripts/build-aarch64-nightly-wheel.sh
+++ b/.github/scripts/build-aarch64-nightly-wheel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+sed -i.bak 's/name = "tensordict"/name = "tensordict-nightly"/' pyproject.toml
+trap 'mv pyproject.toml.bak pyproject.toml' EXIT
+
+# Dependencies, including nightly Torch, are installed by test-infra.
+SETUPTOOLS_SCM_PRETEND_VERSION="$(date +%Y.%m.%d)" python -m pip wheel --no-deps .
+mkdir -p dist
+mv tensordict_nightly-*.whl dist/

--- a/.github/scripts/version_script.sh
+++ b/.github/scripts/version_script.sh
@@ -65,6 +65,11 @@ else
 
     ${CONDA_RUN} conda install -c conda-forge pybind11 -y
 
+    # Python 3.15 beta packages on Linux split the static library from the interpreter.
+    if [[ "${OSTYPE:-}" == linux* && "${PYTHON_VERSION:-}" == 3.15* ]]; then
+        ${CONDA_RUN} conda install -c conda-forge/label/python_dev -c conda-forge libpython-static -y
+    fi
+
     # Install setuptools_scm which is required for building with --no-isolation
     # This is done here (not in pre-script) to avoid cache issues
     ${CONDA_RUN} pip install setuptools_scm

--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -63,7 +63,7 @@ jobs:
       env-var-script: .github/scripts/version_script.sh
       architecture: aarch64
       setup-miniconda: false
-      build-command: ${{ inputs.nightly && 'sed -i.bak ''s/name = "tensordict"/name = "tensordict-nightly"/'' pyproject.toml && SETUPTOOLS_SCM_PRETEND_VERSION=$(date +%Y.%m.%d) pip wheel . && rm pyproject.toml.bak && mkdir -p dist && mv tensordict_nightly-*.whl ./dist' || 'pip wheel . && mkdir -p dist && mv tensordict*.whl ./dist' }}
+      build-command: ${{ inputs.nightly && 'bash .github/scripts/build-aarch64-nightly-wheel.sh' || 'pip wheel --no-deps . && mkdir -p dist && mv tensordict*.whl ./dist' }}
       build-platform: python-build-package
       upload-to-pypi: ${{ inputs.nightly && 'cpu' || '' }}
     secrets:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -59,5 +59,5 @@ jobs:
       trigger-event: ${{ github.event_name }}
       env-var-script: .github/scripts/version_script.sh
       post-script: ${{ matrix.post-script }}
-      build-command: pip wheel . && mkdir -p dist && mv tensordict*.whl ./dist
+      build-command: pip wheel --no-deps . && mkdir -p dist && mv tensordict*.whl ./dist
       build-platform: python-build-package

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -57,7 +57,7 @@ jobs:
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}
       env-var-script: .github/scripts/version_script.sh
-      build-command: pip wheel . && mkdir -p dist && mv tensordict*.whl ./dist
+      build-command: pip wheel --no-deps . && mkdir -p dist && mv tensordict*.whl ./dist
       build-platform: python-build-package
       # Workaround for the M1 runners' Homebrew miniconda base env moving to
       # py3.14, where test-infra's `conda install -y conda=25.3.0` no longer


### PR DESCRIPTION
Today's nightly build for the new Linux aarch64 target (added by my previous PR #1756) failed because of a pretty silly shell command-scoping bug: only the initial `sed` command ran through test-infra's Conda wrapper. Everything after the first `&&`, including `pip wheel`, ran outside the prepared build environment.

Log:
https://github.com/pytorch/tensordict/actions/runs/30919780779

This fixes that by moving the complete nightly wheel build into a small script, so the whole sequence runs inside the Conda environment and `pyproject.toml` is restored even if the build fails. It also builds with `--no-deps`, since test-infra has already installed nightly PyTorch, and installs the split `libpython-static` package that CMake needs for Linux Python 3.15/3.15t builds.

I reproduced the full Linux aarch64 matrix natively (Python 3.10–3.15, including 3.14t and 3.15t). All eight wheels built successfully, passed test-infra's manylinux repair step, and passed `twine check`.
