### PR TITLE
[Compile] Preserve nested structure in shallow TensorDict copies

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -3616,6 +3616,8 @@ class TensorDict(TensorDictBase):
         if not recurse and is_compiling():
             result = TensorDict(batch_size=self.batch_size, device=self.device)
             schema = self._locked_schema
+            _src = self._tensordict
+            _dst = result._tensordict
             if self._is_locked and schema is not None:
                 # Locked-fast-path: walk the cached immutable key tuple
                 # instead of ``result._tensordict.update(self._tensordict)``
@@ -3625,12 +3627,11 @@ class TensorDict(TensorDictBase):
                 # guards on the immutable schema tuple, which Dynamo can
                 # potentially share across TDs that lock to the same
                 # key set.
-                _src = self._tensordict
-                _dst = result._tensordict
-                for key in schema.keys:
-                    _dst[key] = _src[key]
+                keys = schema.keys
             else:
-                result._tensordict.update(self._tensordict)
+                keys = _src
+            for key in keys:
+                _dst[key] = _clone_value(_src[key], recurse=False)
             return result
 
         result = self._new_unsafe(

--- a/test/compile/test_compile.py
+++ b/test/compile/test_compile.py
@@ -294,10 +294,12 @@ class TestTD:
         data_c_c = clone_c(data)
         assert_close(data_c, data_c_c)
         assert clone_c(data) is not data
+        data_c_c.rename_key_(("a", "b"), ("a", "renamed"))
+        assert ("a", "b") in data.keys(include_nested=True)
         if recurse:
-            assert clone_c(data)["a", "b"] is not data["a", "b"]
+            assert clone_c(data)["a", "c"] is not data["a", "c"]
         else:
-            assert clone_c(data)["a", "b"] is data["a", "b"]
+            assert clone_c(data)["a", "c"] is data["a", "c"]
 
     @pytest.mark.parametrize("recurse", [True, False])
     def test_flatten_keys(self, recurse, mode):


### PR DESCRIPTION
## Summary

- preserve independent nested TensorDict container structure in compiled shallow copies
- keep tensor leaves shared, matching eager copy semantics
- cover the regression in the existing compile clone test matrix

Fixes #1783.

## Testing

- pytest test/compile/test_compile.py (219 passed, 19 skipped, 2 xfailed)
- ufmt and flake8 on the changed files