### PR TITLE
[BugFix] Preserve UnbatchedTensor views in compiled vmap

### DIFF
--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -61,7 +61,9 @@ class _UnbatchedTensorMixin:
         self._batch_size = torch.Size(batch_size)
 
     def copy(self):
-        out = type(self)(self._base_tensor())
+        # Alias the payload without converting to a plain Tensor, which Dynamo
+        # cannot trace for the __torch_function__ fallback inside vmap.
+        out = torch.ops.aten.alias.default(self)
         batch_size = getattr(self, "_batch_size", None)
         if batch_size is not None:
             out.batch_size = batch_size

--- a/tensordict/_unbatched.py
+++ b/tensordict/_unbatched.py
@@ -8,6 +8,7 @@ import math
 import warnings
 
 import torch
+from torch.overrides import get_default_nowrap_functions
 
 
 def _has_wrapper_subclass_vmap_fix():
@@ -405,6 +406,9 @@ else:
             batch_size = cls._batch_size_from_args(args, kwargs)
             with torch._C.DisableTorchFunctionSubclass():
                 result = func(*args, **kwargs)
+                # Rewrapping a view's base creates an endless chain of views.
+                if func in get_default_nowrap_functions():
+                    return result
                 if isinstance(result, torch.Tensor):
                     out = result.as_subclass(cls)
                     if batch_size is not None:

--- a/test/compile/test_compile.py
+++ b/test/compile/test_compile.py
@@ -2301,8 +2301,8 @@ class TestGuardCount:
         assert first == 1, f"Expected 1 compile frame, got {first}"
         assert second == 1, f"Recompilation detected: {second} frames"
 
-    def test_unbatched_clone_preserves_semantics(self):
-        """Cloning an UnbatchedTensor must produce independent data."""
+    def test_unbatched_vmap_clone_preserves_semantics(self):
+        """Compiled vmap preserves unbatched metadata and clones the payload."""
 
         def fn(td):
             cloned = td.clone()
@@ -2315,10 +2315,13 @@ class TestGuardCount:
             },
             batch_size=[4],
         )
-        fn_c = torch.compile(fn, fullgraph=True)
+        fn_c = torch.compile(torch.vmap(fn), fullgraph=True)
         result = fn_c(td)
         ut_orig = td.get("unbatched")
         ut_clone = result.get("unbatched")
+        torch.testing.assert_close(result["a"], td["a"])
+        torch.testing.assert_close(ut_clone, ut_orig)
+        assert ut_clone.batch_size == td.batch_size
         assert (
             ut_clone.data_ptr() != ut_orig.data_ptr()
         ), "clone() must produce independent data"

--- a/test/tensordict/test_nontensor.py
+++ b/test/tensordict/test_nontensor.py
@@ -1388,6 +1388,15 @@ class TestUnbatchedTensor:
         assert td.unflatten_keys(separator="_")["c", "d"] is td["c_d"]
         assert td.unflatten_keys(separator="_").flatten_keys()["c.d"] is td["c_d"]
 
+    def test_unbatched_view_base(self):
+        view = UnbatchedTensor(torch.arange(6.0)).clone().reshape(2, 3)
+        base = view._base
+        assert base is not None
+        assert view._base is base
+        assert base._base is None
+        base.zero_()
+        assert not view.any()
+
     def test_unbatched_getitem_returns_unbatched(self):
         data = torch.randn(7, 11)
         td = TensorDict(


### PR DESCRIPTION
Compiled `vmap` encounters two failures in the `UnbatchedTensor` fallback used by older PyTorch versions. Reading a view's `_base` wraps the result with `as_subclass` again, creating an endless chain of new views. Once that is fixed, copying the wrapper's batch metadata converts it to a plain Tensor, which Dynamo cannot trace. The latter failure is reproduced by the compiled Hopper smoke test on PyTorch 2.12.

Honor PyTorch's `get_default_nowrap_functions()` in the fallback, as `torch.Tensor.__torch_function__` does, so view bases and gradient getters return their actual tensors. Use an alias for shallow wrapper copies, sharing payload storage while keeping batch metadata independent and avoiding the unsupported conversion.

The view regression checks a stable terminal base and writes through its shared storage. The existing compiled-clone test now exercises `vmap` and verifies values, batch metadata, and independent cloned storage. Both failures were reproduced before their respective fixes.

Validation on macOS:

- 43 focused tests pass on each of PyTorch 2.11.0, 2.12.0, and 2.15.0.dev20260903, covering both fallback and wrapper-subclass implementations.
- The downstream compiled Hopper rollout passes on PyTorch 2.12.0 and 2.15 nightly, including the assertion that repeated steps use exactly one compiled graph. Dependencies match the MuJoCo CI pins: MuJoCo 3.7 and mujoco-torch 08ec29fb.
- Repository-pinned ufmt, flake8 and whitespace checks pass.

The exact Linux CI nightly (2.12.0.dev20260408+cu128) was not available for local macOS testing; confirmation with that specific build remains pending. The independent missing-Redis compatibility-suite failure is tracked in #1791.
