### PR TITLE
[CI] Restore release validation across platforms

### DIFF
--- a/.github/unittest/rl_linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/rl_linux_optdeps/scripts/run_all.sh
@@ -136,11 +136,14 @@ uv_pip_install --no-build-isolation --no-deps -e .
 # smoke test
 python -c "import tensordict"
 
+printf "* Installing hoptorch\n"
+uv_pip_install "hoptorch>=0.1.4"
+
 printf "* Installing torchrl\n"
 git clone https://github.com/pytorch/rl
+git -C rl checkout --detach "${TORCHRL_REF}"
 cd rl
 uv_pip_install --no-build-isolation --no-deps -e .
-cd ..
 
 # smoke test
 python -c "import torchrl"
@@ -150,9 +153,9 @@ python -c "import torchrl"
 
 python -m torch.utils.collect_env
 
-MUJOCO_GL=egl python -m pytest rl/test --instafail -v --durations 20 \
-  --ignore rl/test/test_distributed.py \
-  --ignore rl/test/llm \
+MUJOCO_GL=egl python -m pytest test --instafail -v --durations 20 \
+  --ignore test/test_distributed.py \
+  --ignore test/llm \
   --timeout=120
 
 # ==================================================================================== #

--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: 'main'
+      python-versions:
+        description: 'JSON-encoded list of Python versions to build; empty builds all supported versions'
+        required: false
+        type: string
+        default: '[]'
       nightly:
         description: 'Build and publish tensordict-nightly wheels'
         required: false
@@ -38,6 +43,7 @@ jobs:
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      python-versions: ${{ inputs.python-versions || '[]' }}
       with-cuda: disable
   build:
     needs: generate-matrix

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: 'main'
+      python-versions:
+        description: 'JSON-encoded list of Python versions to build; empty builds all supported versions'
+        required: false
+        type: string
+        default: '[]'
   workflow_dispatch:
 
 permissions:
@@ -35,6 +40,7 @@ jobs:
       with-rocm: disable
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      python-versions: ${{ inputs.python-versions || '[]' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: 'main'
+      python-versions:
+        description: 'JSON-encoded list of Python versions to build; empty builds all supported versions'
+        required: false
+        type: string
+        default: '[]'
   workflow_dispatch:
 
 permissions:
@@ -33,6 +38,7 @@ jobs:
       os: macos-arm64
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      python-versions: ${{ inputs.python-versions || '[]' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: 'main'
+      python-versions:
+        description: 'JSON-encoded list of Python versions to build; empty builds all supported versions'
+        required: false
+        type: string
+        default: '[]'
   workflow_dispatch:
 
 permissions:
@@ -34,6 +39,7 @@ jobs:
       with-cuda: disable
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      python-versions: ${{ inputs.python-versions || '[]' }}
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,7 @@ jobs:
     uses: ./.github/workflows/build-wheels-linux.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
+      python-versions: ${{ inputs.tag == 'v0.14.1' && '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]' || '[]' }}
 
   build-windows:
     name: Build Windows Wheels
@@ -256,6 +257,7 @@ jobs:
     uses: ./.github/workflows/build-wheels-windows.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
+      python-versions: ${{ inputs.tag == 'v0.14.1' && '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]' || '[]' }}
 
   build-macos:
     name: Build macOS Wheels
@@ -265,6 +267,7 @@ jobs:
     uses: ./.github/workflows/build-wheels-m1.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
+      python-versions: ${{ inputs.tag == 'v0.14.1' && '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]' || '[]' }}
 
   build-aarch64:
     name: Build Aarch64 Linux Wheels
@@ -274,6 +277,7 @@ jobs:
     uses: ./.github/workflows/build-wheels-aarch64-linux.yml
     with:
       test-infra-ref: ${{ inputs.pytorch_release || 'main' }}
+      python-versions: ${{ inputs.tag == 'v0.14.1' && '["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]' || '[]' }}
 
   # =============================================================================
   # COLLECT WHEELS

--- a/.github/workflows/test-rl-gpu.yml
+++ b/.github/workflows/test-rl-gpu.yml
@@ -12,6 +12,9 @@ on:
 
 env:
   CHANNEL: "nightly"
+  # Keep reverse-dependency results reproducible. Bump this only after the
+  # corresponding TorchRL revision has passed this integration suite.
+  TORCHRL_REF: 565e826ef7589006fbde5c4c45c0ec5e2329538b
 
 concurrency:
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.

--- a/test/compile/test_compile.py
+++ b/test/compile/test_compile.py
@@ -903,10 +903,11 @@ class TestTTDDynamoCompatibility:
         assert result == 3.0
 
     @pytest.mark.xfail(
+        TORCH_VERSION < version.parse("2.14.0"),
         strict=True,
         reason=(
             "TensorDict subclass arithmetic hits _has_mps graph break "
-            "without explicit pytree registration."
+            "without explicit pytree registration before torch 2.14."
         ),
     )
     def test_td_subclass_arithmetic_without_registration(self):

--- a/test/tensordict/test_misc.py
+++ b/test/tensordict/test_misc.py
@@ -806,6 +806,9 @@ class TestJacobians:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.filterwarnings(
+                "ignore", message=r"`torch\.jit\.script`.*", category=FutureWarning
+            )
             J = jacfwd(f)(td)
         assert J.batch_size == td.batch_size
         a_flat = td["a"].flatten()
@@ -829,6 +832,9 @@ class TestJacobians:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.filterwarnings(
+                "ignore", message=r"`torch\.jit\.script`.*", category=FutureWarning
+            )
             H = hessian(f)(td)
         assert H.batch_size == td.batch_size
         a_shape = td["a"].shape


### PR DESCRIPTION
## Summary

- make the wheel workflows accept test-infra's explicit Python matrix and omit Python 3.15/3.15t only for the v0.14.1 release
- bound the Dynamo compatibility xfail to PyTorch versions before 2.14 and ignore only the expected `torch.jit.script` future warning in Jacobian tests
- make the TorchRL reverse-dependency check reproducible by pinning its previously tested revision, installing its required `hoptorch` dependency, and running the suite from the TorchRL checkout

Normal main/nightly wheel builds and releases other than v0.14.1 continue to use test-infra's full default Python matrix.

## Test plan

- `python -m pytest -q test/compile/test_compile.py::TestTTDDynamoCompatibility::test_td_subclass_arithmetic_without_registration test/tensordict/test_misc.py::TestJacobians::test_jacfwd test/tensordict/test_misc.py::TestJacobians::test_hessian` (8 passed, 1 expected xfail with local PyTorch 2.11)
- parsed all workflow YAML files with PyYAML
- `bash -n .github/unittest/rl_linux_optdeps/scripts/run_all.sh`
- `git diff --check`
