### PR TITLE
[BugFix] keep ragged lazy stacks during batched indexing

### DIFF
--- a/tensordict/_lazy.py
+++ b/tensordict/_lazy.py
@@ -2696,6 +2696,8 @@ class LazyStackedTensorDict(TensorDictBase):
                     result.lock_()
                 return result
 
+    __getitems__ = __getitem__
+
     def __eq__(self, other):
         return self._dispatch_comparison(other, "__eq__", "__eq__", default=False)
 

--- a/test/tensordict/test_lazy.py
+++ b/test/tensordict/test_lazy.py
@@ -275,6 +275,13 @@ class TestLazyStackedTensorDict:
         test_td = LazyStackedTensorDict(*batches)
         assert_allclose_td(td, test_td)
 
+    def test_batched_indexing_ragged_lazy_stack(self):
+        tensordict = lazy_stack([TensorDict(x=torch.zeros(i)) for i in range(5)])
+        indices = [3, 0, 4]
+        batch = tensordict.__getitems__(indices)
+        assert isinstance(batch, LazyStackedTensorDict)
+        assert [len(td["x"]) for td in batch] == indices
+
     def test_all_keys(self):
         td = TensorDict({"a": torch.zeros(1)}, [])
         td2 = TensorDict({"a": torch.zeros(2)}, [])


### PR DESCRIPTION
### TLDR

LazyStackedTensorDict inherited batched indexing from the base class, which tried to stack ragged values. Routing it through its own indexing keeps the result lazy.

Closes #1296.

<details>
<summary>Reproduction</summary>

```python
import torch

from tensordict import LazyStackedTensorDict, TensorDict, lazy_stack

tensordict = lazy_stack([TensorDict(x=torch.zeros(i)) for i in range(5)])
indices = [3, 0, 4]
batch = tensordict.__getitems__(indices)

assert isinstance(batch, LazyStackedTensorDict)
assert [len(td["x"]) for td in batch] == indices
```

On `main`, batched indexing raises while stacking the unequal tensors. With this change, the ragged selection stays lazy.

</details>

<details>
<summary>Tests</summary>

```bash
python -m pytest -q \
  test/tensordict/test_lazy.py::TestLazyStackedTensorDict::test_batched_indexing_ragged_lazy_stack

python -m pytest -q test/tensordict/test_lazy.py
python -m pytest -q test/tensordict
```

Results: 1 passed; 667 passed, 3 skipped; 7,944 passed, 899 skipped.

</details>