### PR TITLE
[CI] Define integration ref inside test container

### DIFF
--- a/.github/unittest/rl_linux_optdeps/scripts/run_all.sh
+++ b/.github/unittest/rl_linux_optdeps/scripts/run_all.sh
@@ -141,7 +141,7 @@ uv_pip_install "hoptorch>=0.1.4"
 
 printf "* Installing torchrl\n"
 git clone https://github.com/pytorch/rl
-git -C rl checkout --detach "${TORCHRL_REF}"
+git -C rl checkout --detach "${TORCHRL_REF:-565e826ef7589006fbde5c4c45c0ec5e2329538b}"
 cd rl
 uv_pip_install --no-build-isolation --no-deps -e .
 


### PR DESCRIPTION
## Summary

Define the pinned integration revision at the point where it is consumed, because workflow-level environment variables are not propagated into the test-infra container.

Without the fallback, the integration script exits under `set -u` before checking out the pinned dependency revision.

## Test plan

- `bash -n .github/unittest/rl_linux_optdeps/scripts/run_all.sh`
- verified the fallback expansion with `TORCHRL_REF` unset under `bash -u`
- rerun the full integration workflow after merge
