### PR TITLE
[BugFix] Preserve non-tensor values during concatenation

### DIFF
--- a/tensordict/tensorclass.py
+++ b/tensordict/tensorclass.py
@@ -4203,6 +4203,10 @@ class NonTensorDataBase(TensorClass):
     ) -> Callable:
         # A modified version of __torch_function__ to account for the different behaviour
         # of stack, which should return lazy stacks of data of data does not match.
+        if func is torch.cat and all(
+            issubclass(t, (NonTensorData, NonTensorStack)) for t in types
+        ):
+            return NonTensorData._cat_non_tensor(*args, **(kwargs or {}))
         if func not in _TD_PASS_THROUGH or not all(
             issubclass(t, (Tensor, cls)) for t in types
         ):
@@ -4633,6 +4637,44 @@ class NonTensorData(NonTensorDataBase):
     _from_dict = classmethod(_from_dict)
     _from_tensordict = classmethod(_from_tensordict)
     __repr__ = NonTensorDataBase.__repr__
+
+    @classmethod
+    def _cat_non_tensor(cls, tensors, dim=0, out=None):
+        # Concatenate the values, not the empty TensorDicts that carry their
+        # batch sizes. Converting to those TensorDicts loses every value but
+        # the first and cannot dispatch mixed NonTensorData/NonTensorStack inputs.
+        batch_size = tensors[0].batch_size
+        if not -len(batch_size) <= dim < len(batch_size):
+            raise RuntimeError(
+                f"dim must index a batch dimension, got dim={dim} and "
+                f"batch_size={batch_size}"
+            )
+        dim %= len(batch_size)
+        other_dims = batch_size[:dim] + batch_size[dim + 1 :]
+        values = []
+        for tensor in tensors:
+            shape = tensor.batch_size
+            if (
+                len(shape) != len(batch_size)
+                or shape[:dim] + shape[dim + 1 :] != other_dims
+            ):
+                raise RuntimeError(
+                    "Non-tensor batch sizes must match outside the concatenation "
+                    f"dimension, got {batch_size} and {shape}."
+                )
+            values.extend(tensor.unbind(dim))
+        result = (
+            cls._stack_non_tensor(values, dim=dim) if values else tensors[0].clone()
+        )
+        if out is not None:
+            if out.batch_size != result.batch_size:
+                raise RuntimeError("out.batch_size and cat batch size must match.")
+            if isinstance(out, NonTensorData) and isinstance(result, NonTensorStack):
+                with set_capture_non_tensor_stack(True):
+                    result = cls._stack_non_tensor(values, dim=dim)
+            out.update_(result)
+            return out
+        return result
 
     def expand(self, *args, **kwargs) -> T:
         # tensordict_dims = self.batch_dims

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -217,6 +217,56 @@ class TestNonTensorData:
             ("nested", "bool")
         )
 
+    @pytest.mark.parametrize("capture", [False, True])
+    @pytest.mark.parametrize("dim", [0, 1, -1])
+    @pytest.mark.parametrize("stacked", [(False, False), (False, True), (True, False)])
+    @pytest.mark.parametrize("with_out", [False, True])
+    def test_cat_preserves_non_tensor_values(self, capture, dim, stacked, with_out):
+        items = [
+            (
+                NonTensorStack.from_list([[value, value + 1], [value + 2, value + 3]])
+                if as_stack
+                else NonTensorData(value, batch_size=[2, 2])
+            )
+            for value, as_stack in zip((0, 4), stacked)
+        ]
+        expected = torch.cat([torch.tensor(item.tolist()) for item in items], dim)
+        out = NonTensorStack.from_list(torch.full_like(expected, -1).tolist())
+        with set_capture_non_tensor_stack(capture):
+            result = torch.cat(items, dim=dim, out=out if with_out else None)
+        if with_out:
+            assert result is out
+        assert result.batch_size == expected.shape
+        assert result.tolist() == expected.tolist()
+
+    @pytest.mark.parametrize("capture", [False, True])
+    def test_cat_non_tensor_data_out(self, capture):
+        items = [NonTensorData("value", batch_size=[2])] * 2
+        out = NonTensorData("old", batch_size=[4])
+        with set_capture_non_tensor_stack(capture):
+            assert torch.cat(items, out=out) is out
+        assert out.tolist() == ["value"] * 4
+
+    @pytest.mark.parametrize("capture", [False, True])
+    def test_cat_pads_nested_non_tensor_values(self, capture):
+        with set_capture_non_tensor_stack(capture):
+            batch = lazy_stack(
+                [
+                    TensorDict(
+                        observation=torch.tensor([float(index)]),
+                        metadata=TensorDict(index=NonTensorData(index)),
+                    )
+                    for index in range(2)
+                ]
+            ).contiguous()
+            result = torch.cat([batch, batch[-1:].expand(2)])
+        assert result.batch_size == (4,)
+        assert result.get(("metadata", "index")).tolist() == [0, 1, 1, 1]
+        torch.testing.assert_close(
+            result["observation"], torch.tensor([[0.0], [1.0], [1.0], [1.0]])
+        )
+        assert batch.get(("metadata", "index")).tolist() == [0, 1]
+
     def test_expand(self):
         d = NonTensorData(0, batch_size=(3,))
         d_expand = d.expand((2, 3))


### PR DESCRIPTION
Concatenating `NonTensorData` and `NonTensorStack` currently fails dispatch. This occurs when padding a non-tensor batch: with non-tensor capture enabled, slicing and expanding the final value can produce `NonTensorData` beside the original `NonTensorStack`. Concatenating two `NonTensorData` inputs with different values also silently repeats the first input's value.

Route these inputs through value-preserving concatenation instead of concatenating their empty internal TensorDicts. Keep batch-dimension validation and support `out=`, including a uniform `NonTensorData` destination. No public API is added.

For example, this now preserves all four labels:

```python
with set_capture_non_tensor_stack(True):
    labels = NonTensorStack("a", "b")
    padded = torch.cat([labels, labels[-1:].expand(2)])
    assert padded.tolist() == ["a", "b", "b", "b"]
```

Validation:
- The initial regression matrix had 37 failures before the fix. The final tests cover both mixed-input orders, uniform inputs, positive and negative dimensions, output buffers, and padding nested metadata alongside tensors.
- `test/tensordict/test_nontensor.py test/tensordict/test_lazy.py --runslow`: 859 passed, 3 skipped (unavailable streaming/CUDA/NPU).
- Repository-pinned ufmt and flake8 checks passed; `git diff --check` passed.
- A full-graph `torch.compile` padding probe is blocked by the existing `id()` handling in non-tensor slicing, before concatenation. This change does not extend compile support.
