### PR TITLE
[BugFix] Preserve nested trailing dim names when clearing parent names

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -2507,11 +2507,14 @@ class TensorDict(TensorDictBase):
         self._td_dim_names = list(value)
 
     def _rename_subtds(self, names):
+        """Propagates names to nested tensordicts.
+
+        A child may have more batch dims than self. Only the first
+        self.batch_dims are shared, so names beyond that are the child's own
+        and are left alone. ``names=None`` clears the shared dims.
+        """
         if names is None:
-            for item in self._tensordict.values():
-                if _is_tensor_collection(type(item)):
-                    item._erase_names()
-            return
+            names = [None] * self.batch_dims
         for item in self._tensordict.values():
             if isinstance(item, TensorDict):
                 # For TensorDict items, we can directly set _td_dim_names
@@ -2521,6 +2524,8 @@ class TensorDict(TensorDictBase):
                     td_names = list(names) + [None] * (item.batch_dims - len(names))
                 else:
                     td_names = list(names) + list(item_names)[len(names) :]
+                if all(name is None for name in td_names):
+                    td_names = None
                 item._td_dim_names = td_names
                 # Recursively rename nested tensor collections
                 item._rename_subtds(td_names)

--- a/tensordict/persistent.py
+++ b/tensordict/persistent.py
@@ -1288,7 +1288,7 @@ class PersistentTensorDict(TensorDictBase):
             names = [None] * self.ndim
         for item in self._nested_tensordicts.values():
             if is_tensor_collection(item):
-                td_names = list(names) + [None] * (item.ndim - self.ndim)
+                td_names = list(names) + list(item.names)[self.ndim :]
                 item.rename_(*td_names)
 
     def contiguous(self, *, canonical: bool = False):

--- a/tensordict/store/_store.py
+++ b/tensordict/store/_store.py
@@ -1305,7 +1305,7 @@ class TensorDictStore(TensorDictBase):
             names = [None] * self.ndim
         for item in self._nested_tensordicts.values():
             if is_tensor_collection(item):
-                td_names = list(names) + [None] * (item.ndim - self.ndim)
+                td_names = list(names) + list(item.names)[self.ndim :]
                 item.rename_(*td_names)
 
     # ---- Key access / mutation ----

--- a/test/tensordict/test_nameddims.py
+++ b/test/tensordict/test_nameddims.py
@@ -212,6 +212,20 @@ class TestNamedDims(TestTensorDictsBase):
         td.rename_(c="g")
         assert td.names == list("abgd")
 
+    @pytest.mark.skipif(not _has_h5py, reason="h5py not installed")
+    def test__PersistentTensorDict__names_setter__keeps_nested_trailing_name(
+        self, tmpdir
+    ):
+        td = TensorDict(
+            {"agents": TensorDict({"obs": torch.zeros(2, 3, 4)}, [2, 3])}, [2]
+        )
+        tdh5 = td.to_h5(filename=tmpdir / "file.h5")
+        tdh5["agents"].names = [None, "agent"]
+        tdh5.names = ["batch"]
+        assert tdh5["agents"].names == ["batch", "agent"]
+        tdh5.names = None
+        assert tdh5["agents"].names == [None, "agent"]
+
     def test_index(self):
         td = TensorDict(batch_size=[3, 4, 5, 6], names=["a", "b", "c", "d"])
         assert td[0].names == ["b", "c", "d"]
@@ -456,6 +470,26 @@ class TestNamedDims(TestTensorDictsBase):
         td["a"] = TensorDict({}, [3, 4], names=["a", "b"])
         assert td.names == ["a"]
         assert td["a"].names == ["a", "b"]
+
+    def test__TensorDict__init__nested_trailing_name_survives(self):
+        sub = TensorDict({"obs": torch.zeros(2, 3, 4)}, [2, 3], names=[None, "agent"])
+        td = TensorDict({"agents": sub}, [2])
+        assert td["agents"].names == [None, "agent"]
+        assert sub.names == [None, "agent"]
+
+    def test__TensorDict__names_setter__none_keeps_nested_trailing_name(self):
+        sub = TensorDict({"obs": torch.zeros(2, 3, 4)}, [2, 3], names=[None, "agent"])
+        td = TensorDict({"agents": sub}, [2], names=["batch"])
+        assert td["agents"].names == ["batch", "agent"]
+        td.names = None
+        assert td.names == [None]
+        assert td["agents"].names == [None, "agent"]
+
+    def test__TensorDict__names_setter__none_erases_unnamed_nested(self):
+        td = TensorDict({"sub": TensorDict({}, [2, 3])}, [2], names=["batch"])
+        assert td["sub"].names == ["batch", None]
+        td.names = None
+        assert not td["sub"]._has_names()
 
     def test_split(self):
         td = TensorDict(


### PR DESCRIPTION
## Description

`Composite.zero()` and `Composite.rand()` drop dim names with nested Composite. In TorchRL, this bug means `env.fake_tensordict()` drops named dims that `env.reset()` keeps. When the parent names are cleared with `_rename_subtds`, the children named dims are also cleared, including the dimensions that aren't shared with the parent.

Example:
```python
obs = Composite({"agents": Composite({"obs": Unbounded(shape=(3, 4, 5))}, shape=(3, 4)).refine_names(None, "agent")}, shape=(3,))
obs["agents"].names # [None, 'agent']
obs.zero()["agents"].names  # [None, None]
```

`PersistentTensorDict` / `TensorDictStore` had similar issue, fixed too.


## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/tensordict/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
