### PR TITLE
[BugFix] Harden memmap path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ utilities.
 
 ```python
 td = TensorDict({"tokens": tokens, "scores": scores}, batch_size=[n])
-td.memmap("/tmp/batch")          # memory-map every leaf
-reloaded = TensorDict.load_memmap("/tmp/batch")
+td.memmap("/path/to/private/batch")  # memory-map every leaf
+reloaded = TensorDict.load_memmap("/path/to/private/batch")
 ```
 
 Memory-mapped TensorDicts are useful for large offline datasets, replay buffers,

--- a/docs/source/saving.rst
+++ b/docs/source/saving.rst
@@ -59,9 +59,11 @@ predictable names in a shared ``/tmp`` directory.
 
 Robust key encoding is enabled by default and keeps TensorDict keys within
 their save prefix. ``robust_key=False`` exists only to interoperate with
-legacy layouts; do not use it with untrusted keys or metadata. The high-level
-save methods overwrite existing files by default (``existsok=True``), so pass
-``existsok=False`` when replacement is not intended.
+legacy layouts; do not use it with untrusted keys or metadata. Individual
+memory-map leaf files overwrite existing regular files by default
+(``existsok=True``); pass ``existsok=False`` to reject a colliding leaf path.
+The metadata file is still refreshed when reusing an existing save directory,
+so ``existsok=False`` does not reserve the directory as a whole.
 
 tensordict's memory-mapped API relies on four core methods:
 :meth:`~tensordict.TensorDictBase.memmap_`, :meth:`~tensordict.TensorDictBase.memmap`,

--- a/docs/source/saving.rst
+++ b/docs/source/saving.rst
@@ -47,6 +47,22 @@ However, this approach also has some disadvantages:
   The :class:`~tensordict.NonTensorData` class can be used to represent non-tensor
   data in a regular :class:`~tensordict.TensorDict` instance.
 
+Filesystem considerations
+-------------------------
+
+Keep the save directory (or archive's parent directory) writable only by
+trusted principals. Existing symbolic links are rejected when creating
+individual memory-map files, but a path-based API cannot protect against a
+process that can replace names in the parent directory concurrently. Prefer
+:class:`tempfile.TemporaryDirectory` or another private directory over
+predictable names in a shared ``/tmp`` directory.
+
+Robust key encoding is enabled by default and keeps TensorDict keys within
+their save prefix. ``robust_key=False`` exists only to interoperate with
+legacy layouts; do not use it with untrusted keys or metadata. The high-level
+save methods overwrite existing files by default (``existsok=True``), so pass
+``existsok=False`` when replacement is not intended.
+
 tensordict's memory-mapped API relies on four core methods:
 :meth:`~tensordict.TensorDictBase.memmap_`, :meth:`~tensordict.TensorDictBase.memmap`,
 :meth:`~tensordict.TensorDictBase.memmap_like` and :meth:`~tensordict.TensorDictBase.load_memmap`.

--- a/docs/source/storage.rst
+++ b/docs/source/storage.rst
@@ -403,8 +403,8 @@ For **memmap**, non-tensor data is serialised via tensorclass's
    ...     label=NonTensorData(data="cat", batch_size=[4]),
    ...     batch_size=[4],
    ... )
-   >>> td_mm = td.memmap_("/tmp/example")
-   >>> loaded = TensorDict.load_memmap("/tmp/example")  # doctest: +SKIP
+   >>> td_mm = td.memmap_("/path/to/private/example")  # doctest: +SKIP
+   >>> loaded = TensorDict.load_memmap("/path/to/private/example")  # doctest: +SKIP
    >>> loaded["label"].data  # doctest: +SKIP
    'cat'
 

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -3050,6 +3050,11 @@ class TensorDict(TensorDictBase):
                         key, robust=effective_robust_key
                     )
                     value_prefix = prefix / safe_key
+                    if value_prefix.is_symlink():
+                        raise RuntimeError(
+                            "Refusing to write a memory-mapped TensorDict through "
+                            f"symlink {value_prefix}."
+                        )
                 else:
                     value_prefix = None
                 dest._tensordict[key] = value._memmap_(
@@ -3281,7 +3286,13 @@ class TensorDict(TensorDictBase):
                     safe_key = _encode_key_for_filesystem(
                         key_str, robust=effective_robust_key
                     )
-                    result_tmp.memmap_(prefix=result._memmap_prefix / safe_key)
+                    subtd_prefix = result._memmap_prefix / safe_key
+                    if subtd_prefix.is_symlink():
+                        raise RuntimeError(
+                            "Refusing to write a memory-mapped TensorDict through "
+                            f"symlink {subtd_prefix}."
+                        )
+                    result_tmp.memmap_(prefix=subtd_prefix)
                     metadata = _load_metadata(result._memmap_prefix)
                     _update_metadata(
                         metadata=metadata,

--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -67,12 +67,15 @@ from tensordict.utils import (
     _clone_value,
     _create_segments_from_int,
     _create_segments_from_list,
+    _encode_key_for_filesystem,
     _get_item,
     _get_leaf_tensordict,
+    _get_robust_key_setting_with_warning,
     _get_shape_from_args,
     _getitem_batch_size,
     _index_preserve_data_ptr,
     _infer_size_impl,
+    _is_safe_legacy_key,
     _is_shared,
     _is_unbatched,
     _KEY_ERROR,
@@ -3039,8 +3042,18 @@ class TensorDict(TensorDictBase):
         for key, value in self.items():
             type_value = type(value)
             if _is_tensor_collection(type_value):
+                if prefix is not None:
+                    effective_robust_key = _get_robust_key_setting_with_warning(
+                        key, robust_key
+                    )
+                    safe_key = _encode_key_for_filesystem(
+                        key, robust=effective_robust_key
+                    )
+                    value_prefix = prefix / safe_key
+                else:
+                    value_prefix = None
                 dest._tensordict[key] = value._memmap_(
-                    prefix=prefix / key if prefix is not None else None,
+                    prefix=value_prefix,
                     copy_existing=copy_existing,
                     executor=executor,
                     futures=futures,
@@ -3124,22 +3137,17 @@ class TensorDict(TensorDictBase):
         else:
             result = out
 
-        paths = set()
+        paths = []
         for key, entry_metadata in metadata.items():
             if not isinstance(entry_metadata, dict):
                 # there can be other metadata
                 continue
             type_value = entry_metadata.get("type")
             if type_value is not None:
-                paths.add(key)
+                paths.append(key)
                 continue
             dtype = entry_metadata.get("dtype")
             shape = entry_metadata.get("shape")
-            from .utils import (
-                _encode_key_for_filesystem,
-                _get_robust_key_setting_with_warning,
-            )
-
             # Use smart warning for loading that only warns when encoding would differ
             effective_robust_key = _get_robust_key_setting_with_warning(key, robust_key)
 
@@ -3148,7 +3156,11 @@ class TensorDict(TensorDictBase):
             memmap_file = prefix / f"{safe_key}.memmap"
 
             # If robust encoding is requested but file doesn't exist, try legacy filename
-            if not memmap_file.exists() and effective_robust_key:
+            if (
+                not memmap_file.exists()
+                and effective_robust_key
+                and _is_safe_legacy_key(key)
+            ):
                 legacy_key = _encode_key_for_filesystem(key, robust=False)
                 legacy_file = prefix / f"{legacy_key}.memmap"
                 if legacy_file.exists():
@@ -3218,27 +3230,44 @@ class TensorDict(TensorDictBase):
                 inplace=False,
                 non_blocking=False,
             )
-        # iterate over folders and load them
-        for path in prefix.iterdir():
-            if path.is_dir() and path.parts[-1] in paths:
-                key = path.parts[-1]  # path.parts[len(prefix.parts) :]
-                existing_elt = result._get_str(key, default=None)
-                if existing_elt is not None:
-                    existing_elt.load_memmap_(path)
-                else:
-                    result._set_str(
-                        key,
-                        TensorDict.load_memmap(path, device=device, non_blocking=True),
-                        inplace=False,
-                        validated=False,
-                    )
+        # Load collection directories named by metadata. New saves use robust
+        # encoding; safe single-component legacy names remain readable.
+        for key in paths:
+            effective_robust_key = _get_robust_key_setting_with_warning(key, robust_key)
+            safe_key = _encode_key_for_filesystem(key, robust=effective_robust_key)
+            path = prefix / safe_key
+            if (
+                not path.is_dir()
+                and effective_robust_key
+                and _is_safe_legacy_key(key, is_collection=True)
+            ):
+                legacy_path = prefix / key
+                if legacy_path.is_dir():
+                    path = legacy_path
+            if not path.is_dir():
+                continue
+            existing_elt = result._get_str(key, default=None)
+            if existing_elt is not None:
+                existing_elt.load_memmap_(path, robust_key=robust_key)
+            else:
+                result._set_str(
+                    key,
+                    TensorDict.load_memmap(
+                        path,
+                        device=device,
+                        non_blocking=True,
+                        robust_key=robust_key,
+                    ),
+                    inplace=False,
+                    validated=False,
+                )
         # Archive paths are read-only views inside a zip file: they cannot be
         # used as a target for a subsequent memmap_()/refresh, so only real
         # directories are recorded.
         result._memmap_prefix = prefix if isinstance(prefix, Path) else None
         return result
 
-    def _make_memmap_subtd(self, key):
+    def _make_memmap_subtd(self, key, *, robust_key):
         """Creates a sub-tensordict given a tuple key."""
         result = self
         for key_str in key:
@@ -3246,7 +3275,13 @@ class TensorDict(TensorDictBase):
             if result_tmp is None:
                 result_tmp = result.empty()
                 if result._memmap_prefix is not None:
-                    result_tmp.memmap_(prefix=result._memmap_prefix / key_str)
+                    effective_robust_key = _get_robust_key_setting_with_warning(
+                        key_str, robust_key
+                    )
+                    safe_key = _encode_key_for_filesystem(
+                        key_str, robust=effective_robust_key
+                    )
+                    result_tmp.memmap_(prefix=result._memmap_prefix / safe_key)
                     metadata = _load_metadata(result._memmap_prefix)
                     _update_metadata(
                         metadata=metadata,
@@ -3276,7 +3311,7 @@ class TensorDict(TensorDictBase):
 
         key = unravel_key(key)
         if isinstance(key, tuple):
-            last_node = self._make_memmap_subtd(key[:-1])
+            last_node = self._make_memmap_subtd(key[:-1], robust_key=robust_key)
             last_key = key[-1]
         else:
             last_node = self
@@ -3332,7 +3367,7 @@ class TensorDict(TensorDictBase):
 
         key = unravel_key(key)
         if isinstance(key, tuple):
-            last_node = self._make_memmap_subtd(key[:-1])
+            last_node = self._make_memmap_subtd(key[:-1], robust_key=robust_key)
             last_key = key[-1]
         else:
             last_node = self
@@ -3392,7 +3427,7 @@ class TensorDict(TensorDictBase):
 
         key = unravel_key(key)
         if isinstance(key, tuple):
-            last_node = self._make_memmap_subtd(key[:-1])
+            last_node = self._make_memmap_subtd(key[:-1], robust_key=robust_key)
             last_key = key[-1]
         else:
             last_node = self

--- a/tensordict/_utils_key_json.py
+++ b/tensordict/_utils_key_json.py
@@ -13,6 +13,7 @@ __all__ = [
     "_encode_key_for_filesystem",
     "_get_robust_key_setting",
     "_get_robust_key_setting_with_warning",
+    "_is_safe_legacy_key",
     "_json_dumps",
     "get_json_backend",
     "json_dumps",
@@ -28,6 +29,14 @@ def _encode_key_for_filesystem(key: str, *, robust: bool = True) -> str:
     if not robust:
         return key
 
+    # These values do not name a child when used as a path component. A bare
+    # "%" cannot be produced by the encoder (literal percent signs become
+    # "%25"), so it is an unambiguous representation for the empty key.
+    if not key:
+        return "%"
+    if key in (".", ".."):
+        return "%2E" * len(key)
+
     unsafe_chars = set('/<>:"|?*\\ \0%')
     unsafe_chars.update(chr(i) for i in range(32))
     unsafe_chars.add(chr(127))
@@ -40,6 +49,17 @@ def _encode_key_for_filesystem(key: str, *, robust: bool = True) -> str:
             encoded_parts.append(char)
 
     return "".join(encoded_parts)
+
+
+def _is_safe_legacy_key(key: str, *, is_collection: bool = False) -> bool:
+    """Return whether a raw legacy key stays beneath its memmap prefix."""
+    if "/" in key or "\\" in key:
+        return False
+    if len(key) >= 2 and key[0].isalpha() and key[1] == ":":
+        # A drive-relative path such as ``C:payload`` escapes a prefix on
+        # Windows even though it has no slash.
+        return False
+    return not is_collection or key not in ("", ".", "..")
 
 
 def _get_robust_key_setting_with_warning(key: str, robust_key) -> bool:
@@ -58,6 +78,8 @@ def _get_robust_key_setting(robust_key) -> bool:
 
 def _decode_key_from_filesystem(encoded_key: str) -> str:
     """Decode a filesystem-safe key back to the original TensorDict key."""
+    if encoded_key == "%":
+        return ""
     decoded_parts = []
     i = 0
     while i < len(encoded_key):

--- a/tensordict/base.py
+++ b/tensordict/base.py
@@ -79,12 +79,15 @@ from tensordict.utils import (
     _CloudpickleWrapper,
     _convert_list_to_stack,
     _DTYPE_TO_STR_DTYPE,
+    _encode_key_for_filesystem,
     _GENERIC_NESTED_ERR,
+    _get_robust_key_setting_with_warning,
     _get_shared_executor,
     _is_dataclass as is_dataclass,
     _is_list_tensor_compatible,
     _is_non_tensor,
     _is_number,
+    _is_safe_legacy_key,
     _is_tensorclass,
     _is_unbatched,
     _KEY_ERROR,
@@ -7989,7 +7992,22 @@ class TensorDictBase(MutableMapping, TensorCollection):
                         "strings."
                     )
             for part in subpath:
-                prefix = prefix / part
+                effective_robust_key = _get_robust_key_setting_with_warning(
+                    part, robust_key
+                )
+                safe_part = _encode_key_for_filesystem(
+                    part, robust=effective_robust_key
+                )
+                candidate = prefix / safe_part
+                if (
+                    effective_robust_key
+                    and not (candidate / "meta.json").exists()
+                    and _is_safe_legacy_key(part, is_collection=True)
+                ):
+                    legacy_candidate = prefix / part
+                    if (legacy_candidate / "meta.json").exists():
+                        candidate = legacy_candidate
+                prefix = candidate
             if not (prefix / "meta.json").exists():
                 raise ValueError(
                     f"No tensordict found under subpath {'/'.join(subpath)!r} "

--- a/tensordict/memmap.py
+++ b/tensordict/memmap.py
@@ -33,6 +33,34 @@ else:
     Self = Any
 
 
+def _prepare_memmap_file(
+    filename: Path | str, *, existsok: bool, reserve: bool = True
+) -> None:
+    """Validate a memmap path and atomically reserve it when needed."""
+    if not reserve:
+        if Path(filename).is_symlink():
+            raise RuntimeError(
+                f"Refusing to write memory-mapped tensor through symlink {filename}."
+            )
+        if not existsok and os.path.lexists(filename):
+            raise RuntimeError(f"The file {filename} already exists.")
+        return
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    try:
+        fd = os.open(os.fspath(filename), flags, 0o666)
+    except FileExistsError:
+        if Path(filename).is_symlink():
+            raise RuntimeError(
+                f"Refusing to write memory-mapped tensor through symlink {filename}."
+            )
+        if not existsok:
+            raise RuntimeError(f"The file {filename} already exists.")
+    except FileNotFoundError as err:
+        raise RuntimeError(f"{err.strerror}: {filename}") from err
+    else:
+        os.close(fd)
+
+
 class MemoryMappedTensor(torch.Tensor):
     """A Memory-mapped Tensor.
 
@@ -46,6 +74,12 @@ class MemoryMappedTensor(torch.Tensor):
         When used within RPC settings, the filepath should be accessible to both nodes.
         If it isn't the behaviour of passing a MemoryMappedTensor from one worker
         to another is undefined.
+
+    .. warning::
+        A caller that supplies ``filename`` must control its parent directory.
+        Existing symbolic links are rejected, but path-based memory mapping
+        cannot prevent another process with directory write access from
+        replacing a path after it has been validated.
 
     MemoryMappedTensor supports multiple construction methods.
 
@@ -245,8 +279,7 @@ class MemoryMappedTensor(torch.Tensor):
             result = cls(result)
         else:
             handler = None
-            if not existsok and os.path.exists(str(filename)):
-                raise RuntimeError(f"The file {filename} already exists.")
+            _prepare_memmap_file(filename, existsok=existsok, reserve=bool(shape_numel))
             result = torch.from_file(
                 str(filename),
                 shared=True,
@@ -457,6 +490,7 @@ class MemoryMappedTensor(torch.Tensor):
                 Defaults to ``False``.
         """
         shape, device, dtype, _, filename = _proc_args_const(*args, **kwargs)
+        existsok = kwargs.pop("existsok", False)
         if device is not None:
             device = torch.device(device)
             if device.type != "cpu":
@@ -464,7 +498,11 @@ class MemoryMappedTensor(torch.Tensor):
         result = torch.ones((), dtype=dtype, device=device)
         if isinstance(shape, torch.Tensor):
             return cls.empty(
-                shape, device=device, dtype=dtype, filename=filename
+                shape,
+                device=device,
+                dtype=dtype,
+                filename=filename,
+                existsok=existsok,
             ).fill_(1)
         if shape:
             if isinstance(shape[0], (list, tuple)) and len(shape) == 1:
@@ -475,7 +513,7 @@ class MemoryMappedTensor(torch.Tensor):
         return cls.from_tensor(
             result,
             filename=filename,
-            existsok=kwargs.pop("existsok", False),
+            existsok=existsok,
         )
 
     @classmethod
@@ -504,13 +542,18 @@ class MemoryMappedTensor(torch.Tensor):
                 Defaults to ``False``.
         """
         shape, device, dtype, _, filename = _proc_args_const(*args, **kwargs)
+        existsok = kwargs.pop("existsok", False)
         if device is not None:
             device = torch.device(device)
             if device.type != "cpu":
                 raise RuntimeError("Only CPU tensors are supported.")
         if isinstance(shape, torch.Tensor):
             return cls.empty(
-                shape, device=device, dtype=dtype, filename=filename
+                shape,
+                device=device,
+                dtype=dtype,
+                filename=filename,
+                existsok=existsok,
             ).fill_(0)
         result = torch.zeros((), dtype=dtype, device=device)
         if shape:
@@ -522,7 +565,7 @@ class MemoryMappedTensor(torch.Tensor):
         result = cls.from_tensor(
             result,
             filename=filename,
-            existsok=kwargs.pop("existsok", False),
+            existsok=existsok,
         )
         return result
 
@@ -560,6 +603,7 @@ class MemoryMappedTensor(torch.Tensor):
         if isinstance(shape, torch.Tensor):
             # nested tensor
             shape_numel = shape.prod(-1).sum()
+            existsok = kwargs.pop("existsok", False)
 
             if filename is None:
                 if dtype.is_floating_point:
@@ -593,6 +637,9 @@ class MemoryMappedTensor(torch.Tensor):
                 result._handler = handler
                 return result
             else:
+                _prepare_memmap_file(
+                    filename, existsok=existsok, reserve=bool(shape_numel)
+                )
                 result = torch.from_file(
                     str(filename),
                     shared=True,

--- a/tensordict/utils.py
+++ b/tensordict/utils.py
@@ -2906,6 +2906,7 @@ from tensordict._utils_key_json import (  # noqa: F401
     _encode_key_for_filesystem,
     _get_robust_key_setting,
     _get_robust_key_setting_with_warning,
+    _is_safe_legacy_key,
 )
 
 

--- a/test/memmap/test_memmap.py
+++ b/test/memmap/test_memmap.py
@@ -122,6 +122,22 @@ def test_existing(tmp_path):
     )
 
 
+def test_existing_symlink_is_rejected(tmp_path):
+    target = tmp_path / "target"
+    target.write_bytes(b"unchanged")
+    link = tmp_path / "file.memmap"
+    link.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="through symlink"):
+        MemoryMappedTensor.from_tensor(
+            torch.zeros(()),
+            filename=link,
+            existsok=True,
+        )
+
+    assert target.read_bytes() == b"unchanged"
+
+
 @pytest.mark.parametrize("shape", [(), (3, 4)])
 @pytest.mark.parametrize("dtype", [None, torch.float, torch.double, torch.int])
 @pytest.mark.parametrize("device", [None] + get_available_devices())

--- a/test/tensordict/test_misc.py
+++ b/test/tensordict/test_misc.py
@@ -1252,6 +1252,19 @@ class TestMemmap:
         loaded_subtree = TensorDict.load_memmap(prefix, subpath=(key,))
         assert_allclose_td(td[key], loaded_subtree)
 
+    def test_memmap_nested_collection_symlink_is_rejected(self, tmp_path):
+        prefix = tmp_path / "saved"
+        outside = tmp_path / "outside"
+        prefix.mkdir()
+        outside.mkdir()
+        (prefix / "nested").symlink_to(outside, target_is_directory=True)
+        td = TensorDict({"nested": {"x": torch.randn(3)}}, batch_size=[])
+
+        with pytest.raises(RuntimeError, match="TensorDict through symlink"):
+            td.memmap(prefix)
+
+        assert not list(outside.iterdir())
+
     def test_memmap_robust_load_does_not_traverse_legacy_path(self, tmp_path):
         key = "../outside"
         td = TensorDict({key: torch.randn(3)}, batch_size=[])

--- a/test/tensordict/test_misc.py
+++ b/test/tensordict/test_misc.py
@@ -29,6 +29,8 @@ from tensordict.base import TensorDictBase
 from tensordict.memmap import MemoryMappedTensor
 from tensordict.tensorclass import NonTensorData
 from tensordict.utils import (
+    _decode_key_from_filesystem,
+    _encode_key_for_filesystem,
     assert_allclose_td,
     is_non_tensor,
     is_tensorclass,
@@ -1235,6 +1237,33 @@ class TestMemmap:
         assert len(files) == 1
         assert files[0] == "a%2Fb%2Fc.memmap"  # Encoded filename
 
+    def test_memmap_robust_key_nested_pathlike(self, tmp_path):
+        key = "../outside"
+        td = TensorDict({key: {"x": torch.randn(3)}}, batch_size=[])
+        prefix = tmp_path / "saved"
+
+        td.memmap(prefix, robust_key=True)
+
+        encoded = _encode_key_for_filesystem(key)
+        assert (prefix / encoded / "meta.json").is_file()
+        assert not (tmp_path / "outside").exists()
+        loaded = TensorDict.load_memmap(prefix)
+        assert_allclose_td(td, loaded)
+        loaded_subtree = TensorDict.load_memmap(prefix, subpath=(key,))
+        assert_allclose_td(td[key], loaded_subtree)
+
+    def test_memmap_robust_load_does_not_traverse_legacy_path(self, tmp_path):
+        key = "../outside"
+        td = TensorDict({key: torch.randn(3)}, batch_size=[])
+        prefix = tmp_path / "saved"
+        td.memmap(prefix, robust_key=True)
+
+        encoded_file = prefix / f"{_encode_key_for_filesystem(key)}.memmap"
+        encoded_file.replace(tmp_path / "outside.memmap")
+
+        loaded = TensorDict.load_memmap(prefix, robust_key=True)
+        assert key not in loaded
+
     def test_memmap_robust_key_pathlike_legacy_fails(self, tmpdir):
         """Test that path-like keys still fail with robust_key=False."""
         td = TensorDict({"a/b/c": torch.randn(3, 4)})
@@ -1295,11 +1324,6 @@ class TestMemmap:
 
     def test_memmap_robust_key_encoding_bijective(self):
         """Test that key encoding is bijective."""
-        from tensordict.utils import (
-            _decode_key_from_filesystem,
-            _encode_key_for_filesystem,
-        )
-
         test_keys = [
             "a/b/c",
             "path\\with\\backslashes",
@@ -1309,10 +1333,15 @@ class TestMemmap:
             "normal_key",
             "key%with%percent",
             "",
+            ".",
+            "..",
         ]
 
+        encodings = set()
         for key in test_keys:
             encoded = _encode_key_for_filesystem(key, robust=True)
+            assert encoded not in encodings
+            encodings.add(encoded)
             decoded = _decode_key_from_filesystem(encoded)
             assert decoded == key, f"Failed: {key!r} -> {encoded!r} -> {decoded!r}"
 

--- a/test/utils/test_utils_key_json_split.py
+++ b/test/utils/test_utils_key_json_split.py
@@ -26,6 +26,9 @@ def test_filesystem_key_roundtrip_and_default():
     assert utils_module._encode_key_for_filesystem(key, robust=False) == key
     assert utils_module._get_robust_key_setting_with_warning(key, None) is True
     assert utils_module._get_robust_key_setting(None) is True
+    assert utils_module._is_safe_legacy_key("ordinary")
+    assert not utils_module._is_safe_legacy_key("../outside")
+    assert not utils_module._is_safe_legacy_key("C:outside")
 
 
 def test_json_backend_roundtrip():


### PR DESCRIPTION
## Summary

- Apply robust filesystem encoding consistently to nested TensorDict directories, dynamically created subtrees, and `subpath` resolution.
- Retain legacy-layout fallback for safe single-component names.
- Reserve new memory-map targets atomically, reject symbolic-link targets, and preserve the existing no-file behavior for zero-element tensors.
- Clarify filesystem ownership and overwrite expectations in the storage documentation.

## Rationale

Nested collections previously did not use the same filesystem-key handling as tensor leaves. This aligns save and load behavior across both cases while retaining the explicit `robust_key=False` compatibility path and existing overwrite workflows.

## Validation

- `1760 passed, 54 skipped` across memmap-focused constructor, TensorDict, and round-trip tests
- Focused robust-key, legacy-layout, symbolic-link, and key-codec checks
- Repository-pinned ufmt, flake8, and pydocstyle checks
- RST-title and diff validation
