### PR TITLE
[Deprecation] Deprecate TensorDictModule.device

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -1230,6 +1230,19 @@ class TensorDictModule(TensorDictModuleBase):
 
     @property
     def device(self) -> torch.device:
+        """A deprecated approximation of the module device.
+
+        .. deprecated:: 0.15
+            This property will be removed in TensorDict 0.17 because modules may
+            contain parameters and buffers on multiple devices.
+        """
+        warnings.warn(
+            "TensorDictModule.device is deprecated and will be removed in "
+            "TensorDict 0.17. Modules may contain parameters and buffers on "
+            "multiple devices; inspect the relevant module state explicitly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         for p in self.parameters():
             return p.device
         return torch.device("cpu")

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -394,6 +394,11 @@ class TestTDModule:
         assert string.count("module=") == 1
         assert "module=<function" in string
 
+    def test_device_deprecation(self):
+        mod = TensorDictModule(nn.Linear(3, 4), in_keys=["a"], out_keys=["b"])
+        with pytest.warns(DeprecationWarning, match=r"removed in TensorDict 0\.17"):
+            assert mod.device == torch.device("cpu")
+
     def test_mutable_sequence(self):
         in_keys = self.MyMutableSequence(["a", "b", "c"])
         out_keys = self.MyMutableSequence(["d", "e", "f"])


### PR DESCRIPTION
## Description

Deprecates `TensorDictModule.device` in TensorDict 0.15 and schedules its removal for TensorDict 0.17. A module may contain parameters and buffers on multiple devices, so a single inferred device is not a valid module-level property.

The property retains its existing behavior during the deprecation window and emits a `DeprecationWarning` with the removal version. The generated API documentation also marks it as deprecated. No replacement scalar-device API is introduced.

This change was developed as a direct follow-up to #1767 and has now been rebased onto `main` after that PR merged.

## Test plan

- `python -m pytest test/nn/test_nn.py -k "repr or device_deprecation" -q`
- `python -m pytest test/nn -q` (610 passed, 1 skipped)
- Black, critical Ruff checks, and `git diff --check`