### PR TITLE
[BugFix] Restore unpickling of frozen tensorclasses

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1963,11 +1963,14 @@ def _setstate(self, state: dict[str, Any]) -> None:  # noqa: D417
     Args:
         state (dict): State parameter to set the object
     """
-    # after dataclass(), frozen=True installs a guard __setattr__ that would reject a
-    # plain assignment here. object.__setattr__ is the same bypass the frozen __init__
-    # uses (see _has_custom_setattr in _tensorclass).
-    object.__setattr__(self, "_tensordict", state.get("tensordict"))
-    object.__setattr__(self, "_non_tensordict", state.get("non_tensordict"))
+    if type(self)._frozen:
+        # Bypass the dataclass guard while preserving custom __setattr__ behavior
+        # for non-frozen tensorclasses.
+        object.__setattr__(self, "_tensordict", state.get("tensordict"))
+        object.__setattr__(self, "_non_tensordict", state.get("non_tensordict"))
+    else:
+        self._tensordict = state.get("tensordict")
+        self._non_tensordict = state.get("non_tensordict")
 
 
 def _getattr_tensor_only(self, item: str, **kwargs) -> Any:

--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -1963,8 +1963,11 @@ def _setstate(self, state: dict[str, Any]) -> None:  # noqa: D417
     Args:
         state (dict): State parameter to set the object
     """
-    self._tensordict = state.get("tensordict")
-    self._non_tensordict = state.get("non_tensordict")
+    # after dataclass(), frozen=True installs a guard __setattr__ that would reject a
+    # plain assignment here. object.__setattr__ is the same bypass the frozen __init__
+    # uses (see _has_custom_setattr in _tensorclass).
+    object.__setattr__(self, "_tensordict", state.get("tensordict"))
+    object.__setattr__(self, "_non_tensordict", state.get("non_tensordict"))
 
 
 def _getattr_tensor_only(self, item: str, **kwargs) -> Any:

--- a/test/tensorclass/test_tensorclass.py
+++ b/test/tensorclass/test_tensorclass.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import ast
 import contextlib
+import copy
 import dataclasses
 import importlib.util
 import inspect
@@ -251,6 +252,12 @@ except Exception:
 class TCStrings:
     a: str
     b: str
+
+
+@tensorclass(frozen=True)
+class MyDataFrozen:
+    X: torch.Tensor
+    z: str
 
 
 class TestTensorClass:
@@ -1376,6 +1383,27 @@ class TestTensorClass:
         )
         assert isinstance(data2, MyData)
         assert data2.z == data.z
+
+    def test_pickle_frozen(self):
+        data = MyDataFrozen(
+            X=torch.ones(3, 4, 5), z="test_tensorclass", batch_size=[3, 4]
+        )
+        data2 = pickle.loads(pickle.dumps(data))
+        assert isinstance(data2, MyDataFrozen)
+        assert (data2.X == data.X).all()
+        assert data2.z == data.z
+        assert data2.batch_size == data.batch_size
+
+    def test_copy_frozen(self):
+        # copy.copy restores through __setstate__, like pickle does
+        data = MyDataFrozen(
+            X=torch.ones(3, 4, 5), z="test_tensorclass", batch_size=[3, 4]
+        )
+        data2 = copy.copy(data)
+        assert isinstance(data2, MyDataFrozen)
+        assert (data2.X == data.X).all()
+        assert data2.z == data.z
+        assert data2.batch_size == data.batch_size
 
     @pytest.mark.parametrize("consolidate", [False, True])
     def test_pickle_consolidate(self, consolidate):

--- a/test/tensorclass/test_tensorclass.py
+++ b/test/tensorclass/test_tensorclass.py
@@ -1384,26 +1384,15 @@ class TestTensorClass:
         assert isinstance(data2, MyData)
         assert data2.z == data.z
 
-    def test_pickle_frozen(self):
+    def test_pickle_copy_frozen(self):
         data = MyDataFrozen(
             X=torch.ones(3, 4, 5), z="test_tensorclass", batch_size=[3, 4]
         )
-        data2 = pickle.loads(pickle.dumps(data))
-        assert isinstance(data2, MyDataFrozen)
-        assert (data2.X == data.X).all()
-        assert data2.z == data.z
-        assert data2.batch_size == data.batch_size
-
-    def test_copy_frozen(self):
-        # copy.copy restores through __setstate__, like pickle does
-        data = MyDataFrozen(
-            X=torch.ones(3, 4, 5), z="test_tensorclass", batch_size=[3, 4]
-        )
-        data2 = copy.copy(data)
-        assert isinstance(data2, MyDataFrozen)
-        assert (data2.X == data.X).all()
-        assert data2.z == data.z
-        assert data2.batch_size == data.batch_size
+        for data2 in (pickle.loads(pickle.dumps(data)), copy.copy(data)):
+            assert isinstance(data2, MyDataFrozen)
+            assert (data2.X == data.X).all()
+            assert data2.z == data.z
+            assert data2.batch_size == data.batch_size
 
     @pytest.mark.parametrize("consolidate", [False, True])
     def test_pickle_consolidate(self, consolidate):


### PR DESCRIPTION
## Description

`_setstate` now restores `_tensordict` / `_non_tensordict` through `object.__setattr__` instead of plain assignment, so a `frozen=True` tensorclass can be unpickled.

## Motivation and Context

Closes #1774.

`_setstate` is installed on every tensorclass in `_tensorclass`, frozen ones included, but it assigns to `self._tensordict`, which the dataclass frozen guard rejects. A frozen tensorclass therefore pickles fine and raises `FrozenInstanceError` on load; `copy.copy` fails identically, since it goes through the same `__setstate__`. (`copy.deepcopy` is unaffected — it is routed through `TensorDictBase.__deepcopy__`.)

The practical symptom is a `DataLoader` with `num_workers > 0` dying in the pin-memory thread having produced no batch.

`object.__setattr__` is the same escape hatch the frozen `__init__` already uses, and is a no-op for non-frozen classes.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/tensordict/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

Added `TestTensorClass::test_pickle_frozen` and `TestTensorClass::test_copy_frozen`, alongside the existing `test_pickle`, plus a module-level `MyDataFrozen` for them to pickle (a locally defined class cannot).

Both fail on `main` with `FrozenInstanceError` and pass with the fix. Local validation, built from source:

- `pytest test/tensorclass/` — 320 passed, 16 skipped
- `pytest test/tensordict -k "pickle or copy or serial or setstate"` — 120 passed, 2 skipped

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
