### PR TITLE
[BugFix] update TensorDictModule out_keys on assignment

### DIFF
--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -391,7 +391,7 @@ class _OutKeysSelect:
         self.module = module
         if not all(key in module.out_keys for key in self.out_keys):
             raise RuntimeError("Some keys are not part of the module out_keys.")
-        module.out_keys = self.out_keys
+        module._out_keys_apparent = self.out_keys
 
     def __call__(  # noqa: F811
         self,
@@ -409,7 +409,7 @@ class _OutKeysSelect:
         if not tensordict_in and kwargs.get("tensordict") is not None:
             tensordict_in = kwargs.pop("tensordict")
         is_dispatched = self._detect_dispatch(tensordict_in, kwargs, in_keys)
-        out_keys = self.out_keys
+        out_keys = module.out_keys
         # if dispatch filtered the out keys as they should we're happy
         if is_dispatched:
             if (not isinstance(tensordict_out, tuple) and len(out_keys) == 1) or (
@@ -563,11 +563,7 @@ class TensorDictModuleBase(nn.Module):
 
     @out_keys.setter
     def out_keys(self, value: List[Union[str, Tuple[str]]]):
-        # the first time out_keys are set, they are marked as ground truth
-        value = unravel_key_list(list(value))
-        if not hasattr(self, "_out_keys"):
-            self._out_keys = value
-        self._out_keys_apparent = value
+        self._out_keys = self._out_keys_apparent = unravel_key_list(list(value))
 
     def select_out_keys(self, *out_keys) -> TensorDictModuleBase:  # noqa: F811
         """Selects the keys that will be found in the output tensordict.

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -387,11 +387,21 @@ class _OutKeysSelect:
     def _init(self, module):
         if self._initialized:
             return
-        self._initialized = True
-        self.module = module
         if not all(key in module.out_keys for key in self.out_keys):
             raise RuntimeError("Some keys are not part of the module out_keys.")
+        had_out_keys_apparent = "_out_keys_apparent" in module.__dict__
+        out_keys_apparent = module.__dict__.get("_out_keys_apparent")
         module._out_keys_apparent = self.out_keys
+        if module.out_keys != self.out_keys:
+            if had_out_keys_apparent:
+                module._out_keys_apparent = out_keys_apparent
+            else:
+                del module._out_keys_apparent
+            raise RuntimeError(
+                f"{type(module).__name__} does not support select_out_keys."
+            )
+        self._initialized = True
+        self.module = module
 
     def __call__(  # noqa: F811
         self,
@@ -672,10 +682,9 @@ class TensorDictModuleBase(nn.Module):
                 ):
                     err_msg += f"Are you passing the keys in a list? Try unpacking as: `{', '.join(out_keys[0])}`"
                 raise ValueError(err_msg)
-        self.register_forward_hook(_OutKeysSelect(out_keys), with_kwargs=True)
-        for hook in self._forward_hooks.values():
-            if isinstance(hook, _OutKeysSelect):
-                hook._init(self)
+        hook = _OutKeysSelect(out_keys)
+        hook._init(self)
+        self.register_forward_hook(hook, with_kwargs=True)
         return self
 
     def reset_out_keys(self):
@@ -1319,6 +1328,19 @@ class TensorDictModuleWrapper(TensorDictModuleBase):
         if len(self.td_module._forward_hooks):
             for pre_hook in self.td_module._forward_hooks:
                 self.register_forward_hook(self.td_module._forward_hooks[pre_hook])
+
+    @property
+    def out_keys(self):
+        return self.__dict__.get("_out_keys_apparent", self.td_module.out_keys)
+
+    @property
+    def out_keys_source(self):
+        return self.td_module.out_keys_source
+
+    @out_keys.setter
+    def out_keys(self, value: List[Union[str, Tuple[str]]]):
+        self.td_module.out_keys = value
+        self._out_keys_apparent = self.td_module.out_keys
 
     def __getattr__(self, name: str) -> Any:
         if not is_compiling():

--- a/tensordict/nn/common.py
+++ b/tensordict/nn/common.py
@@ -389,6 +389,7 @@ class _OutKeysSelect:
             return
         if not all(key in module.out_keys for key in self.out_keys):
             raise RuntimeError("Some keys are not part of the module out_keys.")
+        self.source = list(module.out_keys)
         had_out_keys_apparent = "_out_keys_apparent" in module.__dict__
         out_keys_apparent = module.__dict__.get("_out_keys_apparent")
         module._out_keys_apparent = self.out_keys
@@ -397,6 +398,12 @@ class _OutKeysSelect:
                 module._out_keys_apparent = out_keys_apparent
             else:
                 del module._out_keys_apparent
+            out_keys_property = type(module).out_keys
+            if out_keys_property.fset is not None:
+                module.out_keys = self.out_keys
+        if module.out_keys != self.out_keys:
+            if out_keys_property.fset is not None:
+                module.out_keys = self.source
             raise RuntimeError(
                 f"{type(module).__name__} does not support select_out_keys."
             )
@@ -474,11 +481,10 @@ class _OutKeysSelect:
         return True
 
     def remove(self):
-        # reset ground truth
         if self.module is None:
             return
-        if self.module._out_keys is not None:
-            self.module.out_keys = self.module._out_keys
+        if self.module.out_keys == self.out_keys:
+            self.module.out_keys = self.source
 
     def __del__(self):
         self.remove()
@@ -720,7 +726,7 @@ class TensorDictModuleBase(nn.Module):
                 device=None,
                 is_shared=False)
         """
-        for i, hook in list(self._forward_hooks.items()):
+        for i, hook in reversed(list(self._forward_hooks.items())):
             if isinstance(hook, _OutKeysSelect):
                 hook.remove()
                 del self._forward_hooks[i]

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -275,7 +275,7 @@ class TensorDictSequential(TensorDictModule):
             selected_out_keys = unravel_key_list(selected_out_keys)
             if not all(key in self.out_keys for key in selected_out_keys):
                 raise ValueError("All keys in selected_out_keys must be in out_keys.")
-            self.out_keys = selected_out_keys
+            self._out_keys_apparent = selected_out_keys
         else:
             self._select_before_return = False
 
@@ -337,7 +337,7 @@ class TensorDictSequential(TensorDictModule):
         selected_out_keys = unravel_key_list(selected_out_keys)
         if not all(key in self.out_keys for key in selected_out_keys):
             raise ValueError("All keys in selected_out_keys must be in out_keys.")
-        self.out_keys = selected_out_keys
+        self._out_keys_apparent = selected_out_keys
         return self
 
     def select_subsequence(

--- a/tensordict/nn/sequence.py
+++ b/tensordict/nn/sequence.py
@@ -191,6 +191,15 @@ class TensorDictSequential(TensorDictModule):
     module: nn.ModuleList
     _select_before_return = False
 
+    @property
+    def out_keys(self):
+        return self._out_keys_apparent
+
+    @out_keys.setter
+    def out_keys(self, value: List[NestedKey]):
+        self._out_keys = self._out_keys_apparent = unravel_key_list(list(value))
+        self._complete_out_keys = list(self._out_keys)
+
     @overload
     def __init__(
         self,

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -408,9 +408,12 @@ class TestTDModule:
         assert "e" in td
         assert "f" in td
 
-    def test_out_keys_setter(self):
+    @pytest.mark.parametrize("wrap", [False, True])
+    def test_out_keys_setter(self, wrap):
         net = nn.Linear(3, 4)
         td_module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
+        if wrap:
+            td_module = TensorDictModuleWrapper(td_module)
 
         def split_output(module, args, output):
             return output, output.mean(dim=1)
@@ -430,6 +433,19 @@ class TestTDModule:
         td_module.select_out_keys("out1")
         td_module.out_keys = ["out1", "out2"]
         assert "out2" in td_module(TensorDict({"in": x}, [3]))
+
+    def test_select_out_keys_unsupported_property(self):
+        module = ProbabilisticTensorDictModule(
+            in_keys=["loc", "scale"],
+            out_keys=["sample"],
+            distribution_class=Normal,
+            return_log_prob=True,
+        )
+
+        with pytest.raises(RuntimeError, match="does not support select_out_keys"):
+            module.select_out_keys("sample")
+        td = module(TensorDict({"loc": torch.zeros(()), "scale": torch.ones(())}, []))
+        assert set(module.out_keys).issubset(td.keys())
 
     def test_auto_unravel(self):
         tdm = TensorDictModule(
@@ -1295,6 +1311,20 @@ class TestTDSequence:
         assert set(seq.in_keys) == set(unravel_key_list(("key1", "key2", "key3")))
         assert seq.out_keys == ["key2"]
         assert seq.out_keys_source == ["foo1", "key1", "key2"]
+
+    def test_out_keys_setter(self):
+        module = TensorDictModule(
+            lambda x: (x, x + 1), in_keys=["in"], out_keys=["out1", "out2"]
+        )
+        seq = TensorDictSequential(module)
+        module.out_keys = ["new_out1", "new_out2"]
+        seq.out_keys = module.out_keys
+
+        seq.select_out_keys("new_out2").reset_out_keys()
+
+        assert seq.out_keys == seq.out_keys_source == ["new_out1", "new_out2"]
+        out1, out2 = seq(torch.zeros(()))
+        torch.testing.assert_close(out2, out1 + 1)
 
     def test_key_exclusion_constructor_exec(self):
         module1 = TensorDictModule(

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -408,6 +408,29 @@ class TestTDModule:
         assert "e" in td
         assert "f" in td
 
+    def test_out_keys_setter(self):
+        net = nn.Linear(3, 4)
+        td_module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])
+
+        def split_output(module, args, output):
+            return output, output.mean(dim=1)
+
+        net.register_forward_hook(split_output)
+        td_module.out_keys = ["out1", "out2"]
+
+        x = torch.randn(3, 3)
+        td_out = td_module(TensorDict({"in": x}, [3]))
+        assert td_module.out_keys == td_module.out_keys_source == ["out1", "out2"]
+        assert "out" not in td_out
+        torch.testing.assert_close(td_out["out2"], td_out["out1"].mean(dim=1))
+
+        out1, out2 = td_module(x)
+        torch.testing.assert_close(out2, out1.mean(dim=1))
+
+        td_module.select_out_keys("out1")
+        td_module.out_keys = ["out1", "out2"]
+        assert "out2" in td_module(TensorDict({"in": x}, [3]))
+
     def test_auto_unravel(self):
         tdm = TensorDictModule(
             lambda x: x,
@@ -1271,6 +1294,7 @@ class TestTDSequence:
         )
         assert set(seq.in_keys) == set(unravel_key_list(("key1", "key2", "key3")))
         assert seq.out_keys == ["key2"]
+        assert seq.out_keys_source == ["foo1", "key1", "key2"]
 
     def test_key_exclusion_constructor_exec(self):
         module1 = TensorDictModule(
@@ -2022,6 +2046,7 @@ class TestSelectOutKeys:
             mod2 = mod.select_out_keys(*out_d_key)
             assert mod2 is mod
             assert mod.out_keys == unravel_key_list(out_d_key)
+            assert mod.out_keys_source == ["c", "d", "e"]
             td = mod(TensorDict({"a": torch.zeros(()), "b": torch.ones(())}, []))
             assert "c" not in td.keys()
             assert all(key in td.keys() for key in ["a", "b", "d"])
@@ -2148,6 +2173,7 @@ class TestSelectOutKeys:
             mod2 = mod.select_out_keys(*out_d_key)
             assert mod2 is mod
             assert mod.out_keys == unravel_key_list(out_d_key)
+            assert mod.out_keys_source == ["c", "d", "e"]
             td = mod(TensorDict({"a": torch.zeros(()), "b": torch.ones(())}, []))
             assert "c" not in td.keys()
             assert all(key in td.keys() for key in ["a", "b", "d"])

--- a/test/nn/test_nn.py
+++ b/test/nn/test_nn.py
@@ -434,7 +434,25 @@ class TestTDModule:
         td_module.out_keys = ["out1", "out2"]
         assert "out2" in td_module(TensorDict({"in": x}, [3]))
 
-    def test_select_out_keys_unsupported_property(self):
+    def test_select_out_keys_property(self):
+        class PropertyModule(TensorDictModuleBase):
+            @property
+            def out_keys(self):
+                return self.keys
+
+            @out_keys.setter
+            def out_keys(self, value):
+                self.keys = value
+
+        module = PropertyModule()
+        module.out_keys = ["a", "b"]
+        module.select_out_keys("a").select_out_keys("a").reset_out_keys()
+        assert module.out_keys == ["a", "b"]
+        module.select_out_keys("a")
+        module.out_keys = ["a", "c"]
+        module.reset_out_keys()
+        assert module.out_keys == ["a", "c"]
+
         module = ProbabilisticTensorDictModule(
             in_keys=["loc", "scale"],
             out_keys=["sample"],


### PR DESCRIPTION
### TLDR

Assigning `TensorDictModule.out_keys` changed the visible keys but left the keys used to write module outputs unchanged. Changing a module's output count therefore paired its outputs with stale keys and failed.

This PR updates both key lists on assignment while keeping `select_out_keys` limited to output filtering.

Fixes https://github.com/pytorch/tensordict/issues/1407

<details><summary>Testing</summary>
<p>

### Direct reproduction

```python
import torch
from torch import nn
from tensordict import TensorDict
from tensordict.nn import TensorDictModule

net = nn.Linear(3, 4)
module = TensorDictModule(net, in_keys=["in"], out_keys=["out"])

def split_output(module, args, output):
    return output, output.mean(dim=1)

net.register_forward_hook(split_output)
module.out_keys = ["out1", "out2"]

x = torch.randn(3, 3)
result = module(TensorDict({"in": x}, [3]))

assert module.out_keys == module.out_keys_source == ["out1", "out2"]
assert "out" not in result
assert result["out1"].shape == (3, 4)
assert result["out2"].shape == (3,)
torch.testing.assert_close(result["out2"], result["out1"].mean(dim=1))

out1, out2 = module(x)
torch.testing.assert_close(out2, out1.mean(dim=1))

module.select_out_keys("out1")
module.out_keys = ["out1", "out2"]
assert "out2" in module(TensorDict({"in": x}, [3]))
```

### Test suites

```bash
pytest \
  test/nn/test_nn.py::TestTDModule::test_out_keys_setter \
  test/nn/test_nn.py::TestTDSequence::test_key_exclusion_constructor \
  test/nn/test_nn.py::TestSelectOutKeys -q
# 62 passed

pytest test/nn -q
# 611 passed, 

pytest test/compile/test_compile.py::TestCudaGraphs::test_tdmodule -q
# 2 passed

pre-commit run --files \
  tensordict/nn/common.py \
  tensordict/nn/sequence.py \
  test/nn/test_nn.py
# all hooks passed
```

</p>
</details>