### PR TITLE
[Deprecation] Deprecate TensorDictModule.device

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -793,12 +793,6 @@ class TensorDictModuleBase(nn.Module):
         # This is necessary to make compiled vmap over TDModule happy
         return self.__class__.__name__
 
-    @property
-    def device(self) -> torch.device:
-        for p in self.parameters():
-            return p.device
-        return torch.device("cpu")
-
     def __repr__(self) -> str:
         entries = [f"{name}={module}" for name, module in self.named_children()]
         # a wrapped callable that is not an nn.Module (a plain function, a lambda, ...)
@@ -806,7 +800,6 @@ class TensorDictModuleBase(nn.Module):
         module = self.__dict__.get("module")
         if module is not None:
             entries.insert(0, f"module={module}")
-        entries.append(f"device={self.device}")
         entries.append(f"in_keys={self.in_keys}")
         entries.append(f"out_keys={self.out_keys}")
         fields = indent(",\n".join(entries), 4 * " ")
@@ -1234,6 +1227,12 @@ class TensorDictModule(TensorDictModuleBase):
             raise err from RuntimeError(
                 f"TensorDictModule failed with operation\n{module}\n{in_keys}\n{out_keys}."
             )
+
+    @property
+    def device(self) -> torch.device:
+        for p in self.parameters():
+            return p.device
+        return torch.device("cpu")
 
     def __getattr__(self, name: str) -> Any:
         if not is_compiling():

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -1230,6 +1230,19 @@ class TensorDictModule(TensorDictModuleBase):
 
     @property
     def device(self) -> torch.device:
+        """A deprecated approximation of the module device.
+
+        .. deprecated:: 0.15
+            This property will be removed in TensorDict 0.17 because modules may
+            contain parameters and buffers on multiple devices.
+        """
+        warnings.warn(
+            "TensorDictModule.device is deprecated and will be removed in "
+            "TensorDict 0.17. Modules may contain parameters and buffers on "
+            "multiple devices; inspect the relevant module state explicitly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         for p in self.parameters():
             return p.device
         return torch.device("cpu")

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -793,8 +793,24 @@ class TensorDictModuleBase(nn.Module):
         # This is necessary to make compiled vmap over TDModule happy
         return self.__class__.__name__
 
-    def __repr__(self):
-        return f"{self.__class__.__name__}()"
+    @property
+    def device(self) -> torch.device:
+        for p in self.parameters():
+            return p.device
+        return torch.device("cpu")
+
+    def __repr__(self) -> str:
+        entries = [f"{name}={module}" for name, module in self.named_children()]
+        # a wrapped callable that is not an nn.Module (a plain function, a lambda, ...)
+        # is stored as a regular attribute, hence missing from the children
+        module = self.__dict__.get("module")
+        if module is not None:
+            entries.insert(0, f"module={module}")
+        entries.append(f"device={self.device}")
+        entries.append(f"in_keys={self.in_keys}")
+        entries.append(f"out_keys={self.out_keys}")
+        fields = indent(",\n".join(entries), 4 * " ")
+        return f"{type(self).__name__}(\n{fields})"
 
 
 class TensorDictModule(TensorDictModuleBase):
@@ -1218,23 +1234,6 @@ class TensorDictModule(TensorDictModuleBase):
             raise err from RuntimeError(
                 f"TensorDictModule failed with operation\n{module}\n{in_keys}\n{out_keys}."
             )
-
-    @property
-    def device(self) -> torch.device:
-        for p in self.parameters():
-            return p.device
-        return torch.device("cpu")
-
-    def __repr__(self) -> str:
-        fields = indent(
-            f"module={self.module},\n"
-            f"device={self.device},\n"
-            f"in_keys={self.in_keys},\n"
-            f"out_keys={self.out_keys}",
-            4 * " ",
-        )
-
-        return f"{type(self).__name__}(\n{fields})"
 
     def __getattr__(self, name: str) -> Any:
         if not is_compiling():

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -394,6 +394,11 @@ class TestTDModule:
         assert string.count("module=") == 1
         assert "module=<function" in string
 
+    def test_device_deprecation(self):
+        mod = TensorDictModule(nn.Linear(3, 4), in_keys=["a"], out_keys=["b"])
+        with pytest.warns(DeprecationWarning, match=r"removed in TensorDict 0\.17"):
+            assert mod.device == torch.device("cpu")
+
     def test_mutable_sequence(self):
         in_keys = self.MyMutableSequence(["a", "b", "c"])
         out_keys = self.MyMutableSequence(["d", "e", "f"])

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -360,6 +360,40 @@ class TestTDModule:
 
         assert td["b"] == 4
 
+    def test_repr(self):
+        class MyModule(TensorDictModuleBase):
+            in_keys = ["a"]
+            out_keys = ["b"]
+
+            def __init__(self):
+                super().__init__()
+                self.net = nn.Linear(3, 4)
+
+            def forward(self, tensordict):
+                tensordict.set("b", self.net(tensordict.get("a")))
+                return tensordict
+
+        string = repr(MyModule())
+        assert "MyModule(" in string
+        assert "net=Linear(in_features=3, out_features=4" in string
+        assert "device=" in string
+        assert "in_keys=['a']" in string
+        assert "out_keys=['b']" in string
+
+        # an nn.Module payload is a child: listed once, and not through __dict__
+        mod = TensorDictModule(nn.Linear(3, 4), in_keys=["a"], out_keys=["b"])
+        assert "module" not in mod.__dict__
+        string = repr(mod)
+        assert string.count("module=") == 1
+        assert "module=Linear(in_features=3, out_features=4" in string
+
+        # a callable that is not an nn.Module is not a child: it comes from __dict__
+        mod = TensorDictModule(lambda x: x + 1, in_keys=["a"], out_keys=["b"])
+        assert dict(mod.named_children()) == {}
+        string = repr(mod)
+        assert string.count("module=") == 1
+        assert "module=<function" in string
+
     def test_mutable_sequence(self):
         in_keys = self.MyMutableSequence(["a", "b", "c"])
         out_keys = self.MyMutableSequence(["d", "e", "f"])

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -376,7 +376,7 @@ class TestTDModule:
         string = repr(MyModule())
         assert "MyModule(" in string
         assert "net=Linear(in_features=3, out_features=4" in string
-        assert "device=" in string
+        assert "device=" not in string
         assert "in_keys=['a']" in string
         assert "out_keys=['b']" in string
 


### PR DESCRIPTION
## Description

Deprecates `TensorDictModule.device` in TensorDict 0.15 and schedules its removal for TensorDict 0.17. A module may contain parameters and buffers on multiple devices, so a single inferred device is not a valid module-level property.

The property retains its existing behavior during the deprecation window and emits a `DeprecationWarning` with the removal version. The generated API documentation also marks it as deprecated. No replacement scalar-device API is introduced.

This PR is stacked on #1767 and should merge after it. Once #1767 lands, this branch can be rebased onto `main`.

## Test plan

- `python -m pytest test/nn/test_nn.py -k "repr or device_deprecation" -q`
- `python -m pytest test/nn -q` (610 passed, 1 skipped)
- Black, critical Ruff checks, and `git diff --check`