### PR TITLE
[BugFix] Add TensorDictModuleBase repr

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -793,12 +793,6 @@ class TensorDictModuleBase(nn.Module):
         # This is necessary to make compiled vmap over TDModule happy
         return self.__class__.__name__
 
-    @property
-    def device(self) -> torch.device:
-        for p in self.parameters():
-            return p.device
-        return torch.device("cpu")
-
     def __repr__(self) -> str:
         entries = [f"{name}={module}" for name, module in self.named_children()]
         # a wrapped callable that is not an nn.Module (a plain function, a lambda, ...)
@@ -806,7 +800,6 @@ class TensorDictModuleBase(nn.Module):
         module = self.__dict__.get("module")
         if module is not None:
             entries.insert(0, f"module={module}")
-        entries.append(f"device={self.device}")
         entries.append(f"in_keys={self.in_keys}")
         entries.append(f"out_keys={self.out_keys}")
         fields = indent(",\n".join(entries), 4 * " ")
@@ -1234,6 +1227,12 @@ class TensorDictModule(TensorDictModuleBase):
             raise err from RuntimeError(
                 f"TensorDictModule failed with operation\n{module}\n{in_keys}\n{out_keys}."
             )
+
+    @property
+    def device(self) -> torch.device:
+        for p in self.parameters():
+            return p.device
+        return torch.device("cpu")
 
     def __getattr__(self, name: str) -> Any:
         if not is_compiling():

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -793,8 +793,24 @@ class TensorDictModuleBase(nn.Module):
         # This is necessary to make compiled vmap over TDModule happy
         return self.__class__.__name__
 
-    def __repr__(self):
-        return f"{self.__class__.__name__}()"
+    @property
+    def device(self) -> torch.device:
+        for p in self.parameters():
+            return p.device
+        return torch.device("cpu")
+
+    def __repr__(self) -> str:
+        entries = [f"{name}={module}" for name, module in self.named_children()]
+        # a wrapped callable that is not an nn.Module (a plain function, a lambda, ...)
+        # is stored as a regular attribute, hence missing from the children
+        module = self.__dict__.get("module")
+        if module is not None:
+            entries.insert(0, f"module={module}")
+        entries.append(f"device={self.device}")
+        entries.append(f"in_keys={self.in_keys}")
+        entries.append(f"out_keys={self.out_keys}")
+        fields = indent(",\n".join(entries), 4 * " ")
+        return f"{type(self).__name__}(\n{fields})"
 
 
 class TensorDictModule(TensorDictModuleBase):
@@ -1218,23 +1234,6 @@ class TensorDictModule(TensorDictModuleBase):
             raise err from RuntimeError(
                 f"TensorDictModule failed with operation\n{module}\n{in_keys}\n{out_keys}."
             )
-
-    @property
-    def device(self) -> torch.device:
-        for p in self.parameters():
-            return p.device
-        return torch.device("cpu")
-
-    def __repr__(self) -> str:
-        fields = indent(
-            f"module={self.module},\n"
-            f"device={self.device},\n"
-            f"in_keys={self.in_keys},\n"
-            f"out_keys={self.out_keys}",
-            4 * " ",
-        )
-
-        return f"{type(self).__name__}(\n{fields})"
 
     def __getattr__(self, name: str) -> Any:
         if not is_compiling():

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -360,6 +360,40 @@ class TestTDModule:
 
         assert td["b"] == 4
 
+    def test_repr(self):
+        class MyModule(TensorDictModuleBase):
+            in_keys = ["a"]
+            out_keys = ["b"]
+
+            def __init__(self):
+                super().__init__()
+                self.net = nn.Linear(3, 4)
+
+            def forward(self, tensordict):
+                tensordict.set("b", self.net(tensordict.get("a")))
+                return tensordict
+
+        string = repr(MyModule())
+        assert "MyModule(" in string
+        assert "net=Linear(in_features=3, out_features=4" in string
+        assert "device=" in string
+        assert "in_keys=['a']" in string
+        assert "out_keys=['b']" in string
+
+        # an nn.Module payload is a child: listed once, and not through __dict__
+        mod = TensorDictModule(nn.Linear(3, 4), in_keys=["a"], out_keys=["b"])
+        assert "module" not in mod.__dict__
+        string = repr(mod)
+        assert string.count("module=") == 1
+        assert "module=Linear(in_features=3, out_features=4" in string
+
+        # a callable that is not an nn.Module is not a child: it comes from __dict__
+        mod = TensorDictModule(lambda x: x + 1, in_keys=["a"], out_keys=["b"])
+        assert dict(mod.named_children()) == {}
+        string = repr(mod)
+        assert string.count("module=") == 1
+        assert "module=<function" in string
+
     def test_mutable_sequence(self):
         in_keys = self.MyMutableSequence(["a", "b", "c"])
         out_keys = self.MyMutableSequence(["d", "e", "f"])

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -376,7 +376,7 @@ class TestTDModule:
         string = repr(MyModule())
         assert "MyModule(" in string
         assert "net=Linear(in_features=3, out_features=4" in string
-        assert "device=" in string
+        assert "device=" not in string
         assert "in_keys=['a']" in string
         assert "out_keys=['b']" in string
 


### PR DESCRIPTION
## Description

Moves `__repr__` to `TensorDictModuleBase` so subclasses provide an informative representation of their child modules, input keys, and output keys. The representation does not report a device because a module may contain state on multiple devices.

## Follow-up

#1770 deprecates the existing `TensorDictModule.device` property for removal in TensorDict 0.17. It was developed as a direct stack on this PR and rebased onto `main` after this PR merged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature which changes existing functionality)
- [ ] Documentation

## Checklist

- [x] I have read the contribution guide.
- [x] I have updated the tests accordingly.
- [ ] My change requires documentation updates.