### PR TITLE
[BugFix] Copy NonTensorStack entries on advanced indexing

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -5329,6 +5329,24 @@ class NonTensorStack(LazyStackedTensorDict):
             )
         return self
 
+    def __getitem__(self, index: IndexType) -> NonTensorStack | NonTensorDataBase | Any:
+        result = super().__getitem__(index)
+        if not isinstance(result, NonTensorStack):
+            return result
+        indices = index if isinstance(index, tuple) else (index,)
+        if all(
+            idx is None or idx is Ellipsis or isinstance(idx, (int, slice))
+            for idx in indices
+        ):
+            # basic indexing shares the entries, like a view
+            return result
+        # Advanced indexing (tensors, masks, lists) copies, as it does for
+        # tensors. The lazy stack would otherwise hand out the source entries
+        # themselves, so a repeated index yields aliased entries and a later
+        # in-place assignment on the result rewrites the source and every
+        # alias at once.
+        return result.clone(recurse=False)
+
     def __setitem__(self, index: IndexType, value: Any):
         memmap = False
         if self._is_memmap and hasattr(self, "_path_to_memmap"):

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -1043,6 +1043,51 @@ class TestNonTensorData:
         assert empty.batch_size == torch.Size([0])
         assert empty.tolist() == []
 
+    def test_nontensorstack_advanced_index_copies(self):
+        stack = NonTensorStack("walk", "jump", "stand")
+        # advanced indexing returns independent entries, as it does for
+        # tensors: neither the source nor the repeated entries alias each other
+        gathered = stack[torch.tensor([1, 0, 0, 1, 1])]
+        assert gathered.tolist() == ["jump", "walk", "walk", "jump", "jump"]
+        gathered[torch.tensor([True, False, False, False, True])] = NonTensorStack(
+            "walk", "stand"
+        )
+        assert gathered.tolist() == ["walk", "walk", "walk", "jump", "stand"]
+        assert stack.tolist() == ["walk", "jump", "stand"]
+        masked = stack[torch.tensor([True, False, True])]
+        masked[0] = "hop"
+        assert masked.tolist() == ["hop", "stand"]
+        assert stack.tolist() == ["walk", "jump", "stand"]
+        listed = stack[[2, 2]]
+        listed[1] = "hop"
+        assert listed.tolist() == ["stand", "hop"]
+        assert stack.tolist() == ["walk", "jump", "stand"]
+        # basic indexing keeps view semantics
+        view = stack[1:]
+        view[0] = "hop"
+        assert stack.tolist() == ["walk", "hop", "stand"]
+
+    def test_tensorclass_nontensor_field_gather_then_assign(self):
+        @tensorclass
+        class Task:
+            weight: torch.Tensor
+            instruction: str
+
+        library = torch.stack(
+            [
+                Task(torch.tensor([0.0]), "walk", batch_size=[]),
+                Task(torch.tensor([1.0]), "jump", batch_size=[]),
+                Task(torch.tensor([2.0]), "stand", batch_size=[]),
+            ]
+        )
+        per_env = library[torch.tensor([1, 0, 0, 1, 1])]
+        per_env[torch.tensor([True, False, False, False, True])] = library[
+            torch.tensor([0, 2])
+        ]
+        assert per_env.weight.squeeze(-1).tolist() == [0.0, 0.0, 0.0, 1.0, 2.0]
+        assert list(per_env.instruction) == ["walk", "walk", "walk", "jump", "stand"]
+        assert list(library.instruction) == ["walk", "jump", "stand"]
+
 
 class TestMetaData:
     def test_typed_metadata(self):


### PR DESCRIPTION
## Summary

Indexing a `NonTensorStack` with a tensor, a list or a boolean mask handed out the source `NonTensorData` entries themselves instead of copies. A repeated index, such as gathering a per-env task from a task library with `library[task_id]`, therefore produced a stack whose entries alias each other and the source. A later in-place assignment on the result, for instance a masked reset `per_env[mask] = ...`, then rewrote the source stack and every alias at once. Tensor leaves of the same stacked tensorclass were unaffected, so the string field silently disagreed with the tensor fields:

```python
@tensorclass
class Task:
    weight: torch.Tensor
    instruction: str

library = torch.stack([Task(torch.tensor([0.]), "walk"), Task(torch.tensor([1.]), "jump"), Task(torch.tensor([2.]), "stand")])
per_env = library[torch.tensor([1, 0, 0, 1, 1])]
per_env[torch.tensor([True, False, False, False, True])] = library[torch.tensor([0, 2])]
per_env.weight.squeeze(-1).tolist()   # [0., 0., 0., 1., 2.]  correct
list(per_env.instruction)             # ['stand', 'walk', 'walk', 'stand', 'stand']  wrong, expected ['walk', 'walk', 'walk', 'jump', 'stand']
list(library.instruction)             # ['walk', 'stand', 'stand']  the library was rewritten too
```

## Fix

`NonTensorStack.__getitem__` now returns fresh entries for advanced indices (tensors, masks, lists, ranges), matching tensor semantics: a shallow clone creates new `NonTensorData` containers that share the payload. Basic indexing with ints, slices, `None` and `Ellipsis` keeps sharing the entries, like a view, so `stack[1:][0] = "x"` still writes through as before.

The dense `TensorDict` and tensorclass indexing paths reach the stack through `_get_item`, so the tensorclass case above is covered by the same override.

Out of scope: a plain `LazyStackedTensorDict` still shares its sub-tensordicts under advanced indexing. Copying there would clone arbitrarily large tensors on every gather, which is a separate design decision.

## Tests

`test/tensordict/test_nontensor.py`:

- `test_nontensorstack_advanced_index_copies`: tensor, mask and list indexing return independent entries and leave the source untouched, while slice indexing keeps view semantics.
- `test_tensorclass_nontensor_field_gather_then_assign`: the reproduction above, asserting the string field agrees with the tensor field and the library is untouched.

Both fail on `main` and pass with this change. `test/tensordict/test_nontensor.py` (including `--runslow`) and the non-tensor, indexing and stacking selections of the tensorclass, generic, methods, nn, store and compile suites pass locally.
