### PR TITLE
[BugFix] Preserve typed state during nested traversal and compilation

### DIFF
--- a/tensordict/_td.py
+++ b/tensordict/_td.py
@@ -5067,6 +5067,11 @@ class _TensorDictKeysView:
             tensordict = tensordict._tensordict
         if isinstance(tensordict, TensorDict):
             return tensordict._tensordict.items()
+        # Imported lazily: TypedTensorDict delegates its storage to this module.
+        from tensordict.typedtensordict import TypedTensorDict
+
+        if isinstance(tensordict, TypedTensorDict):
+            return self._items(tensordict._source)
         from tensordict.nn import TensorDictParams
 
         if isinstance(tensordict, TensorDictParams):

--- a/tensordict/typedtensordict.py
+++ b/tensordict/typedtensordict.py
@@ -534,8 +534,8 @@ class TypedTensorDict(TensorDictBase, metaclass=_TypedTensorDictMeta):
         )
 
     def __setattr__(self, name: str, value: Any) -> None:
-        expected = type(self).__dict__.get("__expected_keys__", None)
-        if expected is not None and name in expected:
+        expected = type(self).__expected_keys__
+        if name in expected:
             self[name] = value
             return
         object.__setattr__(self, name, value)

--- a/test/compile/test_compile.py
+++ b/test/compile/test_compile.py
@@ -661,15 +661,19 @@ class TestTTD:
         d1 = _TTDState(a=torch.arange(3), b=torch.arange(3), batch_size=[3])
         assert (cat_tds(d0, d1) == cat_tds_c(d0, d1)).all()
 
-    def test_reshape(self, mode):
+    @pytest.mark.parametrize("mutate", [False, True])
+    def test_reshape(self, mode, mutate):
         def reshape(td):
+            if mutate:
+                td["a"] = td["a"] + 1
             return td.reshape(2, 2)
 
         reshape_c = torch.compile(reshape, fullgraph=True, mode=mode)
         data = _TTDState(a=torch.arange(4), b=torch.arange(4), batch_size=[4])
-        data_reshape = reshape(data)
-        _ = reshape_c(data)
-        data_reshape_c = reshape_c(data)
+        data_reshape = reshape(data.clone())
+        _ = reshape_c(data.clone())
+        data_reshape_c = reshape_c(data.clone())
+        assert isinstance(data_reshape_c, _TTDState)
         assert (data_reshape == data_reshape_c).all()
 
     def test_view(self, mode):

--- a/test/tensorclass/test_typedtensordict.py
+++ b/test/tensorclass/test_typedtensordict.py
@@ -18,7 +18,7 @@ import tempfile
 import pytest
 import torch
 from tensordict import lazy_stack, TensorDict, TypedTensorDict
-from tensordict.base import TensorDictBase
+from tensordict.base import _default_is_leaf, TensorDictBase
 from torch import Tensor
 
 _has_mypy = importlib.util.find_spec("mypy") is not None
@@ -311,6 +311,21 @@ class TestFieldAccess:
             batch_size=[3],
         )
         assert set(state.keys()) == {"eta", "X", "beta"}
+
+    @pytest.mark.parametrize("backend", ["dense", "lazy", "memmap"])
+    def test_nested_keys_with_leaf_predicate(self, backend, tmp_path):
+        source = TensorDict(
+            {"eta": torch.ones(3), "X": torch.zeros(3), "beta": torch.ones(3)}, [3]
+        )
+        if backend == "lazy":
+            source = lazy_stack([source, source], 0)
+        elif backend == "memmap":
+            source = source.memmap(tmp_path)
+        state = PredictorState.from_tensordict(source)
+        outer = TensorDict({"state": state}, source.batch_size)
+        keys = set(outer.keys(True, True, is_leaf=_default_is_leaf))
+        assert keys == {("state", "eta"), ("state", "X"), ("state", "beta")}
+        assert all(torch.equal(outer.get(key), source.get(key[-1])) for key in keys)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Nested leaf enumeration with a custom `is_leaf` predicate raises `NotImplementedError` when a child is a TypedTensorDict. Delegate traversal to its backing TensorDict so dense, lazy-stacked and memmap values expose the same paths and values.

Wrapping a typed value after a TensorDict mutation also graph-breaks on newer PyTorch nightly builds: `__setattr__` accesses a class mapping proxy. Read the schema attribute directly, as `__getattr__` already does, so compiled state updates and reshaping preserve the type. No schema validation is added to ordinary operations.

These are compatibility fixes demonstrated by TorchRL's structured recurrent-state integration. Rebased onto `main` after #1766 merged.

## Validation

- Extended the existing reshape test to cover mutation followed by typed wrapping; reproduced the mapping-proxy graph break before the fix.
- PyTorch `2.15.0.dev20260911`: `python -m pytest test/compile/test_compile.py::TestTTD test/tensorclass/test_typedtensordict.py -q` — **125 passed, 5 skipped** (CUDA and mypy unavailable).
- `pre-commit run --all-files` passed.
- The nested traversal regression covers dense, lazy-stacked and memmap backends.
